### PR TITLE
fix: preserva atualizado_em quando o uso não muda (0.45.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.45.0] — 2026-07-18
+
+### Fixed
+
+- Observabilidade: o note de sessão deixa de ser reescrito com timestamp novo a cada Stop
+  quando o uso não muda. A preservação de `atualizado_em` (`token-usage.mjs`) comparava
+  `previous` (parseado do note) com `current` (recém-computado) via `JSON.stringify` —
+  sensível à ordem das chaves, que difere entre parse e build, então a comparação **sempre**
+  falhava e o timestamp era re-stampado toda vez. Novo `sameUsageData(a, b)` compara os campos
+  de uso de forma ordem-insensível (ignorando `atualizado_em`). Corrige o churn de reescrita e
+  o teste flaky "same sources produce byte-identical markdown".
+
 ## [0.44.0] — 2026-07-17
 
 ### Changed

--- a/hooks/token-usage.mjs
+++ b/hooks/token-usage.mjs
@@ -604,6 +604,19 @@ function transcriptIdFromPath(transcriptPath) {
   return basename(String(transcriptPath || '')).replace(/\.jsonl?$/i, '') || 'desconhecido';
 }
 
+// The usage fields that define whether a transcript's entry "changed" — everything except the
+// key (transcript_id) and the timestamp (atualizado_em). Order-insensitive by design: a new
+// field here is the single place to keep preservation correct.
+const USAGE_FIELDS = ['provider', 'pensamento', 'input', 'cache_write', 'cache_read',
+  'output', 'reasoning', 'total', 'custo_usd', 'prompts', 'tool_calls', 'chamadas_llm'];
+
+export function sameUsageData(a, b) {
+  if (!a || !b) return false;
+  const listEqual = (x, y) => (x || []).join(' ') === (y || []).join(' ');
+  return USAGE_FIELDS.every((f) => (a[f] ?? null) === (b[f] ?? null))
+    && listEqual(a.modelos, b.modelos) && listEqual(a.tools, b.tools);
+}
+
 function entryFromSummary(summary, transcriptId) {
   return {
     transcript_id: transcriptId,
@@ -931,10 +944,11 @@ export function collectSessionUsage({ sessionContent, transcriptPath }) {
   const transcriptId = transcriptIdFromPath(transcriptPath);
   const previous = existingEntries.find((entry) => entry.transcript_id === transcriptId);
   const current = entryFromSummary(summary, transcriptId);
-  if (previous) {
-    const comparable = (entry) => JSON.stringify({ ...entry, atualizado_em: undefined });
-    if (comparable(previous) === comparable(current)) current.atualizado_em = previous.atualizado_em;
-  }
+  // Preserve the old timestamp when the usage data is unchanged, so an unchanged session note
+  // stays byte-identical (no needless rewrite on every Stop). Compared semantically, NOT via
+  // JSON.stringify: the parsed-from-note entry and the freshly-built one have different key
+  // orders, which made the old stringify compare always mismatch — preservation never fired.
+  if (previous && sameUsageData(previous, current)) current.atualizado_em = previous.atualizado_em;
   let entries = existingEntries.filter((e) => e.transcript_id !== transcriptId);
 
   if (!existingEntries.length) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "license": "MIT",
       "bin": {
         "wendkeep": "bin/wendkeep.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "description": "A persistent-memory harness for AI coding agents on your Obsidian vault: turn-by-turn session capture plus a native, zero-dependency spec→change→verify→archive loop (sensor-gated, independent verdict, mutation discrimination). Local-first, agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "bin": {

--- a/tests/session-observability.test.mjs
+++ b/tests/session-observability.test.mjs
@@ -6,6 +6,29 @@ import { join } from 'node:path';
 import { updateSessionObservability } from '../hooks/session-observability.mjs';
 import { refreshSubagents } from '../hooks/subagent-stop.mjs';
 import { upsertSessionRegistry, writeControl } from '../hooks/obsidian-common.mjs';
+import { sameUsageData } from '../hooks/token-usage.mjs';
+
+// Preservação de `atualizado_em`: o dado é "o mesmo" independente da ORDEM das chaves.
+// A entrada vinda do parse do note (transcript_id, modelos, tools, provider, …) tem ordem
+// diferente da recém-computada (transcript_id, provider, modelos, …). O compare antigo
+// (JSON.stringify) dava false p/ dado idêntico → atualizado_em re-stampado → teste flaky.
+test('sameUsageData: identical usage with different key order compares equal', () => {
+  const built = { transcript_id: 'main', provider: 'openai', modelos: ['x'], pensamento: 'high', input: 100, cache_write: 0, cache_read: 50, output: 40, reasoning: 20, total: 190, custo_usd: 0.0017, prompts: 1, tool_calls: 0, chamadas_llm: 1, tools: [], atualizado_em: '2026-07-18T00:19:39' };
+  const parsed = { transcript_id: 'main', modelos: ['x'], tools: [], provider: 'openai', pensamento: 'high', input: 100, cache_write: 0, cache_read: 50, output: 40, reasoning: 20, total: 190, custo_usd: 0.0017, prompts: 1, tool_calls: 0, chamadas_llm: 1, atualizado_em: '2026-07-18T00:19:41' };
+  assert.equal(sameUsageData(built, parsed), true, 'ordem de chaves e atualizado_em não contam');
+});
+
+test('sameUsageData: any changed usage number compares unequal', () => {
+  const a = { provider: 'openai', modelos: ['x'], input: 100, output: 40, total: 190, custo_usd: 0.0017, tools: [] };
+  assert.equal(sameUsageData(a, { ...a, output: 41 }), false, 'output mudou → re-stampa');
+  assert.equal(sameUsageData(a, { ...a, modelos: ['x', 'y'] }), false, 'modelos mudou → re-stampa');
+  assert.equal(sameUsageData(a, { ...a, tools: ['Read'] }), false, 'tools mudou → re-stampa');
+});
+
+test('sameUsageData: null/undefined side is never equal', () => {
+  assert.equal(sameUsageData(null, {}), false);
+  assert.equal(sameUsageData({}, undefined), false);
+});
 
 function codexTranscript({ id, model, effort, input, cached, output, reasoning }) {
   return [


### PR DESCRIPTION
## Por quê

Teste flaky `session-observability.test.mjs` ("same sources produce byte-identical markdown"): falhava raro na suite completa, passava isolado.

**Raiz (não é o `observability_updated_at`, que tem guard).** A preservação de `atualizado_em` em `token-usage.mjs:934-936` comparava `previous` (parseado do note) com `current` (recém-computado) via `JSON.stringify` — sensível à **ordem das chaves**. `entryFromSummary` e `parseUsageHistory` reconstroem os campos em ordens diferentes, então a comparação **sempre** falhava mesmo com dado idêntico → `atualizado_em` (precisão de segundos) re-stampado a cada build. Passava só quando os 2 builds caíam no mesmo segundo.

Repro determinístico: `comparable(built) === comparable(parsed)` → `false` (mesmo dado, só ordem difere).

**Impacto além do teste:** em produção o note era reescrito com timestamp novo a cada Stop mesmo sem o uso mudar — churn desnecessário.

## O que muda

- Novo `sameUsageData(a, b)`: compara os campos de uso **ordem-insensível** (ignora `atualizado_em`/`transcript_id`). Substitui o `comparable` de `JSON.stringify`.
- Dado inalterado → `atualizado_em` preservado (byte-idêntico estável); dado mudou → re-stampa.

## Verificação

- TDD: teste `sameUsageData` (ordem diferente → true = litmus do bug; número/lista diferente → false; null → false).
- Suite completa 384/384; o teste antes flaky rodado **5×** → fail 0.
- `spec_impact: none` (bugfix interno, sem contrato de capability); verdict trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)