### PR TITLE
fix: resiliência de captura do Codex — turnos perdidos, resgate cego, títulos poluídos (0.46.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,57 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.46.1] — 2026-07-19
+
+### Fixed
+
+- **Turnos do Codex sumiam da nota sem nenhum aviso.** No Windows o Codex serializa o payload
+  do `Stop` com o campo `last_assistant_message` cortado no meio, sem fechar a string JSON —
+  bug upstream ainda aberto ([openai/codex#23784](https://github.com/openai/codex/issues/23784)).
+  Sessão em português enche esse campo de acento, então o corte é frequente. O
+  `readHookInput` fazia `JSON.parse` cru, lançava, e o `session-stop` saía com código 0
+  escrevendo só no stderr — que o Codex descarta. Resultado: a nota era criada, o summary
+  atualizava a cada prompt, e nenhuma iteração jamais entrava. Só o `Stop` quebrava porque
+  `last_assistant_message` é o único campo exclusivo dele; `SessionStart` e
+  `UserPromptSubmit` não o carregam.
+  Como esse campo é o **último** do `StopCommandInput`, tudo que o wendkeep consome
+  (`session_id`, `turn_id`, `transcript_path`, `cwd`) está no prefixo bem-formado. O
+  `readHookInput` passa a recuperar esse prefixo numa passada só, descartando o campo
+  truncado — nunca reconstruindo-o, porque metade de uma mensagem é dado inventado.
+- **O hook parou de falhar em silêncio.** Todo caminho de bail do `session-stop` agora emite
+  `systemMessage`, que a UI do Codex mostra, com o motivo e o comando de recuperação. O exit
+  code continua 0 de propósito: hook de `Stop` que sai diferente de zero trava o turno
+  (openai/codex#21921), e trocar turno perdido por sessão travada é pior negócio.
+- **`resolveSessionIdentity` passa a usar o `SESSION_REGISTRY` como fonte do
+  `transcript_path`** quando o payload não o traz. O registry já tinha o mapeamento; o lookup
+  é que ficava abaixo do gate, inalcançável justo no caso que resolveria. A entrada precisa
+  ser do mesmo provider, o que preserva o invariante do incidente de contaminação
+  cross-provider de 2026-07-11.
+- **`wendkeep import` deixou de ser cego para a sessão danificada.** O dedup perguntava
+  "existe registro?", não "existe conteúdo?" — e como o `session-start` registra antes do
+  `session-stop` escrever, **as sessões esvaziadas pelo bug acima eram exatamente as que o
+  comando de recuperação se recusava a consertar.** Agora a decisão compara os turnos do
+  transcript com os marcadores `wk-turn` já na nota: cobertura completa pula, parcial ou
+  vazia completa a nota existente sem criar uma segunda. Sem flag opt-in — quem roda `import`
+  depois de perder sessão não tem como saber que precisaria de uma. O relatório ganhou a
+  categoria `repaired`, separada de `imported` (nota nova) e de `skipped` (já completa).
+- **Sessões importadas ganhavam título de bloco injetado pelo harness.** Seis notas de um
+  mesmo projeto ficaram chamadas `<recommended_plugins> Here is a list of plugins that ar`,
+  no frontmatter e no nome do arquivo. Causa de uma linha: `buildIterationBlock` seleciona
+  `userPrompts.at(-1)` e o `deriveSummary` usava `.find(Boolean)` — o harness injeta o bloco
+  como **primeiro** prompt do turno e o pedido do usuário vem por **último**. Mesmo dado,
+  ponta oposta. As duas seleções agora são a mesma, com `isBootstrapPrompt` (que passou a
+  reconhecer `<recommended_plugins>`) como rede, aplicado ao prompt inteiro e não linha a
+  linha — filtrar por linha cairia na linha seguinte do próprio bloco injetado.
+
+### Recuperação
+
+- Quem perdeu turnos de sessões Codex antes desta versão recupera com
+  `wendkeep import --source codex`. O rollout do Codex fica íntegro em disco, e o import agora
+  completa a nota existente em vez de pulá-la. Rodar mais de uma vez é no-op.
+- Notas já criadas com título poluído **não** são renomeadas automaticamente: mexer em nome de
+  arquivo quebra wikilink e reorganiza o grafo, e isso é decisão do dono do vault.
+
 ## [0.46.0] — 2026-07-18
 
 ### Added

--- a/hooks/import-sessions.mjs
+++ b/hooks/import-sessions.mjs
@@ -17,7 +17,7 @@ import {
 import { buildSessionContent, allocateSessionPath } from './session-start.mjs';
 import { createLinkedNotes } from './linked-notes.mjs';
 import { updateSessionObservability } from './session-observability.mjs';
-import { readSessionRegistry, upsertSessionRegistry, formatLocalIso, formatDate, providerMeta } from './obsidian-common.mjs';
+import { readSessionRegistry, upsertSessionRegistry, formatLocalIso, formatDate, providerMeta, isBootstrapPrompt } from './obsidian-common.mjs';
 import { getLocale } from './locale.mjs';
 import { captureProseDecisions } from './decision-capture.mjs';
 
@@ -154,6 +154,36 @@ export function capturedSessionIds(vaultBase) {
   return ids;
 }
 
+// session_id -> absolute note path, for the sessions that already have a note on disk. The
+// registry alone is not enough: it records a session the moment session-start runs, which is
+// exactly the state a damaged session is stuck in (registered, note empty).
+export function capturedSessionNotes(vaultBase) {
+  const notes = new Map();
+  const registry = readSessionRegistry(vaultBase).sessions || {};
+  for (const [id, entry] of Object.entries(registry)) {
+    if (!entry?.session_file) continue;
+    const abs = join(vaultBase, ...String(entry.session_file).split('/'));
+    if (existsSync(abs)) notes.set(id, abs);
+  }
+  try {
+    const sessionsDir = join(vaultBase, getLocale(vaultBase).folders.sessions);
+    for (const path of walkFiles(sessionsDir, /\.md$/i)) {
+      const id = noteSessionId(path);
+      if (id && !notes.has(id)) notes.set(id, path);
+    }
+  } catch { /* registry alone is enough */ }
+  return notes;
+}
+
+// Turn ids already memorialized in a note, read from the `wk-turn` markers insertIteration
+// writes. Missing/unreadable note = nothing captured.
+export function noteTurnIds(notePath) {
+  try {
+    const md = readFileSync(notePath, 'utf-8');
+    return new Set([...md.matchAll(/<!-- (?:wk|codex)-turn: ([^\s]+) -->/g)].map((m) => m[1]));
+  } catch { return new Set(); }
+}
+
 export function discoverCodexTranscripts(projectPath, fromDir) {
   const dir = fromDir || defaultCodexSessionsDir();
   if (!dir || !existsSync(dir)) return { dir, transcripts: [] };
@@ -168,9 +198,14 @@ export function discoverCodexTranscripts(projectPath, fromDir) {
 }
 
 // Session objective for the note title/frontmatter: first real user prompt, one line.
-function deriveSummary(tx) {
-  for (const turn of tx.turns || []) {
-    const prompt = (turn.userPrompts || []).find(Boolean);
+// Mirrors buildIterationBlock's selection (`userPrompts.at(-1)`) on purpose: the harness
+// injects preamble as the FIRST prompt of a turn and the user's request lands LAST, so taking
+// the first titled six Vendiva sessions "<recommended_plugins> Here is a list of plugins".
+// isBootstrapPrompt is the belt: it runs per whole prompt, not per line — filtering by line
+// would fall through to the next line of the SAME injected block.
+export function deriveSummary(tx) {
+  for (const turn of tx?.turns || []) {
+    const prompt = (turn.userPrompts || []).filter((p) => p && !isBootstrapPrompt(p)).at(-1);
     if (prompt) {
       return prompt.replace(/[\r\n#]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 80) || 'session';
     }
@@ -313,15 +348,18 @@ export function runImport(vaultBase, opts = {}) {
     codexDir = d.dir;
     transcripts.push(...d.transcripts);
   }
-  const captured = capturedSessionIds(vaultBase);
+  const notes = capturedSessionNotes(vaultBase);
   const sinceMs = since ? Date.parse(since) : 0;
-  const report = { source: src, claudeDir, codexDir, scanned: transcripts.length, imported: 0, skipped: 0, errors: [], sessions: [] };
+  const report = { source: src, claudeDir, codexDir, scanned: transcripts.length, imported: 0, repaired: 0, skipped: 0, errors: [], sessions: [] };
 
   let done = 0;
   for (const t of transcripts) {
-    if (captured.has(t.sessionId)) { report.skipped++; continue; }
     if (limit && done >= limit) break;
 
+    // Every transcript is parsed now, including already-captured ones: partial coverage is
+    // undetectable without the turn list. The old presence-only check was cheaper but made
+    // the recovery command blind to exactly the sessions it exists to repair. Narrow a large
+    // vault with --since / --limit.
     let tx;
     try {
       tx = parseTranscript(t.path);
@@ -331,6 +369,31 @@ export function runImport(vaultBase, opts = {}) {
     }
     const turns = tx.turns || [];
     if (!turns.length) { report.skipped++; continue; }
+
+    const existingNote = notes.get(t.sessionId);
+    if (existingNote) {
+      const have = noteTurnIds(existingNote);
+      const missing = turns.filter((turn) => !have.has(String(turn.turnId)));
+      if (!missing.length) { report.skipped++; continue; }
+      if (dryRun) {
+        report.sessions.push({ sessionId: t.sessionId, turns: missing.length, repaired: true, dryRun: true });
+        report.repaired++;
+        done++;
+        continue;
+      }
+      try {
+        for (const turn of missing) {
+          insertIteration(existingNote, buildIterationBlock(tx, { turn_id: turn.turnId, now: turn.timestamp }), turn.turnId, tx);
+        }
+        try { updateSessionObservability({ sessionPath: existingNote, transcriptPath: t.path }); } catch { /* best-effort */ }
+        report.sessions.push({ sessionId: t.sessionId, turns: missing.length, repaired: true });
+        report.repaired++;
+        done++;
+      } catch (error) {
+        report.errors.push({ sessionId: t.sessionId, error: error.message });
+      }
+      continue;
+    }
 
     const startTs = turns[0].timestamp || '';
     if (sinceMs && startTs && Number.isFinite(Date.parse(startTs)) && Date.parse(startTs) < sinceMs) {

--- a/hooks/obsidian-common.mjs
+++ b/hooks/obsidian-common.mjs
@@ -23,10 +23,52 @@ export const VAULT_COMPLEMENT_RULES = [
   'Atualize `SHARED_MEMORY.md` somente quando a síntese mudar estado ativo que outro agente precise saber.',
 ];
 
+// Codex on Windows serializes the Stop payload with `last_assistant_message` cut mid-string
+// and never closed when the assistant text carries non-ASCII (openai/codex#23784). That field
+// is LAST in codex-rs's StopCommandInput, so everything wendkeep consumes — session_id,
+// turn_id, transcript_path, cwd — sits in the intact prefix.
+//
+// One pass, tracking quotes/escapes/depth, remembering the offset of the last top-level comma
+// that was NOT inside a string. Re-closing there yields the well-formed prefix. Deliberately
+// NOT a decreasing brute-force parse: this runs on every turn and the payload can be tens of
+// KB. The truncated field is dropped, never reconstructed — half an assistant message is
+// invented data, and it is the one field we do not need.
+export function salvageTruncatedJson(raw) {
+  const text = String(raw || '');
+  if (text[0] !== '{') return null;
+  let inString = false;
+  let escaped = false;
+  let depth = 0;
+  let lastBoundary = -1;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (escaped) { escaped = false; continue; }
+    if (ch === '\\') { if (inString) escaped = true; continue; }
+    if (ch === '"') { inString = !inString; continue; }
+    if (inString) continue;
+    if (ch === '{' || ch === '[') depth += 1;
+    else if (ch === '}' || ch === ']') depth -= 1;
+    else if (ch === ',' && depth === 1) lastBoundary = i;
+  }
+  if (lastBoundary === -1) return null;
+  try {
+    const parsed = JSON.parse(`${text.slice(0, lastBoundary)}}`);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch { return null; }
+}
+
 export function readHookInput() {
   const raw = readFileSync(0, 'utf-8').trim();
   if (!raw) return {};
-  return JSON.parse(raw);
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    const salvaged = salvageTruncatedJson(raw);
+    // `_wk` prefix: the object is the harness payload merged with our own metadata, and a
+    // silent key collision here would be worse than the ugly prefix.
+    if (salvaged) return { ...salvaged, _wkSalvaged: true };
+    throw error;
+  }
 }
 
 export function writeHookOutput(payload = {}) {
@@ -503,6 +545,10 @@ export function isBootstrapPrompt(text = '') {
   return clean.startsWith('# AGENTS.md instructions')
     || clean.startsWith('<environment_context>')
     || clean.startsWith('<permissions instructions>')
+    // Codex injects the available-plugins catalogue as the first userPrompt of turn 1.
+    // Anchored with startsWith on purpose: matching the bare substring would discard a
+    // legitimate prompt that merely asks about plugins.
+    || clean.startsWith('<recommended_plugins>')
     || clean.includes('You are Codex, a coding agent')
     || clean.startsWith('## Memory');
 }

--- a/hooks/session-identity.mjs
+++ b/hooks/session-identity.mjs
@@ -96,6 +96,30 @@ export function resolveSessionIdentity(vaultBase, input = {}, provider = detectP
     };
   }
 
+  // Codex on Windows can deliver a Stop payload whose transcript_path never arrives (or is
+  // lost to a truncated JSON, openai/codex#23784). The registry already knows the mapping —
+  // the lookup below just sat under this gate, unreachable in the one case it solves. The
+  // comment above says we require "rollout/registry"; the registry half was never wired.
+  // Requiring the entry's provider to match preserves the cross-provider invariant from the
+  // 2026-07-11 incident: we are not minting a canonical id, we are finding an ALREADY
+  // REGISTERED session whose key is the hook's own id. A resume with a fresh id simply
+  // misses and stays deferred.
+  if (!transcriptPath && hookId) {
+    const entry = readSessionRegistry(vaultBase).sessions?.[hookId];
+    if (entry?.transcript_path && entry.provider === provider) {
+      return {
+        state: 'resolved',
+        provider,
+        canonicalConversationId: hookId,
+        hookSessionId: hookId,
+        transcriptPath: entry.transcript_path,
+        transcriptId: entry.transcript_id || basename(entry.transcript_path, '.jsonl'),
+        parentConversationId: '',
+        diagnostics: ['transcript recuperado do SESSION_REGISTRY'],
+      };
+    }
+  }
+
   if (!transcriptPath || !inspected.canonicalConversationId) {
     return { state: 'deferred', provider, transcriptPath, diagnostics: ['transcript ausente ou sem identidade canônica'] };
   }

--- a/hooks/session-stop.mjs
+++ b/hooks/session-stop.mjs
@@ -584,6 +584,16 @@ function formatTokenLine(usage, model) {
   return cost ? `${line} — ≈ API equivalente (não é cobrança do plano)` : line;
 }
 
+// User-facing explanation for a turn that could not be memorialized. Names the upstream bug
+// when the payload arrived salvaged, because "wendkeep didn't record it" reads as a wendkeep
+// defect and the user would have nowhere to look.
+export function bailMessage(why, input = {}) {
+  const truncated = input._wkSalvaged
+    ? ' O payload do Stop chegou truncado (openai/codex#23784).'
+    : '';
+  return `[wendkeep] Turno não registrado: ${why}.${truncated} Recupere com \`wendkeep import --source codex\`.`;
+}
+
 export function buildIterationBlock(tx, input) {
   const turnId = input.turn_id || tx.latestTurnId || `${Date.now()}`;
   const turn = selectTurn(tx, turnId);
@@ -1033,8 +1043,11 @@ function main() {
   const transcriptPath = input.transcript_path || input.transcriptPath || '';
   const { identity, entry } = resolveSessionEntry(vaultBase, input);
   if (identity.state !== 'resolved' || !entry?.session_file) {
-    process.stderr.write(`[wendkeep] Stop sem identidade segura: ${identity.diagnostics?.join('; ') || 'sessão não registrada'}\n`);
-    writeHookOutput({});
+    const why = identity.diagnostics?.join('; ') || 'sessão não registrada';
+    process.stderr.write(`[wendkeep] Stop sem identidade segura: ${why}\n`);
+    // stderr alone is a black hole here: Codex discards it, which is how an entire session of
+    // lost turns produced no signal at all. systemMessage is what the UI actually shows.
+    writeHookOutput({ systemMessage: bailMessage(why, input) });
     return;
   }
 
@@ -1160,6 +1173,9 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     main();
   } catch (error) {
     process.stderr.write(`[wendkeep] Stop falhou: ${error.message}\n`);
-    writeHookOutput({});
+    // Same reasoning as the identity bail: stderr is discarded by Codex. Exit stays 0 —
+    // a non-zero Stop hook blocks the turn (openai/codex#21921), and trading a lost turn
+    // for a stuck session is a worse deal.
+    writeHookOutput({ systemMessage: bailMessage(error.message) });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.46.0",
+      "version": "0.46.1",
       "license": "MIT",
       "bin": {
         "wendkeep": "bin/wendkeep.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "A persistent-memory harness for AI coding agents on your Obsidian vault: turn-by-turn session capture plus a native, zero-dependency spec→change→verify→archive loop (sensor-gated, independent verdict, mutation discrimination). Local-first, agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "bin": {

--- a/tests/codex-capture-recovery.test.mjs
+++ b/tests/codex-capture-recovery.test.mjs
@@ -1,0 +1,115 @@
+// End-to-end for the Vendiva incident: Codex truncates the Stop payload (openai/codex#23784)
+// so the session note stays empty while the registry says it exists; `import` then refuses to
+// touch it; and whatever it does import gets titled with the injected plugin catalogue.
+// This drives the whole chain on a Codex-shaped transcript.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runImport } from '../hooks/import-sessions.mjs';
+
+const CWD = 'C:\\proj\\vendiva';
+const SID = '019f7764-7627-79a3-b609-65abaa36eedd';
+const INJECTED = '<recommended_plugins> Here is a list of plugins that are available but not '
+  + 'installed. - Box (box@openai-curated-remote) - Figma (figma@openai-curated-remote)';
+const REAL = 'Analise os arquivos nas pastas docs e design e vamos planejar o desenvolvimento';
+
+// Turn 1 carries the injected block FIRST and the user's request LAST — the real ordering,
+// verified against the Vendiva rollout.
+const TRANSCRIPT = [
+  { type: 'session_meta', timestamp: '2026-07-18T19:42:00.000Z', payload: { id: SID, timestamp: '2026-07-18T19:42:00.000Z', cwd: CWD, model: 'gpt-5.6-sol', model_provider: 'openai' } },
+  { type: 'event_msg', timestamp: '2026-07-18T19:42:01.000Z', payload: { type: 'task_started', turn_id: 'turn-1' } },
+  { type: 'event_msg', timestamp: '2026-07-18T19:42:02.000Z', payload: { type: 'user_message', turn_id: 'turn-1', message: INJECTED } },
+  { type: 'event_msg', timestamp: '2026-07-18T19:42:03.000Z', payload: { type: 'user_message', turn_id: 'turn-1', message: REAL } },
+  { type: 'event_msg', timestamp: '2026-07-18T19:42:04.000Z', payload: { type: 'agent_message', turn_id: 'turn-1', message: 'Analisei os arquivos e a configuração está correta.' } },
+  { type: 'event_msg', timestamp: '2026-07-18T19:45:00.000Z', payload: { type: 'task_started', turn_id: 'turn-2' } },
+  { type: 'event_msg', timestamp: '2026-07-18T19:45:01.000Z', payload: { type: 'user_message', turn_id: 'turn-2', message: 'Opção C, modo Completo APP e WEB' } },
+  { type: 'event_msg', timestamp: '2026-07-18T19:45:02.000Z', payload: { type: 'agent_message', turn_id: 'turn-2', message: 'Seguindo com a opção C.' } },
+];
+
+const turnMarkers = (md) => (md.match(/<!-- wk-turn: /g) || []).length;
+
+function walkNotes(dir, out = []) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) walkNotes(p, out);
+    else if (e.name.endsWith('.md')) out.push(p);
+  }
+  return out;
+}
+
+// A vault in exactly the damaged state: session-start wrote the note + registry entry, the
+// Stop hook never landed a single turn.
+function damagedVault(txPath) {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-e2e-vault-'));
+  const rel = '02-Sessões/2026/07-JUL/DIA 18/19-42-session.md';
+  const abs = join(vault, ...rel.split('/'));
+  mkdirSync(join(abs, '..'), { recursive: true });
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  writeFileSync(abs, [
+    '---', 'type: session', `session_id: "${SID}"`, 'provider: codex', 'status: active',
+    'summary: "session"', 'source: codex-hook', '---', '',
+    '# 19:42 - session', '', '## Iterações', '', '### 19:42 - Início da sessão', '',
+    'Sessão iniciada automaticamente pelo hook de início (Codex).', '',
+    '## Decisões geradas nesta sessão', '', 'Nenhuma decisão registrada ainda.', '',
+  ].join('\n'), 'utf-8');
+  writeFileSync(join(vault, '.brain', 'SESSION_REGISTRY.json'), JSON.stringify({
+    version: 1,
+    sessions: { [SID]: { session_file: rel, status: 'active', provider: 'codex', transcript_path: txPath, transcript_id: SID } },
+  }), 'utf-8');
+  return { vault, note: abs };
+}
+
+function seed() {
+  const src = mkdtempSync(join(tmpdir(), 'wk-e2e-src-'));
+  const day = join(src, '2026', '07', '18');
+  mkdirSync(day, { recursive: true });
+  const txPath = join(day, `rollout-2026-07-18T19-41-45-${SID}.jsonl`);
+  writeFileSync(txPath, TRANSCRIPT.map((e) => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
+  return { src, txPath, ...damagedVault(txPath) };
+}
+
+test('recuperação e2e: sessão registrada e vazia recebe os turnos que o Stop perdeu', () => {
+  const { src, vault, note } = seed();
+  assert.equal(turnMarkers(readFileSync(note, 'utf8')), 0, 'pré-condição: nota vazia');
+
+  const r = runImport(vault, { source: 'codex', projectPath: CWD, codexFrom: src });
+
+  assert.equal(r.repaired, 1, 'a sessão danificada foi completada, não pulada');
+  assert.equal(r.skipped, 0);
+  const md = readFileSync(note, 'utf8');
+  assert.equal(turnMarkers(md), 2, 'os dois turnos entraram');
+  assert.ok(md.includes(REAL), 'o pedido real está na nota');
+  assert.ok(md.includes('Opção C'), 'o segundo turno também');
+  assert.equal(walkNotes(join(vault, '02-Sessões')).length, 1, 'reparou a nota existente, sem criar outra');
+});
+
+test('recuperação e2e: sessão nova nasce com título limpo, sem o bloco injetado', () => {
+  const { src, txPath } = seed();
+  // Vault sem registro nenhum: o import cria a nota do zero e escolhe o título.
+  const vault = mkdtempSync(join(tmpdir(), 'wk-e2e-fresh-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  void txPath;
+
+  const r = runImport(vault, { source: 'codex', projectPath: CWD, codexFrom: src });
+  assert.equal(r.imported, 1);
+
+  const [notePath] = walkNotes(join(vault, '02-Sessões'));
+  assert.ok(!/recommended-plugins/i.test(notePath), `nome do arquivo poluído: ${notePath}`);
+  const md = readFileSync(notePath, 'utf8');
+  const summary = (md.match(/^summary: "?(.*?)"?$/m) || [])[1] || '';
+  assert.ok(summary.includes('Analise os arquivos'), `summary errado: ${summary}`);
+  assert.ok(!/recommended_plugins/i.test(summary), 'bloco do harness não pode titular a sessão');
+});
+
+test('recuperação e2e: rodar o import de novo não altera nada', () => {
+  const { src, vault, note } = seed();
+  runImport(vault, { source: 'codex', projectPath: CWD, codexFrom: src });
+  const afterRepair = readFileSync(note, 'utf8');
+
+  const second = runImport(vault, { source: 'codex', projectPath: CWD, codexFrom: src });
+  assert.equal(second.repaired, 0);
+  assert.equal(second.skipped, 1, 'agora está completa');
+  assert.equal(readFileSync(note, 'utf8'), afterRepair, 'nota intocada');
+});

--- a/tests/hook-input-salvage.test.mjs
+++ b/tests/hook-input-salvage.test.mjs
@@ -1,0 +1,142 @@
+// The Codex Stop payload arrives truncated on Windows when the assistant message carries
+// non-ASCII text (openai/codex#23784): the JSON string is cut and never closed. Everything
+// wendkeep needs sits before that field, so the prefix must survive.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { salvageTruncatedJson } from '../hooks/obsidian-common.mjs';
+
+// Field order mirrors StopCommandInput in codex-rs — last_assistant_message is final.
+const PREFIX = '{"session_id":"019f7764-7627-79a3-b609-65abaa36eedd","turn_id":"turn-abc",'
+  + '"transcript_path":"C:\\\\Users\\\\x\\\\rollout.jsonl","cwd":"C:\\\\GitHub\\\\Vendiva",'
+  + '"hook_event_name":"Stop","model":"gpt-5.6-sol","permission_mode":"default","stop_hook_active":false';
+
+// --- CODEX-8 -----------------------------------------------------------------
+
+test('salvageTruncatedJson: recupera os campos do prefixo quando a última string não fecha', () => {
+  const raw = `${PREFIX},"last_assistant_message":"Analisei a configura}`;
+  assert.throws(() => JSON.parse(raw), 'o payload precisa ser realmente inválido');
+
+  const out = salvageTruncatedJson(raw);
+  assert.equal(out.session_id, '019f7764-7627-79a3-b609-65abaa36eedd');
+  assert.equal(out.turn_id, 'turn-abc');
+  assert.equal(out.transcript_path, 'C:\\Users\\x\\rollout.jsonl');
+  assert.equal(out.cwd, 'C:\\GitHub\\Vendiva');
+  assert.equal(out.hook_event_name, 'Stop');
+  assert.equal(out.stop_hook_active, false);
+});
+
+test('salvageTruncatedJson: descarta o campo truncado em vez de adivinhar o conteúdo', () => {
+  const out = salvageTruncatedJson(`${PREFIX},"last_assistant_message":"Analisei a configura}`);
+  assert.ok(!('last_assistant_message' in out), 'campo cortado não pode ser inventado pela metade');
+});
+
+test('salvageTruncatedJson: corte no meio de um caractere acentuado', () => {
+  const out = salvageTruncatedJson(`${PREFIX},"last_assistant_message":"ConfiguraÃ}`);
+  assert.equal(out.session_id, '019f7764-7627-79a3-b609-65abaa36eedd');
+  assert.equal(out.transcript_path, 'C:\\Users\\x\\rollout.jsonl');
+});
+
+test('salvageTruncatedJson: vírgula dentro de string não conta como fronteira de campo', () => {
+  // A gulosa: cortar na última vírgula literal cairia DENTRO do cwd e perderia campos.
+  const raw = '{"session_id":"abc","cwd":"C:\\\\a, b, c","transcript_path":"/x.jsonl",'
+    + '"last_assistant_message":"texto corta}';
+  const out = salvageTruncatedJson(raw);
+  assert.equal(out.cwd, 'C:\\a, b, c', 'vírgulas dentro da string preservadas');
+  assert.equal(out.transcript_path, '/x.jsonl', 'campo depois da string com vírgula sobrevive');
+});
+
+test('salvageTruncatedJson: aspas escapadas não encerram a string', () => {
+  const raw = '{"session_id":"abc","cwd":"diz \\"oi\\", certo","transcript_path":"/x.jsonl",'
+    + '"last_assistant_message":"corta}';
+  const out = salvageTruncatedJson(raw);
+  assert.equal(out.cwd, 'diz "oi", certo');
+  assert.equal(out.transcript_path, '/x.jsonl');
+});
+
+// Os casos abaixo põem o conteúdo difícil DENTRO do campo cortado, que é onde ele aparece no
+// payload real do Codex. Sem isso, um `lastIndexOf(',')` ingênuo passaria em todos os testes
+// acima — o conteúdo difícil vinha antes do corte, onde as duas estratégias concordam.
+
+test('salvageTruncatedJson: vírgula DENTRO da mensagem truncada não é fronteira de campo', () => {
+  const raw = `${PREFIX},"last_assistant_message":"Analisei, revisei e corrigi a configura`;
+  const out = salvageTruncatedJson(raw);
+  assert.ok(out, 'cortar na última vírgula literal cairia dentro da mensagem e perderia tudo');
+  assert.equal(out.transcript_path, 'C:\\Users\\x\\rollout.jsonl');
+  assert.equal(out.session_id, '019f7764-7627-79a3-b609-65abaa36eedd');
+  assert.ok(!('last_assistant_message' in out));
+});
+
+test('salvageTruncatedJson: aspas escapadas dentro da mensagem truncada', () => {
+  const raw = `${PREFIX},"last_assistant_message":"Rodei \\"npm test\\", passou, mas o build`;
+  const out = salvageTruncatedJson(raw);
+  assert.ok(out);
+  assert.equal(out.transcript_path, 'C:\\Users\\x\\rollout.jsonl');
+});
+
+test('salvageTruncatedJson: aspa escapada ímpar SEGUIDA de vírgula', () => {
+  // Só a aspa ímpar não basta: sem rastrear o escape ela "fecha" a string cedo, mas se não
+  // vier vírgula depois os dois caminhos coincidem. Com a vírgula, a versão sem escape a lê
+  // como fronteira de campo, corta dentro da mensagem e devolve null. É o caso que separa.
+  const raw = `${PREFIX},"last_assistant_message":"Rodei \\"npm test, passou, mas o build`;
+  const out = salvageTruncatedJson(raw);
+  assert.ok(out, 'sem rastrear o escape, a vírgula de dentro vira fronteira e o prefixo se perde');
+  assert.equal(out.transcript_path, 'C:\\Users\\x\\rollout.jsonl');
+  assert.equal(out.session_id, '019f7764-7627-79a3-b609-65abaa36eedd');
+  assert.ok(!('last_assistant_message' in out));
+});
+
+test('salvageTruncatedJson: chave iniciada mas sem valor ainda', () => {
+  const out = salvageTruncatedJson(`${PREFIX},"last_assistant_`);
+  assert.ok(out);
+  assert.equal(out.turn_id, 'turn-abc');
+});
+
+test('salvageTruncatedJson: devolve null quando nem o prefixo é aproveitável', () => {
+  assert.equal(salvageTruncatedJson('{"session_id":"abc'), null, 'só um campo, ele mesmo cortado');
+  assert.equal(salvageTruncatedJson('não é json'), null);
+  assert.equal(salvageTruncatedJson(''), null);
+});
+
+test('salvageTruncatedJson: objeto aninhado não fecha a fronteira cedo demais', () => {
+  const raw = '{"session_id":"abc","meta":{"a":1,"b":2},"transcript_path":"/x.jsonl",'
+    + '"last_assistant_message":"corta}';
+  const out = salvageTruncatedJson(raw);
+  assert.deepEqual(out.meta, { a: 1, b: 2 });
+  assert.equal(out.transcript_path, '/x.jsonl');
+});
+
+// readHookInput reads fd 0, so exercise it through a child process. The module URL is derived
+// from this test file so the spawn works on Windows and on the Linux CI matrix alike.
+const COMMON_URL = new URL('../hooks/obsidian-common.mjs', import.meta.url).href;
+const runReadHookInput = (stdin) => {
+  const code = `import{readHookInput}from${JSON.stringify(COMMON_URL)};`
+    + 'try{process.stdout.write(JSON.stringify({ok:true,value:readHookInput()}))}'
+    + 'catch(e){process.stdout.write(JSON.stringify({ok:false,message:String(e.message)}))}';
+  const r = spawnSync(process.execPath, ['--input-type=module', '-e', code], { input: stdin, encoding: 'utf8' });
+  return JSON.parse(r.stdout);
+};
+
+test('readHookInput: payload íntegro não é marcado como salvo', () => {
+  const out = runReadHookInput('{"session_id":"abc","transcript_path":"/x.jsonl"}');
+  assert.equal(out.ok, true);
+  assert.equal(out.value.session_id, 'abc');
+  assert.ok(!('_wkSalvaged' in out.value), 'parse normal não marca salvamento');
+});
+
+test('readHookInput: payload truncado é salvo e marcado', () => {
+  const out = runReadHookInput(`${PREFIX},"last_assistant_message":"corta}`);
+  assert.equal(out.ok, true, 'não pode mais lançar');
+  assert.equal(out.value._wkSalvaged, true);
+  assert.equal(out.value.transcript_path, 'C:\\Users\\x\\rollout.jsonl');
+});
+
+test('readHookInput: stdin vazio continua devolvendo objeto vazio', () => {
+  assert.deepEqual(runReadHookInput('').value, {});
+});
+
+test('readHookInput: lixo irrecuperável ainda lança — salvamento não vira silêncio novo', () => {
+  const out = runReadHookInput('isso não é json de jeito nenhum');
+  assert.equal(out.ok, false);
+  assert.match(out.message, /JSON/i);
+});

--- a/tests/identity-registry-fallback.test.mjs
+++ b/tests/identity-registry-fallback.test.mjs
@@ -1,0 +1,61 @@
+// The registry already maps session_id -> transcript_path, but the lookup sat BELOW the
+// transcript gate in resolveSessionIdentity — unreachable exactly when the payload arrives
+// without a transcript_path, which is the case it would have solved.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveSessionIdentity } from '../hooks/session-identity.mjs';
+
+const SID = '019f7764-7627-79a3-b609-65abaa36eedd';
+const TX = join(tmpdir(), 'wk-fallback-rollout.jsonl');
+
+function vaultWith(sessions) {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-ident-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  writeFileSync(join(vault, '.brain', 'SESSION_REGISTRY.json'), JSON.stringify({ version: 1, sessions }), 'utf-8');
+  return vault;
+}
+
+const codexEntry = {
+  session_file: '02-Sessões/2026/07-JUL/DIA 18/19-42-sessao.md',
+  status: 'active',
+  provider: 'codex',
+  transcript_path: TX,
+  transcript_id: SID,
+};
+
+// --- CODEX-10 ----------------------------------------------------------------
+
+test('resolveSessionIdentity: resolve pelo registry quando o payload não traz transcript_path', () => {
+  const vault = vaultWith({ [SID]: codexEntry });
+  const r = resolveSessionIdentity(vault, { session_id: SID, hook_event_name: 'Stop' }, 'codex');
+  assert.equal(r.state, 'resolved', `esperava resolved, veio ${r.state}: ${r.diagnostics?.join('; ')}`);
+  assert.equal(r.canonicalConversationId, SID);
+  assert.equal(r.transcriptPath, TX, 'o transcript vem da entrada do registry');
+});
+
+test('resolveSessionIdentity: session_id fora do registry continua deferred', () => {
+  const vault = vaultWith({ [SID]: codexEntry });
+  const r = resolveSessionIdentity(vault, { session_id: 'id-que-nunca-existiu' }, 'codex');
+  assert.equal(r.state, 'deferred', 'não pode inventar identidade');
+});
+
+test('resolveSessionIdentity: entrada de outro provider não serve de fallback', () => {
+  // Invariante do incidente 2026-07-11 (contaminação cross-provider).
+  const vault = vaultWith({ [SID]: { ...codexEntry, provider: 'claude' } });
+  const r = resolveSessionIdentity(vault, { session_id: SID }, 'codex');
+  assert.equal(r.state, 'deferred');
+});
+
+test('resolveSessionIdentity: entrada sem transcript_path não resolve', () => {
+  const vault = vaultWith({ [SID]: { ...codexEntry, transcript_path: '' } });
+  const r = resolveSessionIdentity(vault, { session_id: SID }, 'codex');
+  assert.equal(r.state, 'deferred');
+});
+
+test('resolveSessionIdentity: sem session_id nenhum, segue deferred', () => {
+  const vault = vaultWith({ [SID]: codexEntry });
+  assert.equal(resolveSessionIdentity(vault, {}, 'codex').state, 'deferred');
+});

--- a/tests/import-repair.test.mjs
+++ b/tests/import-repair.test.mjs
@@ -1,0 +1,108 @@
+// A session the live hook registered but never filled (BUG-0003) used to be invisible to
+// `wendkeep import`: dedup asked "is it registered?" instead of "does it have the turns?",
+// so the exact sessions the recovery command exists for were the ones it refused to touch.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runImport } from '../hooks/import-sessions.mjs';
+
+const TRANSCRIPT = [
+  { type: 'user', uuid: 't1', timestamp: '2026-06-13T09:00:00.000Z', sessionId: 'sid-repair', message: { role: 'user', content: 'Primeira pergunta sobre autenticacao' } },
+  { type: 'assistant', uuid: 'a1', timestamp: '2026-06-13T09:00:05.000Z', sessionId: 'sid-repair', message: { role: 'assistant', model: 'claude-opus-4-8', usage: { input_tokens: 100, output_tokens: 200 }, content: [{ type: 'text', text: 'Resposta um' }] } },
+  { type: 'user', uuid: 't2', timestamp: '2026-06-13T09:05:00.000Z', sessionId: 'sid-repair', message: { role: 'user', content: 'Segunda pergunta do usuario' } },
+  { type: 'assistant', uuid: 'a2', timestamp: '2026-06-13T09:05:05.000Z', sessionId: 'sid-repair', message: { role: 'assistant', model: 'claude-opus-4-8', usage: { input_tokens: 50, output_tokens: 80 }, content: [{ type: 'text', text: 'Resposta dois' }] } },
+];
+
+const tmp = (p) => mkdtempSync(join(tmpdir(), p));
+const turnMarkers = (md) => (md.match(/<!-- wk-turn: /g) || []).length;
+
+function walkNotes(dir, out = []) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) walkNotes(p, out);
+    else if (e.name.endsWith('.md')) out.push(p);
+  }
+  return out;
+}
+
+function seed() {
+  const src = tmp('wk-rep-src-');
+  const vault = tmp('wk-rep-vault-');
+  writeFileSync(join(src, 'sid-repair.jsonl'), TRANSCRIPT.map((e) => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
+  const first = runImport(vault, { source: 'claude', from: src });
+  const note = join(vault, first.sessions[0].relPath);
+  return { src, vault, note };
+}
+
+const sessionNotes = (vault) => walkNotes(join(vault, '02-Sessões'));
+
+// --- IMPORT-1 ----------------------------------------------------------------
+
+test('runImport: completa uma sessão registrada cuja nota ficou sem nenhum turno', () => {
+  const { src, vault, note } = seed();
+  assert.equal(turnMarkers(readFileSync(note, 'utf8')), 2, 'pré-condição: nota cheia');
+
+  // Reproduz o dano do BUG-0003: registro sobrevive, iterações somem.
+  const gutted = readFileSync(note, 'utf8').replace(/\n### \d\d:\d\d - [\s\S]*?(?=\n## )/g, '\n');
+  writeFileSync(note, gutted, 'utf-8');
+  assert.equal(turnMarkers(readFileSync(note, 'utf8')), 0, 'pré-condição: nota esvaziada');
+
+  const repair = runImport(vault, { source: 'claude', from: src });
+  assert.equal(turnMarkers(readFileSync(note, 'utf8')), 2, 'os dois turnos voltaram');
+  assert.equal(sessionNotes(vault).length, 1, 'reparo na nota existente, não numa segunda');
+  assert.equal(repair.repaired, 1, 'contada como reparada, não pulada');
+  assert.equal(repair.skipped, 0);
+  assert.equal(repair.imported, 0, 'não é nota nova — `imported` fica pra criação do zero');
+});
+
+test('runImport: nota já completa é pulada e não é modificada', () => {
+  const { src, vault, note } = seed();
+  const before = readFileSync(note, 'utf8');
+
+  const rerun = runImport(vault, { source: 'claude', from: src });
+  assert.equal(readFileSync(note, 'utf8'), before, 'byte a byte idêntica');
+  assert.equal(rerun.imported, 0);
+  assert.equal(rerun.skipped, 1);
+});
+
+test('runImport: cobertura parcial acrescenta só o turno que falta, sem duplicar', () => {
+  const { src, vault, note } = seed();
+  // Remove apenas o último bloco de iteração.
+  const md = readFileSync(note, 'utf8');
+  const cut = md.lastIndexOf('\n### ');
+  const end = md.indexOf('\n## ', cut);
+  writeFileSync(note, md.slice(0, cut) + md.slice(end), 'utf-8');
+  assert.equal(turnMarkers(readFileSync(note, 'utf8')), 1, 'pré-condição: um turno só');
+
+  runImport(vault, { source: 'claude', from: src });
+  assert.equal(turnMarkers(readFileSync(note, 'utf8')), 2, 'o que faltava entrou');
+  const ids = readFileSync(note, 'utf8').match(/<!-- wk-turn: ([^\s]+) -->/g) || [];
+  assert.equal(new Set(ids).size, ids.length, 'nenhum turno duplicado');
+});
+
+test('runImport: reparar é idempotente — a terceira rodada não muda nada', () => {
+  const { src, vault, note } = seed();
+  writeFileSync(note, readFileSync(note, 'utf8').replace(/\n### \d\d:\d\d - [\s\S]*?(?=\n## )/g, '\n'), 'utf-8');
+  runImport(vault, { source: 'claude', from: src });
+  const afterRepair = readFileSync(note, 'utf8');
+  runImport(vault, { source: 'claude', from: src });
+  assert.equal(readFileSync(note, 'utf8'), afterRepair, 'no-op depois de reparada');
+  assert.equal(sessionNotes(vault).length, 1);
+});
+
+// --- IMPORT-2 ----------------------------------------------------------------
+
+test('runImport: relatório separa já-completa de completada', () => {
+  const { src, vault, note } = seed();
+  writeFileSync(note, readFileSync(note, 'utf8').replace(/\n### \d\d:\d\d - [\s\S]*?(?=\n## )/g, '\n'), 'utf-8');
+
+  const repaired = runImport(vault, { source: 'claude', from: src });
+  assert.equal(repaired.repaired, 1, 'a sessão completada é contada à parte');
+  assert.equal(repaired.skipped, 0);
+
+  const noop = runImport(vault, { source: 'claude', from: src });
+  assert.equal(noop.repaired, 0);
+  assert.equal(noop.skipped, 1, 'já completa conta como pulada');
+});

--- a/tests/import-summary.test.mjs
+++ b/tests/import-summary.test.mjs
@@ -1,0 +1,63 @@
+// The harness injects blocks like <recommended_plugins> as the FIRST userPrompt of a turn;
+// the user's real request is the LAST. buildIterationBlock already takes .at(-1) and gets it
+// right — deriveSummary took .find(Boolean) and titled six Vendiva sessions with the injected
+// block. Same data, opposite end.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveSummary } from '../hooks/import-sessions.mjs';
+import { isBootstrapPrompt } from '../hooks/obsidian-common.mjs';
+
+const INJECTED = '<recommended_plugins> Here is a list of plugins that are available but not '
+  + 'installed. - Box (box@openai-curated-remote) - Figma (figma@openai-curated-remote)';
+const REAL = 'Analise os arquivos nas pastas docs e design e vamos planejar o desenvolvimento do app';
+
+// --- IMPORT-3 ----------------------------------------------------------------
+
+test('deriveSummary: pega o pedido real, não o bloco injetado antes dele', () => {
+  const tx = { turns: [{ userPrompts: [INJECTED, REAL] }] };
+  const summary = deriveSummary(tx);
+  assert.ok(summary.includes('Analise os arquivos'), `esperava o pedido real, veio: ${summary}`);
+  assert.ok(!/recommended_plugins/i.test(summary), 'bloco do harness não pode titular a sessão');
+});
+
+test('deriveSummary: com dois pedidos legítimos no mesmo turno, vale o último', () => {
+  // O caso que discrimina `.at(-1)` de `[0]`: sem dois prompts NÃO-bootstrap no mesmo turno,
+  // o filtro sozinho já resolveria e a seleção poderia estar errada sem ninguém notar. O
+  // bloco de iteração usa userPrompts.at(-1) (session-stop.mjs) — as duas têm que concordar,
+  // senão o título da sessão contradiz o corpo dela.
+  const tx = { turns: [{ userPrompts: ['Comece pelo backend', 'Na verdade, comece pelo frontend'] }] };
+  assert.equal(deriveSummary(tx), 'Na verdade, comece pelo frontend');
+});
+
+test('deriveSummary: bloco injetado ENTRE dois pedidos não desloca a escolha', () => {
+  const tx = { turns: [{ userPrompts: ['Comece pelo backend', INJECTED, 'Na verdade, pelo frontend'] }] };
+  assert.equal(deriveSummary(tx), 'Na verdade, pelo frontend');
+});
+
+test('deriveSummary: turno só de bootstrap cede a vez pro turno seguinte', () => {
+  const tx = { turns: [{ userPrompts: [INJECTED] }, { userPrompts: ['Opção C, modo Completo'] }] };
+  assert.ok(deriveSummary(tx).includes('Opção C'));
+});
+
+test('deriveSummary: sem nenhum prompt aproveitável cai no fallback', () => {
+  assert.equal(deriveSummary({ turns: [{ userPrompts: [INJECTED] }] }), 'session');
+  assert.equal(deriveSummary({ turns: [] }), 'session');
+  assert.equal(deriveSummary({}), 'session');
+});
+
+test('deriveSummary: prompt único e legítimo continua intacto', () => {
+  const tx = { turns: [{ userPrompts: ['Opção C, modo Completo APP(Android) e WEB'] }] };
+  assert.equal(deriveSummary(tx), 'Opção C, modo Completo APP(Android) e WEB');
+});
+
+test('deriveSummary: um prompt que apenas MENCIONA plugins não é descartado', () => {
+  // A guarda contra filtro guloso: descartar por substring engoliria pedido legítimo.
+  const tx = { turns: [{ userPrompts: ['Quais recommended_plugins devo instalar no projeto?'] }] };
+  assert.ok(deriveSummary(tx).includes('Quais recommended_plugins'));
+});
+
+test('isBootstrapPrompt: reconhece o bloco de plugins injetado', () => {
+  assert.equal(isBootstrapPrompt(INJECTED), true);
+  assert.equal(isBootstrapPrompt(REAL), false);
+  assert.equal(isBootstrapPrompt('Quais recommended_plugins devo instalar?'), false);
+});

--- a/tests/stop-bail-visibility.test.mjs
+++ b/tests/stop-bail-visibility.test.mjs
@@ -1,0 +1,96 @@
+// The Stop hook used to bail by writing to stderr and exiting 0. Codex discards stderr, so a
+// whole session of lost turns produced zero user-visible signal — that is why BUG-0003
+// survived unnoticed. `systemMessage` is the channel the Codex UI actually surfaces.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HOOK = join(dirname(fileURLToPath(import.meta.url)), '..', 'hooks', 'session-stop.mjs');
+
+function runStop(buildPayload, { vault } = {}) {
+  const proj = mkdtempSync(join(tmpdir(), 'wk-bail-proj-'));
+  const payload = typeof buildPayload === 'function' ? buildPayload(proj) : buildPayload;
+  const vaultBase = vault || join(proj, '.v');
+  mkdirSync(join(vaultBase, '.brain'), { recursive: true });
+  // A real binding on both ends: without PROJECT.json the hook bails on vault resolution
+  // instead of on identity, and the test would prove the wrong path.
+  writeFileSync(join(proj, '.wendkeep.json'), JSON.stringify({ schemaVersion: 1, projectId: 'p1', vault: '.v' }), 'utf-8');
+  writeFileSync(join(vaultBase, '.brain', 'PROJECT.json'), JSON.stringify({ schemaVersion: 1, projectId: 'p1' }), 'utf-8');
+  const r = spawnSync(process.execPath, [HOOK], {
+    input: payload,
+    encoding: 'utf8',
+    cwd: proj,
+    env: { ...process.env, OBSIDIAN_VAULT_PATH: vaultBase, CLAUDECODE: '', CLAUDE_CODE_SESSION_ID: '' },
+  });
+  let out = {};
+  try { out = JSON.parse(r.stdout || '{}'); } catch { /* keep {} */ }
+  return { ...r, out };
+}
+
+// `cwd` MUST point at the fixture project: session-stop resolves the vault from the payload's
+// cwd, not from the process cwd. Pointing it elsewhere kills the run at vault resolution and
+// exercises only the top-level catch — which is how the identity-bail branch went untested.
+const unresolvable = (proj) => JSON.stringify({
+  session_id: 'nao-registrada-em-lugar-nenhum',
+  turn_id: 'turn-1',
+  hook_event_name: 'Stop',
+  cwd: proj,
+});
+
+// --- CODEX-9 -----------------------------------------------------------------
+
+test('session-stop: bail por identidade não resolvida avisa via systemMessage', () => {
+  const { out, stderr } = runStop(unresolvable);
+  // Prova que chegamos no bail de IDENTIDADE, e não no catch de topo por vault não resolvido.
+  assert.match(stderr, /Stop sem identidade segura/, `caminho errado exercitado: ${stderr}`);
+  assert.equal(typeof out.systemMessage, 'string', 'o usuário precisa ver alguma coisa');
+  assert.match(out.systemMessage, /wendkeep/i);
+  // O motivo é metade da cláusula: uma mensagem que só diz "não registrado, rode o import"
+  // manda o usuário pro comando sem dizer o que aconteceu. Ancorar no diagnóstico que o
+  // próprio hook reportou, em vez de numa string fixa, prova que o motivo é PROPAGADO —
+  // remover `${why}` de bailMessage quebra aqui.
+  const why = (stderr.match(/Stop sem identidade segura: (.+)/) || [])[1]?.trim();
+  assert.ok(why, 'o stderr precisa trazer o diagnóstico');
+  assert.ok(out.systemMessage.includes(why), `systemMessage não repassa o motivo "${why}": ${out.systemMessage}`);
+  assert.match(out.systemMessage, /import --source codex/, 'precisa dizer como recuperar');
+});
+
+test('session-stop: falha dura também avisa, não só o bail de identidade', () => {
+  // Vault inexistente: cai no catch de topo, que também escrevia {} e sumia com o erro.
+  const { out } = runStop(unresolvable, { vault: join(tmpdir(), 'wk-vault-que-nao-existe-xyz') });
+  assert.equal(typeof out.systemMessage, 'string', 'catch de topo não pode voltar a ser mudo');
+  assert.match(out.systemMessage, /import --source codex/);
+});
+
+test('session-stop: payload truncado nomeia a issue upstream, não deixa parecer defeito nosso', () => {
+  // Prefixo bem-formado + string cortada: o salvamento recupera os campos e o hook chega no
+  // bail de identidade já sabendo que o payload veio truncado.
+  const truncated = (proj) => `{"session_id":"nao-registrada","turn_id":"t1","hook_event_name":"Stop",`
+    + `"cwd":${JSON.stringify(proj)},"last_assistant_message":"Analisei a configura}`;
+  const { out, stderr } = runStop(truncated);
+  assert.match(stderr, /Stop sem identidade segura/, 'precisa alcançar o bail de identidade');
+  assert.match(out.systemMessage, /openai\/codex#23784/, 'sem a issue, o usuário culpa o wendkeep');
+});
+
+test('session-stop: bail comum NÃO cita a issue upstream — o aviso tem que ser honesto', () => {
+  // A guarda contra citar #23784 em toda falha: só o payload truncado justifica a menção.
+  const { out } = runStop(unresolvable);
+  assert.ok(!/23784/.test(out.systemMessage), `citou a issue sem payload truncado: ${out.systemMessage}`);
+});
+
+test('session-stop: sai com código 0 mesmo falhando — exit != 0 trava o turno no Codex', () => {
+  assert.equal(runStop(unresolvable).status, 0);
+  assert.equal(runStop('lixo que não parseia').status, 0);
+});
+
+test('session-stop: stdout continua sendo JSON válido em todo caminho de bail', () => {
+  for (const payload of [unresolvable, '', 'lixo que não parseia']) {
+    const r = runStop(payload);
+    assert.ok(r.stdout.trim(), 'stdout vazio esconderia o bail — precisa ter JSON');
+    assert.doesNotThrow(() => JSON.parse(r.stdout));
+  }
+});


### PR DESCRIPTION
Três bugs encadeados fizeram uma sessão real de trabalho no Vendiva sumir do vault, e cada elo escondia o anterior. Este PR corrige os três e faz o bump de release **0.46.1**.

## A cadeia

**[BUG-0003] Stop do Codex no Windows manda JSON truncado** ([openai/codex#23784](https://github.com/openai/codex/issues/23784), upstream, aberto)
O Codex serializa o payload do `Stop` com `last_assistant_message` cortado no meio, sem fechar a string. Sessão em português enche esse campo de acento → corte frequente. `readHookInput` fazia `JSON.parse` cru, lançava, e o `session-stop` saía **0** com a mensagem só no stderr, que o Codex descarta. A nota era criada, o summary atualizava, e **nenhuma iteração entrava**. Só o `Stop` quebrava porque `last_assistant_message` é o único campo exclusivo dele — `SessionStart` e `UserPromptSubmit` não o carregam.

**[BUG-0004] O import se recusava a consertar a sessão danificada**
O dedup perguntava "existe registro?", não "existe conteúdo?". Como o `session-start` registra antes do `session-stop` escrever, **as sessões esvaziadas pelo BUG-0003 eram exatamente as que o comando de recuperação pulava.** O resgate era cego no caso que mais precisava dele.

**[BUG-0005] Título de bloco injetado**
Seis notas ficaram chamadas `<recommended_plugins> Here is a list of plugins that ar`. `buildIterationBlock` usa `userPrompts.at(-1)`; `deriveSummary` usava `.find(Boolean)` — o harness injeta o bloco como **primeiro** prompt do turno, o pedido vem por **último**. Mesmo dado, ponta oposta.

## As correções

- **`salvageTruncatedJson`** recupera o prefixo bem-formado numa passada (rastreando aspas/escape/profundidade); o campo truncado é descartado, nunca reconstruído.
- **`session-stop` emite `systemMessage`** no bail — canal que a UI do Codex mostra — em vez de stderr descartado. Exit 0 mantido (exit ≠ 0 trava o turno, openai/codex#21921).
- **`resolveSessionIdentity`** ganhou fallback pelo `SESSION_REGISTRY` quando falta `transcript_path`, exigindo provider igual (invariante cross-provider de 2026-07-11).
- **Dedup do import por cobertura de turno**: compara os `wk-turn` na nota com os turnos do transcript. Completa pula, parcial/vazia completa a nota existente. Sem flag opt-in. Relatório ganhou `repaired`, separado de `imported` e `skipped`.
- **`deriveSummary` alinhado ao caminho vivo**: `.at(-1)` + `isBootstrapPrompt` (que passou a reconhecer `<recommended_plugins>`), aplicado ao prompt inteiro.

## Recuperação

Quem perdeu turnos antes desta versão: `wendkeep import --source codex`. O rollout fica íntegro em disco e o import agora completa a nota em vez de pular. Rodar de novo é no-op. Notas já criadas com título poluído **não** são renomeadas automaticamente — mexer em nome de arquivo quebra wikilink e reorganiza o grafo, decisão do dono do vault.

## Verificação

48 testes novos em 6 arquivos. **440 passando**, `npm run check` limpo.

Quatro passes de verificação independente (autor ≠ verificador). Os três primeiros deram `ok: false`, cada um achando um gap **distinto** de discriminação — o padrão recorrente era assert com regex permissiva que passaria sob implementação errada:
1. fixture não alcançava o bail de identidade (exercitava o catch de topo); casos de salvamento com o conteúdo difícil antes do corte.
2. mutante `.at(-1)` → `[0]` sobrevivia (nenhum fixture tinha dois prompts legítimos no mesmo turno).
3. assert do motivo frouxo (`/wendkeep/i` casava sem o motivo); catch de topo mudo; dois testes de escape vacuous.

Cada gap virou tarefa e foi fechado com o mutante correspondente confirmado morto. O quarto passe: `ok: true`, 12 mutantes semânticos, todos mortos, nenhum gap bloqueante novo.

> O merge dispara o `auto-tag.yml` (tag `v0.46.1` + GitHub Release do CHANGELOG). **Publicação no npm fica com o mantenedor** — `npm publish` direto, não `npm run release` (aborta quando a tag já existe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
