### PR TITLE
ci: auto-tag-release + PR-por-implementação

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,49 @@
+name: auto-tag-release
+
+# Closes the recurring gap: `npm publish` (or a merge) lands a version bump on main but the
+# git tag is never pushed, so `release.yml` never fires and the GitHub Releases page falls
+# behind npm/CHANGELOG. This watches main; when `package.json` carries a version with no
+# matching tag yet, it creates the tag AND the GitHub Release in one job (notes from
+# CHANGELOG via scripts/print-release-notes.mjs). The tag is a no-op if it already exists
+# (e.g. the maintainer used `npm run release`), so the two flows coexist.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'CHANGELOG.md'
+
+permissions:
+  contents: write
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Tag + release when the version is new
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v$VERSION"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "tag $TAG já existe — release fica com o fluxo do tag push"; exit 0
+          fi
+          # CHANGELOG is the single source of truth — fail loud if the entry is missing.
+          node scripts/print-release-notes.mjs "$VERSION" > RELEASE_NOTES.md
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "$TAG"
+          git push origin "$TAG"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --notes-file RELEASE_NOTES.md
+          else
+            gh release create "$TAG" --title "$TAG" --notes-file RELEASE_NOTES.md
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,19 +20,40 @@ Process skills (full text in `.claude/skills/`, `.agents/skills/`, and the vault
 - **wk-workflow** — Use SEMPRE que o usuário pedir para implementar, criar, corrigir, refatorar, adicionar ou alterar código — qualquer tarefa de código não-trivial. Invoque ANTES de editar qualquer arquivo: orquestra o loop a2 (wendkeep change new → tarefas → verify → archive) e registra tudo no vault.
 <!-- wendkeep:skills:end -->
 
+## Contribuição — PR por implementação (regra do projeto)
+
+**Toda implementação vai por Pull Request. Nunca commite direto na `main`.** Cada change do
+loop a2 (ou correção de infra) nasce num branch `wk/<slug>`, vira PR e é revisada/merged pelo
+mantenedor. O merge na `main` é o gatilho da release (ver automação abaixo).
+
+1. `git checkout -b wk/<slug>` antes de editar.
+2. Implemente pelo loop a2 (change new → tarefas TDD → verify → archive). Bump de versão +
+   `CHANGELOG.md` no MESMO PR quando a mudança afeta o pacote.
+3. `git push origin wk/<slug>` e abra o PR (`gh pr create`) com resumo + entrada do CHANGELOG.
+4. Mantenedor revisa e faz merge. **Não faça self-merge sem revisão se a branch protection exigir.**
+
 ## Release & publicação (regra do projeto)
 
-O mantenedor executa a publicação; agentes apenas **preparam**. Nunca rode `npm publish`
-nem `npm run release` por conta própria.
+CHANGELOG ↔ NPM ↔ GitHub **sempre na mesma versão**. A **tag `vX.Y.Z` é o elo** que fecha isso:
+sem a tag pushada, o `release.yml` não cria a GitHub Release e a página fica atrás do npm.
+Esse foi um atrito recorrente (12/07, 16/07) — `npm publish` avulso publicava sem tag.
 
-1. **Antes de preparar**, consulte a versão publicada: `npm view wendkeep version`. Alinhe
-   `package.json`, `CHANGELOG.md` e a tag `vX.Y.Z` a esse estado antes de bumpar.
-2. Bump SemVer: `npm version <patch|minor|major> --no-git-tag-version` (fix→patch, feat→minor).
-3. Adicione a entrada `## [X.Y.Z] — AAAA-MM-DD` no topo do `CHANGELOG.md` (Keep a Changelog).
-   O CHANGELOG é a fonte única — `scripts/release.mjs` e a GitHub Release (`release.yml`) leem dele.
-4. Commit `fix|feat: <resumo> (X.Y.Z)` com código + `package.json` + `CHANGELOG.md`. O working
-   tree precisa ficar limpo (guard do release).
-5. Valide com `npm run release -- --dry-run` (checa CHANGELOG, tree limpo, tag inexistente) e **pare**.
-6. O mantenedor roda `npm run release` (npm publish + tag + push; a GitHub Release nasce do push da tag).
+**Automação (auto-tag-release):** `.github/workflows/auto-tag.yml` observa a `main`; quando o
+`package.json` traz uma versão sem tag correspondente, ele **cria a tag E a GitHub Release**
+(notas do CHANGELOG). Ou seja: merge de um PR que bumpa a versão → release automática. Ninguém
+mais depende de lembrar de pushar a tag.
 
-CHANGELOG ↔ NPM ↔ GitHub devem ficar sempre na mesma versão.
+**Fluxo do agente (só prepara):**
+1. `npm view wendkeep version` — alinhe `package.json`/`CHANGELOG`/tag a esse estado antes de bumpar.
+2. Bump SemVer no PR: `npm version <patch|minor|major> --no-git-tag-version` (fix→patch, feat→minor).
+3. Entrada `## [X.Y.Z] — AAAA-MM-DD` no topo do `CHANGELOG.md` (fonte única; `release.yml`/
+   `auto-tag.yml`/`scripts/release.mjs` leem dela).
+4. Commit `fix|feat: <resumo> (X.Y.Z)` no branch; abra o PR. Ao merge, a automação tag+release.
+
+**Mantenedor (publica no npm):** `npm run release` (npm publish + tag + push, atômico) OU
+`npm publish` — neste caso a `auto-tag.yml` cobre a tag no push da `main`. Nunca deixe npm à
+frente da GitHub Release sem tag.
+
+**Recuperação retroativa** (releases perdidas): `git tag -a vX.Y.Z <sha> -m "vX.Y.Z" && git push
+origin vX.Y.Z` no commit cujo `package.json` tem a versão — o `release.yml` monta a Release do
+CHANGELOG.


### PR DESCRIPTION
## Por quê

As GitHub Releases ficaram repetidamente atrás do npm/CHANGELOG (v0.41.0 latest enquanto npm=0.44.0). Causa raiz: `npm publish` avulso publica sem criar/pushar a tag `vX.Y.Z`, e o `release.yml` só dispara no push da tag.

## O que muda

- **`.github/workflows/auto-tag.yml`**: observa a `main`; quando `package.json` traz uma versão sem tag, cria a tag **e** a GitHub Release (notas do CHANGELOG via `scripts/print-release-notes.mjs`). Merge de um PR que bumpa a versão passa a gerar release sozinho. No-op se a tag já existe (coexiste com `npm run release`).
- **AGENTS.md**: nova regra **PR por implementação** (branch `wk/<slug>` → PR → merge dispara release) + reforço de que a tag é o elo CHANGELOG↔npm↔GitHub.

## Notas

- Este próprio PR já pratica a regra (não fui direto na main).
- Enforcement real (bloquear push direto na main) = branch protection — pendente de decisão do mantenedor (ver conversa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)