### PR TITLE
chore: sync skills + devDep para 0.44.0

### DIFF
--- a/.agents/skills/example-skill/.wendkeep-meta.json
+++ b/.agents/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.39.0",
+  "wendkeepVersion": "0.44.0",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.agents/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.agents/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.39.0",
+  "wendkeepVersion": "0.44.0",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.agents/skills/wk-debugging/.wendkeep-meta.json
+++ b/.agents/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.39.0",
-  "sourceHash": "cdc56b09ca9312f77708839cc4711aeebfa67828ab9d75cac69b9116860b35d0"
+  "wendkeepVersion": "0.44.0",
+  "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.agents/skills/wk-debugging/SKILL.md
+++ b/.agents/skills/wk-debugging/SKILL.md
@@ -24,3 +24,10 @@ mudando coisas no escuro.
   isole uma variável por vez.
 - Leia a mensagem de erro inteira e a stack — a linha decisiva costuma estar ali.
 - "Não faz sentido" = uma suposição sua está errada. Cheque as suposições, não o improvável.
+
+## Registro no vault
+
+Bug com valor durável vira nota numerada: `wendkeep note new --type bug "resumo"` —
+cria `BUG-NNNN-<slug>.md` na pasta do mês de `05-Bugs` (nunca subpasta `DIA N`) e
+imprime o path pra você preencher sintoma/causa raiz/correção. Aprendizado extraído do
+debug: `wendkeep note new --type learning "lição"` (vira `APR-NNNN-` em `06-Aprendizados`).

--- a/.agents/skills/wk-planning/.wendkeep-meta.json
+++ b/.agents/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.39.0",
+  "wendkeepVersion": "0.44.0",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.agents/skills/wk-tdd/.wendkeep-meta.json
+++ b/.agents/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.39.0",
+  "wendkeepVersion": "0.44.0",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.agents/skills/wk-verify/.wendkeep-meta.json
+++ b/.agents/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.39.0",
+  "wendkeepVersion": "0.44.0",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.agents/skills/wk-workflow/.wendkeep-meta.json
+++ b/.agents/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.39.0",
-  "sourceHash": "f7d302e2273ba681e4632ea7da091f6bf5e8fdc1c1f186e485a351b68055a536"
+  "wendkeepVersion": "0.44.0",
+  "sourceHash": "25e296237bb9c8a18441a7c3cf61efc39af53216080bb94254320d6b6ed35d82"
 }

--- a/.agents/skills/wk-workflow/SKILL.md
+++ b/.agents/skills/wk-workflow/SKILL.md
@@ -26,15 +26,18 @@ vault cego. Exceção única: mudança trivial (typo, 1 linha).
    Antes de implementar, resolva `spec_impact` na proposta:
    - `required`: liste a capability em `specs:` e preencha
      `specs/<capability>/spec.md` com ADDED/MODIFIED/REMOVED; ligue tarefas com `[req:ID]`.
+     Heading de requisito: `### Requisito: <ID> — <nome>` (ou só `### Requisito: <ID>`);
+     o ID é a identidade (ex.: `GATE-1`, `API-AUTH-2`).
    - `none`: registre uma justificativa real em `spec_impact_reason`.
    `pending` nunca é estado pronto para implementação ou archive.
 3. **Apply** — implemente cada tarefa de `tarefas.md` com disciplina **wk-tdd**
    (teste vermelho antes do código). Marque `- [x]` ao concluir. Declare nas tarefas:
    - `[sensor:<id>]` — a prova automatizada (roda no verify).
    - `[req:<ID>]` — o requisito do spec que a tarefa satisfaz (ex.: `[req:GATE-1]`),
-      quando a change mexe numa capability. Toda autoria de spec ocorre somente em
+      quando a change mexe numa capability. Uma tarefa pode declarar vários
+      `[req:]` — todos contam na cobertura. Toda autoria de spec ocorre somente em
       `08-Mudanças/<slug>/specs/<capability>/spec.md`; `07-Specs` é gerado/read-only.
-   Ex.: `- [ ] 2.1 valida CORE [req:MEM-1] [sensor:memory-validation]`.
+   Ex.: `- [ ] 2.1 valida CORE [req:MEM-1] [req:MEM-2] [sensor:memory-validation]`.
 4. **Verify** — `wendkeep verify` roda os sensores → `evidencia.json`. Depois
    `wendkeep verify --deep` monta o *pacote de verificação* pro passe independente.
 5. **Verify deep** — a skill **wk-verify** (passe fresco, autor≠verificador) lê o pacote,
@@ -53,3 +56,6 @@ vault cego. Exceção única: mudança trivial (typo, 1 linha).
   o que você declarou. Sem `[sensor:]`, o archive não trava.
 - A proposta linka a sessão de origem; a sessão linka a mudança ativa. É de propósito:
   o grafo do Obsidian mostra plano↔sessão↔decisão.
+- Notas derivadas (bug/aprendizado) são numeradas (`BUG-NNNN-`/`APR-NNNN-`) e vivem na
+  pasta do mês — nunca em subpasta `DIA N`. Crie via `wendkeep note new --type
+  bug|learning "título"` (imprime o path), não à mão.

--- a/.claude/skills/example-skill/.wendkeep-meta.json
+++ b/.claude/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.39.0",
+  "wendkeepVersion": "0.44.0",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.claude/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.claude/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.39.0",
+  "wendkeepVersion": "0.44.0",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.claude/skills/wk-debugging/.wendkeep-meta.json
+++ b/.claude/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.39.0",
-  "sourceHash": "cdc56b09ca9312f77708839cc4711aeebfa67828ab9d75cac69b9116860b35d0"
+  "wendkeepVersion": "0.44.0",
+  "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.claude/skills/wk-debugging/SKILL.md
+++ b/.claude/skills/wk-debugging/SKILL.md
@@ -24,3 +24,10 @@ mudando coisas no escuro.
   isole uma variável por vez.
 - Leia a mensagem de erro inteira e a stack — a linha decisiva costuma estar ali.
 - "Não faz sentido" = uma suposição sua está errada. Cheque as suposições, não o improvável.
+
+## Registro no vault
+
+Bug com valor durável vira nota numerada: `wendkeep note new --type bug "resumo"` —
+cria `BUG-NNNN-<slug>.md` na pasta do mês de `05-Bugs` (nunca subpasta `DIA N`) e
+imprime o path pra você preencher sintoma/causa raiz/correção. Aprendizado extraído do
+debug: `wendkeep note new --type learning "lição"` (vira `APR-NNNN-` em `06-Aprendizados`).

--- a/.claude/skills/wk-planning/.wendkeep-meta.json
+++ b/.claude/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.39.0",
+  "wendkeepVersion": "0.44.0",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.claude/skills/wk-tdd/.wendkeep-meta.json
+++ b/.claude/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.39.0",
+  "wendkeepVersion": "0.44.0",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.claude/skills/wk-verify/.wendkeep-meta.json
+++ b/.claude/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.39.0",
+  "wendkeepVersion": "0.44.0",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.claude/skills/wk-workflow/.wendkeep-meta.json
+++ b/.claude/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.39.0",
-  "sourceHash": "f7d302e2273ba681e4632ea7da091f6bf5e8fdc1c1f186e485a351b68055a536"
+  "wendkeepVersion": "0.44.0",
+  "sourceHash": "25e296237bb9c8a18441a7c3cf61efc39af53216080bb94254320d6b6ed35d82"
 }

--- a/.claude/skills/wk-workflow/SKILL.md
+++ b/.claude/skills/wk-workflow/SKILL.md
@@ -26,15 +26,18 @@ vault cego. Exceção única: mudança trivial (typo, 1 linha).
    Antes de implementar, resolva `spec_impact` na proposta:
    - `required`: liste a capability em `specs:` e preencha
      `specs/<capability>/spec.md` com ADDED/MODIFIED/REMOVED; ligue tarefas com `[req:ID]`.
+     Heading de requisito: `### Requisito: <ID> — <nome>` (ou só `### Requisito: <ID>`);
+     o ID é a identidade (ex.: `GATE-1`, `API-AUTH-2`).
    - `none`: registre uma justificativa real em `spec_impact_reason`.
    `pending` nunca é estado pronto para implementação ou archive.
 3. **Apply** — implemente cada tarefa de `tarefas.md` com disciplina **wk-tdd**
    (teste vermelho antes do código). Marque `- [x]` ao concluir. Declare nas tarefas:
    - `[sensor:<id>]` — a prova automatizada (roda no verify).
    - `[req:<ID>]` — o requisito do spec que a tarefa satisfaz (ex.: `[req:GATE-1]`),
-      quando a change mexe numa capability. Toda autoria de spec ocorre somente em
+      quando a change mexe numa capability. Uma tarefa pode declarar vários
+      `[req:]` — todos contam na cobertura. Toda autoria de spec ocorre somente em
       `08-Mudanças/<slug>/specs/<capability>/spec.md`; `07-Specs` é gerado/read-only.
-   Ex.: `- [ ] 2.1 valida CORE [req:MEM-1] [sensor:memory-validation]`.
+   Ex.: `- [ ] 2.1 valida CORE [req:MEM-1] [req:MEM-2] [sensor:memory-validation]`.
 4. **Verify** — `wendkeep verify` roda os sensores → `evidencia.json`. Depois
    `wendkeep verify --deep` monta o *pacote de verificação* pro passe independente.
 5. **Verify deep** — a skill **wk-verify** (passe fresco, autor≠verificador) lê o pacote,
@@ -53,3 +56,6 @@ vault cego. Exceção única: mudança trivial (typo, 1 linha).
   o que você declarou. Sem `[sensor:]`, o archive não trava.
 - A proposta linka a sessão de origem; a sessão linka a mudança ativa. É de propósito:
   o grafo do Obsidian mostra plano↔sessão↔decisão.
+- Notas derivadas (bug/aprendizado) são numeradas (`BUG-NNNN-`/`APR-NNNN-`) e vivem na
+  pasta do mês — nunca em subpasta `DIA N`. Crie via `wendkeep note new --type
+  bug|learning "título"` (imprime o path), não à mão.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- wendkeep:skills:start -->
-<!-- wendkeep-version: 0.39.0; skills-sha256: d09987ccbbefccd06af0a290dc6d820444e6c306230b1e4cba9b7d0cccd3039f -->
+<!-- wendkeep-version: 0.44.0; skills-sha256: c69f17a96cefc1f8a24a6bb6295bd4c0368c99f6d9f722f3ee6b95854729e8ad -->
 ## wendkeep — process skills & loop
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. Work

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,16 +13,16 @@
         "wk": "bin/wendkeep.mjs"
       },
       "devDependencies": {
-        "wendkeep": "^0.39.0"
+        "wendkeep": "^0.44.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/wendkeep": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/wendkeep/-/wendkeep-0.39.0.tgz",
-      "integrity": "sha512-ByPyLsoYNp1tE1DwjhpNN32o9OVB73sPWlF6AZE2xXswloQJ+pw1VOi2tN+P2OXHmjJoYRrQBwTkUC77E+ORwA==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/wendkeep/-/wendkeep-0.44.0.tgz",
+      "integrity": "sha512-XHp1nd/M+arRX55Bd1YpMGWgGax1HbSEo8pPKjE52e9PbdUTorbrYP++yoZXRAFbINLN+TM4nqxqT1REVdN03g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "url": "https://github.com/rogersialves/wendkeep/issues"
   },
   "devDependencies": {
-    "wendkeep": "^0.39.0"
+    "wendkeep": "^0.44.0"
   }
 }


### PR DESCRIPTION
Housekeeping: regeneração de `sync-defs` acumulada nas releases 0.41-0.44.

- `.claude/skills` + `.agents/skills` sincronizadas com os seeds atuais (convenção `wendkeep note new` em wk-debugging/wk-workflow)
- `.wendkeep-meta.json` bump 0.39→0.44 + sourceHash
- devDependency `wendkeep` ^0.39.0 → ^0.44.0 (dogfood)

Sem mudança de comportamento; artefatos gerados. Versão do `package.json` inalterada (0.44.0), então a auto-tag no merge é no-op (tag v0.44.0 já existe) — valida o guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)