### PR TITLE
chore(release): 0.46.0 — hooks de sessão do Codex no init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.45.1",
+  "version": "0.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.45.1",
+      "version": "0.46.0",
       "license": "MIT",
       "bin": {
         "wendkeep": "bin/wendkeep.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.45.1",
+  "version": "0.46.0",
   "description": "A persistent-memory harness for AI coding agents on your Obsidian vault: turn-by-turn session capture plus a native, zero-dependency spec→change→verify→archive loop (sensor-gated, independent verdict, mutation discrimination). Local-first, agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bump de versão para `0.46.0`. Entrega:

- **[#8](https://github.com/rogersialves/wendkeep/pull/8)** — `init` wira os hooks de sessão do Codex em `.codex/hooks.json` (sete hooks; cinco fora, cada um com motivo registrado no spec).
- **[#7](https://github.com/rogersialves/wendkeep/pull/7)** — bytes de controle literais em `src/taxonomy.mjs` escapados, que faziam o ripgrep pular o arquivo em silêncio.

CHANGELOG já documenta as duas, incluindo a nota de migração: quem já tem hooks Codex do wendkeep leva **um** prompt "Hooks need review" neste upgrade, porque o fix `timeout` → `timeoutSec` muda a identidade hasheada do hook. Esperado, não regressão.

`npm test` 398/398 · `npm run check` limpo · `print-release-notes.mjs 0.46.0` renderiza.

O merge dispara o `auto-tag.yml`, que cria a tag `v0.46.0` e o GitHub Release a partir do CHANGELOG. **A publicação no npm fica com o mantenedor.**

> ⚠️ Depois do merge, use `npm publish` direto — **não** `npm run release`. O script aborta quando a tag já existe, e o auto-tag terá criado a `v0.46.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
