### PR TITLE
fix: escapa bytes de controle literais no regex de sanitização

### DIFF
--- a/src/taxonomy.mjs
+++ b/src/taxonomy.mjs
@@ -330,7 +330,7 @@ export function deriveVaultDirName(projectPath) {
     .pop() || '';
   const clean = base
     .replace(/^[.\s]+/, '') // drop leading dots/space so we never get `..name`
-    .replace(/[<>:"/\\|?* -]/g, '-') // FS-unsafe chars -> dash
+    .replace(/[<>:"/\\|?*\x00-\x1f]/g, '-') // FS-unsafe chars -> dash
     .replace(/\s+/g, '-') // whitespace -> dash
     .replace(/-+/g, '-') // collapse dash runs
     .replace(/^-+|-+$/g, '') // trim edge dashes


### PR DESCRIPTION
## Problema

`src/taxonomy.mjs` carregava dois bytes de controle **literais** dentro da classe de caracteres do `deriveVaultDirName`: um NUL (`0x00`) e um `0x1f`.

Por causa do NUL, o `file` classificava o fonte como `data` — binário. O ripgrep pula arquivos binários por default, então **um Grep por qualquer termo em `taxonomy.mjs` voltava vazio, em silêncio**. Não é erro, é ausência de resultado: a busca parece ter rodado e não achado nada.

Isso importa porque `taxonomy.mjs` é onde vivem os specs de hook (`SESSION_HOOKS`, `CHANGE_NUDGE_HOOKS`, `CHANGE_GATE_HOOKS`) e as constantes de companion — exatamente o arquivo que uma busca de código não pode perder.

## Correção

Troca os dois bytes crus pelas sequências de escape `\x00` e `\x1f`. Só isso.

```diff
-    .replace(/[<>:"/\|?* -]/g, '-')      // ← os dois bytes crus são invisíveis aqui
+    .replace(/[<>:"/\|?*\x00-\x1f]/g, '-')
```

O `0x1f` não estava no relato original, mas é o mesmo defeito no mesmo regex — deixar um caractere de controle invisível ao lado do que acabou de ser corrigido só adia o problema.

## Verificação

| | antes | depois |
|---|---|---|
| `file src/taxonomy.mjs` | `data` | `JavaScript source, Unicode text, UTF-8 text` |
| Grep `SESSION_HOOKS` no arquivo | zero resultados | `98:` e `258:` |

Comportamento do regex é byte-idêntico — provado direto:

```
deriveVaultDirName('C:/x/ab\x00cd\x1fef')  →  '.ab-cd-ef-vault'
```

`npm test` 384/384 · `npm run check` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
