### PR TITLE
fix: subagent do Codex — nota fantasma no import e telemetria perdida (0.46.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.46.2] — 2026-07-19
+
+### Fixed
+
+- **Rollout de subagent do Codex virava sessão top-level no import.** Um subagent do Codex
+  não é um arquivo em `<transcript>/subagents/` — é um rollout **irmão** no
+  `~/.codex/sessions/`, cujo `session_meta` declara `source.subagent` e aponta pro pai via
+  `parent_thread_id`. O import ignorava o marcador e materializava o subagent como uma
+  "sessão" própria, com o contexto do pai inteiro replicado (subagent herda o histórico) —
+  no caso real, uma nota fantasma de 23 turnos duplicando a conversa da sessão-mãe. Agora a
+  descoberta expõe o marcador, o import conta subagents à parte no relatório (nunca em
+  `skipped`) e nenhuma nota é criada. A entrada de registry que o import antigo escreveu
+  para um subagent é removida — self-healing do nosso próprio dado errado, nunca limpeza
+  genérica: entrada com o mesmo id mas transcript diferente é preservada.
+- **Telemetria de subagent do Codex nunca chegava à sessão-mãe — nem ao vivo.** A descoberta
+  (`collectSubagentUsage`) era Claude-shaped: procurava um diretório `subagents/` ao lado do
+  transcript, que no Codex não existe. Resultado: toda sessão Codex fechava com
+  `subagents_count: 0`, tanto no import quanto no hook vivo `SubagentStop` wirado na 0.46.0
+  — o custo dos subagents simplesmente não existia no vault. A nova
+  `collectCodexSubagentUsage` acha os irmãos por `parent_thread_id` (no dia do rollout pai e
+  no dia seguinte, cobrindo spawn que cruza a meia-noite UTC — o caso real passou a seis
+  minutos disso) e devolve o mesmo agregado que o writer já consome: vivo e import passam a
+  atribuir pelo mesmo caminho.
+- **O bloco injetado ainda aparecia como fala do usuário no "Contexto conversado".** O fix
+  da 0.46.1 protegeu o título, mas a linha `**Usuário:**` da iteração vinha de um segundo
+  filtro (`shouldIgnoreUserText`) que duplicava por cópia a lista do `isBootstrapPrompt` — e
+  as cópias divergiram. O filtro agora delega: um lugar só para o próximo bloco que o
+  harness inventar.
+- Bytes NUL literais em `hooks/token-usage.mjs` e `hooks/subagent-usage.mjs` escapados —
+  mesma classe do fix de `taxonomy.mjs` (#7): o byte cru fazia o `file` classificar o fonte
+  como binário e o ripgrep pulá-lo em silêncio. Entrou `tests/source-hygiene.test.mjs`
+  barrando byte de controle em qualquer fonte publicado; ele pegou uma quarta ocorrência
+  introduzida durante esta própria mudança.
+
 ## [0.46.1] — 2026-07-19
 
 ### Fixed

--- a/hooks/import-sessions.mjs
+++ b/hooks/import-sessions.mjs
@@ -17,7 +17,7 @@ import {
 import { buildSessionContent, allocateSessionPath } from './session-start.mjs';
 import { createLinkedNotes } from './linked-notes.mjs';
 import { updateSessionObservability } from './session-observability.mjs';
-import { readSessionRegistry, upsertSessionRegistry, formatLocalIso, formatDate, providerMeta, isBootstrapPrompt } from './obsidian-common.mjs';
+import { readSessionRegistry, upsertSessionRegistry, removeSessionRegistryEntry, formatLocalIso, formatDate, providerMeta, isBootstrapPrompt } from './obsidian-common.mjs';
 import { getLocale } from './locale.mjs';
 import { captureProseDecisions } from './decision-capture.mjs';
 
@@ -192,7 +192,12 @@ export function discoverCodexTranscripts(projectPath, fromDir) {
     const meta = readSessionMeta(path);
     if (!meta || !meta.id) continue;
     if (projectPath && !cwdMatchesProject(meta.cwd, projectPath)) continue;
-    transcripts.push({ path, sessionId: meta.id, cwd: meta.cwd || '' });
+    // A subagent thread's rollout is a SIBLING file of its parent's — same dir, own id. The
+    // meta says what the file IS; ignoring it turned hierarchy into a duplicate session note.
+    const subagent = meta.source?.subagent
+      ? { parentThreadId: meta.parent_thread_id || meta.source.subagent.thread_spawn?.parent_thread_id || '', nickname: meta.source.subagent.thread_spawn?.agent_nickname || '' }
+      : null;
+    transcripts.push({ path, sessionId: meta.id, cwd: meta.cwd || '', subagent });
   }
   return { dir, transcripts };
 }
@@ -350,10 +355,21 @@ export function runImport(vaultBase, opts = {}) {
   }
   const notes = capturedSessionNotes(vaultBase);
   const sinceMs = since ? Date.parse(since) : 0;
-  const report = { source: src, claudeDir, codexDir, scanned: transcripts.length, imported: 0, repaired: 0, skipped: 0, errors: [], sessions: [] };
+  const report = { source: src, claudeDir, codexDir, scanned: transcripts.length, imported: 0, repaired: 0, skipped: 0, subagents: 0, errors: [], sessions: [] };
 
   let done = 0;
   for (const t of transcripts) {
+    // A subagent rollout is telemetry of its PARENT session, never a session of its own —
+    // importing it materialized the parent's replayed context as a ghost note. Counted apart
+    // from `skipped` (which means "session already covered"). If import <=0.46.1 registered
+    // it as a top-level session, that entry is our own bad write: heal it.
+    if (t.subagent) {
+      report.subagents++;
+      if (!dryRun) {
+        try { removeSessionRegistryEntry(vaultBase, t.sessionId, t.path); } catch { /* best-effort */ }
+      }
+      continue;
+    }
     if (limit && done >= limit) break;
 
     // Every transcript is parsed now, including already-captured ones: partial coverage is

--- a/hooks/obsidian-common.mjs
+++ b/hooks/obsidian-common.mjs
@@ -355,6 +355,25 @@ function meaningfulPatch(patch = {}) {
   }));
 }
 
+// Remove one registry entry, but ONLY when its transcript matches the given path — this is
+// self-healing for entries wendkeep itself mis-wrote (a subagent rollout registered as a
+// top-level session by import <=0.46.1), never generic registry cleanup. An entry with the
+// same id but a different transcript belongs to someone else's state and is preserved.
+export function removeSessionRegistryEntry(vaultBase, sessionId, transcriptPath) {
+  if (!sessionId) return false;
+  let removed = false;
+  mutateSessionRegistry(vaultBase, (registry) => {
+    const entry = registry.sessions[sessionId];
+    if (!entry) return null;
+    const paths = [...(Array.isArray(entry.transcript_paths) ? entry.transcript_paths : []), entry.transcript_path].filter(Boolean);
+    if (!paths.some((p) => transcriptsMatch(p, transcriptPath))) return null;
+    delete registry.sessions[sessionId];
+    removed = true;
+    return null;
+  });
+  return removed;
+}
+
 export function upsertSessionRegistry(vaultBase, sessionId, patch) {
   if (!sessionId) return null;
   const clean = meaningfulPatch(patch);

--- a/hooks/session-observability.mjs
+++ b/hooks/session-observability.mjs
@@ -1,7 +1,7 @@
 // Single atomic writer for session usage, models, reasoning/effort and subagents.
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { collectSessionUsage } from './token-usage.mjs';
-import { collectSubagentUsage, sessionDirFromTranscript } from './subagent-usage.mjs';
+import { collectSubagentUsage, collectCodexSubagentUsage, sessionDirFromTranscript } from './subagent-usage.mjs';
 import { inspectTranscriptIdentity } from './session-identity.mjs';
 
 const HEADING = '## Agentes, tokens e custos';
@@ -137,7 +137,11 @@ ${renderSubagents(subagents)}`;
 export function buildSessionObservability({ sessionContent, transcriptPath }) {
   const main = collectSessionUsage({ sessionContent, transcriptPath });
   if (!main) return null;
-  const subagents = collectSubagentUsage(sessionDirFromTranscript(transcriptPath));
+  // Claude layout first (<transcript>/subagents/); when absent, the Codex layout — sibling
+  // rollouts linked by parent_thread_id. The Codex collector self-gates: a Claude transcript
+  // has no session_meta line, so it returns null and this stays a strict fallback.
+  const subagents = collectSubagentUsage(sessionDirFromTranscript(transcriptPath))
+    || collectCodexSubagentUsage(transcriptPath);
   const ledger = [...mainLedger(main), ...subagentLedger(subagents)];
   const sub = subagents?.aggregate || { count: 0, tokens: 0, cost: 0, wasted: 0, tools: [] };
   let content = main.content;

--- a/hooks/session-stop.mjs
+++ b/hooks/session-stop.mjs
@@ -18,6 +18,7 @@ import {
   formatLocalIso,
   getNextAdrNumber,
   getVaultBase,
+  isBootstrapPrompt,
   warnIfDefaultVault,
   listMarkdownFiles,
   readControl,
@@ -53,11 +54,12 @@ const SYNTHETIC_EVENT_TAG = /^<\/?(?:task-notification|system-reminder|local-com
 
 function shouldIgnoreUserText(text) {
   const trimmed = String(text || '').trim();
+  // Bootstrap detection is DELEGATED, not copied: this used to duplicate isBootstrapPrompt's
+  // prefix list and the copies drifted — <recommended_plugins> made it into one and not the
+  // other, so the title came out clean while the same block still showed as "Usuário" in the
+  // conversation context. One filter, one place to add the next injected block.
   return SYNTHETIC_EVENT_TAG.test(trimmed)
-    || /^# AGENTS\.md instructions/.test(trimmed)
-    || trimmed.startsWith('<permissions instructions>')
-    || trimmed.includes('You are Codex, a coding agent')
-    || trimmed.startsWith('## Memory')
+    || isBootstrapPrompt(trimmed)
     // Harness utility meta-prompts (title generation, classifiers) — not real user turns; they
     // were leaking into note titles/summaries on import.
     || /^Generate a concise( UI)? title/i.test(trimmed)

--- a/hooks/subagent-usage.mjs
+++ b/hooks/subagent-usage.mjs
@@ -76,6 +76,109 @@ const round4 = (n) => Math.round((Number(n) || 0) * 10000) / 10000;
 
 // Aggregate every subagent transcript under <sessionDir>/subagents. null when the dir is
 // absent (Codex / a session with no subagents) or nothing parseable.
+// --- Codex discovery ----------------------------------------------------------
+// A Codex subagent is not a file under `<transcript>/subagents/` — it is a SIBLING rollout
+// in ~/.codex/sessions/YYYY/MM/DD/, whose session_meta declares source.subagent and points
+// back via parent_thread_id. Without this, every Codex session closed with subagents_count 0,
+// live (SubagentStop) and on import alike.
+
+// First line of a rollout, bounded — Codex meta lines can be large (env, git, instructions).
+function readRolloutMeta(path, maxBytes = 4 * 1024 * 1024) {
+  try {
+    const text = readFileSync(path, 'utf-8');
+    if (text.length > maxBytes) return null;
+    const line = text.slice(0, text.indexOf('\n') === -1 ? text.length : text.indexOf('\n'));
+    const e = JSON.parse(line);
+    return e.type === 'session_meta' ? (e.payload || {}) : null;
+  } catch { return null; }
+}
+
+// Sibling day dirs to scan: the parent rollout's own dir plus the NEXT day — a session that
+// crosses midnight UTC spawns its subagent in the other day's folder, and the first real case
+// (Vendiva, 23:54 UTC) missed that by six minutes.
+function codexSiblingDirs(transcriptPath) {
+  const dir = join(transcriptPath, '..');
+  const m = String(dir).replace(/[\\/]+$/, '').match(/(\d{4})[\\/](\d{2})[\\/](\d{2})$/);
+  if (!m) return [dir];
+  const next = new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]) + 1));
+  const pad = (n) => String(n).padStart(2, '0');
+  const nextDir = join(dir, '..', '..', '..', String(next.getUTCFullYear()), pad(next.getUTCMonth() + 1), pad(next.getUTCDate()));
+  return [dir, nextDir];
+}
+
+export function collectCodexSubagentUsage(transcriptPath) {
+  const meta = readRolloutMeta(transcriptPath);
+  if (!meta?.id) return null; // not a Codex rollout — the Claude path stays untouched
+  const canonicalId = meta.id;
+
+  const subagents = [];
+  const allTools = new Set();
+  const usageAgg = { input: 0, cached: 0, cacheWrite: 0, output: 0, reasoning: 0, total: 0 };
+  const modelMap = new Map();
+  let count = 0;
+  let calls = 0;
+  let cost = 0;
+
+  for (const dayDir of codexSiblingDirs(transcriptPath)) {
+    let names;
+    try { names = readdirSync(dayDir); } catch { continue; }
+    for (const n of names) {
+      if (!/\.jsonl$/i.test(n)) continue;
+      const f = join(dayDir, n);
+      if (f === transcriptPath) continue;
+      const sib = readRolloutMeta(f);
+      if (!sib?.source?.subagent) continue;
+      const parent = sib.parent_thread_id || sib.source.subagent.thread_spawn?.parent_thread_id || '';
+      if (parent !== canonicalId) continue;
+
+      const summary = summarizeTokenUsage(parseTokenUsageFromTranscript(f));
+      if (!summary.calls) continue;
+      const tokens = tokensTotal(summary.totals);
+      for (const t of summary.tools) allTools.add(t);
+
+      subagents.push({
+        id: String(sib.id || basename(f, '.jsonl')).slice(0, 12),
+        agentType: sib.source.subagent.thread_spawn?.agent_nickname || 'codex-subagent',
+        workflow: null,
+        model: summary.models[0] || '?',
+        effort: summary.pensamento || '',
+        tools: summary.tools.length,
+        toolNames: summary.tools,
+        calls: summary.calls,
+        tokens,
+        cost: round4(summary.costs.model),
+        modelRows: summary.modelRows,
+      });
+
+      for (const row of summary.modelRows || []) {
+        const rowEffort = summary.pensamento || '';
+        const key = `${row.provider || '?'}\u0000${row.model || '?'}\u0000${rowEffort}`;
+        const current = modelMap.get(key) || { provider: row.provider || '?', model: row.model || '?', effort: rowEffort, calls: 0, tokens: 0, cost: 0,
+          usage: { input: 0, cached: 0, cacheWrite: 0, output: 0, reasoning: 0, total: 0 } };
+        current.calls += row.calls || 0;
+        current.tokens += tokensTotal(row.usage);
+        current.cost += row.costs?.model || 0;
+        for (const k of Object.keys(current.usage)) current.usage[k] += row.usage?.[k] || 0;
+        modelMap.set(key, current);
+      }
+
+      count += 1;
+      calls += summary.calls;
+      cost += summary.costs.model;
+      for (const k of Object.keys(usageAgg)) usageAgg[k] += summary.totals[k] || 0;
+    }
+  }
+
+  if (!count) return null;
+  return {
+    subagents,
+    workflows: [],
+    aggregate: { count, calls, tokens: tokensTotal(usageAgg), cost: round4(cost), wasted: 0, usage: usageAgg, tools: [...allTools],
+      modelRows: [...modelMap.values()].map((r) => ({ ...r, cost: round4(r.cost), source: 'subagent' })),
+    },
+  };
+}
+
 export function collectSubagentUsage(sessionDir) {
   const subDir = join(sessionDir, 'subagents');
   if (!existsSync(subDir)) return null;

--- a/hooks/token-usage.mjs
+++ b/hooks/token-usage.mjs
@@ -612,7 +612,7 @@ const USAGE_FIELDS = ['provider', 'pensamento', 'input', 'cache_write', 'cache_r
 
 export function sameUsageData(a, b) {
   if (!a || !b) return false;
-  const listEqual = (x, y) => (x || []).join(' ') === (y || []).join(' ');
+  const listEqual = (x, y) => (x || []).join('\u0000') === (y || []).join('\u0000');
   return USAGE_FIELDS.every((f) => (a[f] ?? null) === (b[f] ?? null))
     && listEqual(a.modelos, b.modelos) && listEqual(a.tools, b.tools);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.46.1",
+  "version": "0.46.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.46.1",
+      "version": "0.46.2",
       "license": "MIT",
       "bin": {
         "wendkeep": "bin/wendkeep.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.46.1",
+  "version": "0.46.2",
   "description": "A persistent-memory harness for AI coding agents on your Obsidian vault: turn-by-turn session capture plus a native, zero-dependency spec→change→verify→archive loop (sensor-gated, independent verdict, mutation discrimination). Local-first, agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "bin": {

--- a/tests/codex-subagent-usage.test.mjs
+++ b/tests/codex-subagent-usage.test.mjs
@@ -1,0 +1,83 @@
+// Codex subagent telemetry: the discovery used to be Claude-shaped only (a `subagents/`
+// directory beside the transcript), so Codex sessions closed with subagents_count: 0 both
+// live (SubagentStop hook) and on import. Codex subagents are SIBLING rollouts linked by
+// parent_thread_id.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { collectCodexSubagentUsage } from '../hooks/subagent-usage.mjs';
+import { updateSessionObservability } from '../hooks/session-observability.mjs';
+
+const PARENT = '019f7764-7627-79a3-b609-65abaa36eedd';
+const CHILD = '019f77a7-0c9b-76b3-8968-e49c51ae16a7';
+
+const meta = (id, extra = {}) => ({ type: 'session_meta', timestamp: '2026-07-18T19:41:45.000Z', payload: { id, timestamp: '2026-07-18T19:41:45.000Z', cwd: 'C:\\proj\\x', model: 'gpt-5', model_provider: 'openai', ...extra } });
+const subagentMeta = (id, parent, nickname = 'Lovelace') => meta(id, { session_id: parent, parent_thread_id: parent, source: { subagent: { thread_spawn: { parent_thread_id: parent, depth: 1, agent_nickname: nickname } } } });
+const usageEvent = (turn, tokens) => ({ type: 'event_msg', timestamp: '2026-07-18T20:55:00.000Z', payload: { type: 'token_count', turn_id: turn, info: { model: 'gpt-5', last_token_usage: { input_tokens: tokens, output_tokens: 100 } } } });
+const turnEvents = (turn) => [
+  { type: 'event_msg', timestamp: '2026-07-18T20:54:30.000Z', payload: { type: 'task_started', turn_id: turn } },
+  { type: 'event_msg', timestamp: '2026-07-18T20:54:31.000Z', payload: { type: 'user_message', turn_id: turn, message: 'faz' } },
+  { type: 'event_msg', timestamp: '2026-07-18T20:54:32.000Z', payload: { type: 'agent_message', turn_id: turn, message: 'feito' } },
+];
+
+function writeRollout(dayDir, name, events) {
+  mkdirSync(dayDir, { recursive: true });
+  const p = join(dayDir, name);
+  writeFileSync(p, events.map((e) => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
+  return p;
+}
+
+function seed({ childDay = '18', parentId = PARENT } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'wk-cxsub-'));
+  const parentPath = writeRollout(join(root, '2026', '07', '18'), `rollout-2026-07-18T19-41-45-${PARENT}.jsonl`,
+    [meta(PARENT), ...turnEvents('turn-1'), usageEvent('turn-1', 500)]);
+  writeRollout(join(root, '2026', '07', childDay), `rollout-2026-07-${childDay}T20-54-29-${CHILD}.jsonl`,
+    [subagentMeta(CHILD, parentId), ...turnEvents('turn-sub'), usageEvent('turn-sub', 7000)]);
+  return { root, parentPath };
+}
+
+// --- OBS-3 -------------------------------------------------------------------
+
+test('collectCodexSubagentUsage: acha o irmão pelo parent_thread_id e soma o usage', () => {
+  const { parentPath } = seed();
+  const out = collectCodexSubagentUsage(parentPath);
+  assert.ok(out, 'descoberta devolve agregado');
+  assert.equal(out.aggregate.count, 1);
+  assert.ok(out.aggregate.tokens >= 7000, `tokens do subagent somados, veio ${out.aggregate.tokens}`);
+  assert.equal(out.subagents[0].agentType, 'Lovelace', 'nickname vira agentType');
+});
+
+test('collectCodexSubagentUsage: irmão de OUTRO pai não é somado', () => {
+  const { parentPath } = seed({ parentId: '01900000-0000-7000-8000-000000000000' });
+  assert.equal(collectCodexSubagentUsage(parentPath), null);
+});
+
+test('collectCodexSubagentUsage: subagent na pasta do dia seguinte é descoberto', () => {
+  const { parentPath } = seed({ childDay: '19' });
+  const out = collectCodexSubagentUsage(parentPath);
+  assert.equal(out?.aggregate.count, 1, 'spawn cruzando a meia-noite UTC não some');
+});
+
+test('collectCodexSubagentUsage: transcript Claude devolve null — caminho Claude intacto', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'wk-cxsub-claude-'));
+  const p = join(dir, 'sid-claude.jsonl');
+  writeFileSync(p, JSON.stringify({ type: 'user', uuid: 'u1', sessionId: 'sid-claude', message: { role: 'user', content: 'oi' } }) + '\n', 'utf-8');
+  assert.equal(collectCodexSubagentUsage(p), null);
+});
+
+test('updateSessionObservability: a nota da mãe fecha com subagents_count e tokens do filho', () => {
+  const { parentPath } = seed();
+  const vault = mkdtempSync(join(tmpdir(), 'wk-cxsub-note-'));
+  const notePath = join(vault, 'sessao.md');
+  writeFileSync(notePath, ['---', 'type: session', `session_id: "${PARENT}"`, 'provider: codex', '---', '', '# sessão', '', '## Iterações', '', '## Pendências', '', 'Nenhuma.', ''].join('\n'), 'utf-8');
+
+  updateSessionObservability({ sessionPath: notePath, transcriptPath: parentPath });
+
+  const md = readFileSync(notePath, 'utf8');
+  assert.match(md, /^subagents_count: 1$/m, 'o filho conta no frontmatter da mãe');
+  const total = Number((md.match(/^subagents_tokens_total: (\d+)$/m) || [])[1] || 0);
+  assert.ok(total >= 7000, `tokens do subagent no frontmatter, veio ${total}`);
+  assert.match(md, /Lovelace/, 'a tabela de subagents nomeia o agente');
+});

--- a/tests/import-subagent.test.mjs
+++ b/tests/import-subagent.test.mjs
@@ -1,0 +1,111 @@
+// A Codex subagent rollout (session_meta.source.subagent) is a sibling file of its parent's
+// rollout. Import used to treat it as a top-level session: it created a ghost note with the
+// parent's whole replayed context while the parent closed with subagents_count: 0.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { discoverCodexTranscripts, runImport } from '../hooks/import-sessions.mjs';
+import { readSessionRegistry } from '../hooks/obsidian-common.mjs';
+
+const CWD = 'C:\\proj\\subdemo';
+const PARENT = '019f7764-7627-79a3-b609-65abaa36eedd';
+const CHILD = '019f77a7-0c9b-76b3-8968-e49c51ae16a7';
+
+const parentEvents = [
+  { type: 'session_meta', timestamp: '2026-07-18T19:41:45.000Z', payload: { id: PARENT, timestamp: '2026-07-18T19:41:45.000Z', cwd: CWD, model: 'gpt-5', model_provider: 'openai' } },
+  { type: 'event_msg', timestamp: '2026-07-18T19:42:01.000Z', payload: { type: 'task_started', turn_id: 'turn-1' } },
+  { type: 'event_msg', timestamp: '2026-07-18T19:42:02.000Z', payload: { type: 'user_message', turn_id: 'turn-1', message: 'Analise os arquivos do projeto' } },
+  { type: 'event_msg', timestamp: '2026-07-18T19:42:03.000Z', payload: { type: 'agent_message', turn_id: 'turn-1', message: 'Analisado.' } },
+];
+
+// The child replays the parent's turns — that is why the ghost note looked like a duplicate.
+const childEvents = [
+  { type: 'session_meta', timestamp: '2026-07-18T20:54:29.000Z', payload: { id: CHILD, session_id: PARENT, parent_thread_id: PARENT, forked_from_id: PARENT, timestamp: '2026-07-18T20:54:29.000Z', cwd: CWD, model: 'gpt-5', model_provider: 'openai', source: { subagent: { thread_spawn: { parent_thread_id: PARENT, depth: 1, agent_nickname: 'Lovelace' } } } } },
+  { type: 'event_msg', timestamp: '2026-07-18T20:54:30.000Z', payload: { type: 'task_started', turn_id: 'turn-sub-1' } },
+  { type: 'event_msg', timestamp: '2026-07-18T20:54:31.000Z', payload: { type: 'user_message', turn_id: 'turn-sub-1', message: 'Mapeie o repositório' } },
+  { type: 'event_msg', timestamp: '2026-07-18T20:54:32.000Z', payload: { type: 'agent_message', turn_id: 'turn-sub-1', message: 'Mapeado.' } },
+];
+
+function seedRollouts() {
+  const src = mkdtempSync(join(tmpdir(), 'wk-sub-src-'));
+  const day = join(src, '2026', '07', '18');
+  mkdirSync(day, { recursive: true });
+  const write = (name, events) => {
+    const p = join(day, name);
+    writeFileSync(p, events.map((e) => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
+    return p;
+  };
+  return {
+    src,
+    parentPath: write(`rollout-2026-07-18T19-41-45-${PARENT}.jsonl`, parentEvents),
+    childPath: write(`rollout-2026-07-18T20-54-29-${CHILD}.jsonl`, childEvents),
+  };
+}
+
+function walkNotes(dir, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) walkNotes(p, out);
+    else if (e.name.endsWith('.md')) out.push(p);
+  }
+  return out;
+}
+
+// --- IMPORT-4 ----------------------------------------------------------------
+
+test('discoverCodexTranscripts expõe o marcador de subagent do session_meta', () => {
+  const { src } = seedRollouts();
+  const { transcripts } = discoverCodexTranscripts(CWD, src);
+  const parent = transcripts.find((t) => t.sessionId === PARENT);
+  const child = transcripts.find((t) => t.sessionId === CHILD);
+  assert.ok(parent && child, 'os dois rollouts descobertos');
+  assert.equal(parent.subagent, null, 'pai é top-level');
+  assert.equal(child.subagent?.parentThreadId, PARENT);
+  assert.equal(child.subagent?.nickname, 'Lovelace');
+});
+
+test('runImport: subagent nunca vira nota; só o pai produz sessão', () => {
+  const { src } = seedRollouts();
+  const vault = mkdtempSync(join(tmpdir(), 'wk-sub-vault-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+
+  const r = runImport(vault, { source: 'codex', projectPath: CWD, codexFrom: src });
+  assert.equal(r.imported, 1, 'só o pai');
+  assert.equal(r.subagents, 1, 'subagent contado à parte');
+  assert.equal(r.skipped, 0, 'subagent NÃO é skipped — skipped significa sessão coberta');
+
+  const notes = walkNotes(join(vault, '02-Sessões'));
+  assert.equal(notes.length, 1, 'uma nota só');
+  const md = readFileSync(notes[0], 'utf8');
+  assert.match(md, new RegExp(PARENT), 'a nota é a do pai');
+  assert.ok(!md.includes(`session_id: "${CHILD}"`), 'nada do subagent como sessão');
+  assert.equal(readSessionRegistry(vault).sessions[CHILD], undefined, 'subagent fora do registry');
+});
+
+test('runImport: remove a entrada de registry que o bug antigo escreveu pro subagent', () => {
+  const { src, childPath } = seedRollouts();
+  const vault = mkdtempSync(join(tmpdir(), 'wk-sub-heal-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  // Estado que o import 0.46.0 deixou: entrada top-level pro rollout do subagent.
+  writeFileSync(join(vault, '.brain', 'SESSION_REGISTRY.json'), JSON.stringify({
+    version: 1,
+    sessions: { [CHILD]: { session_file: '02-Sessões/2026/07-JUL/DIA 18/20-54-fantasma.md', status: 'done', provider: 'codex', transcript_path: childPath, transcript_id: CHILD } },
+  }), 'utf-8');
+
+  runImport(vault, { source: 'codex', projectPath: CWD, codexFrom: src });
+  assert.equal(readSessionRegistry(vault).sessions[CHILD], undefined, 'entrada errada removida');
+});
+
+test('runImport: entrada com o mesmo id mas transcript DIFERENTE é preservada', () => {
+  const { src } = seedRollouts();
+  const vault = mkdtempSync(join(tmpdir(), 'wk-sub-keep-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  const foreign = { session_file: '02-Sessões/x.md', status: 'done', provider: 'codex', transcript_path: 'C:\\outro\\lugar\\rollout-outro.jsonl', transcript_id: CHILD };
+  writeFileSync(join(vault, '.brain', 'SESSION_REGISTRY.json'), JSON.stringify({ version: 1, sessions: { [CHILD]: foreign } }), 'utf-8');
+
+  runImport(vault, { source: 'codex', projectPath: CWD, codexFrom: src });
+  assert.deepEqual(readSessionRegistry(vault).sessions[CHILD], foreign, 'self-healing não vira limpeza genérica');
+});

--- a/tests/import-summary.test.mjs
+++ b/tests/import-summary.test.mjs
@@ -61,3 +61,53 @@ test('isBootstrapPrompt: reconhece o bloco de plugins injetado', () => {
   assert.equal(isBootstrapPrompt(REAL), false);
   assert.equal(isBootstrapPrompt('Quais recommended_plugins devo instalar?'), false);
 });
+
+// --- OBS-4: o bloco de iteração usa o MESMO filtro do título ------------------
+
+test('buildIterationBlock: Contexto conversado não mostra o bloco injetado como Usuário', async () => {
+  const { mkdtempSync, mkdirSync, writeFileSync } = await import('node:fs');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const { parseTranscript, buildIterationBlock } = await import('../hooks/session-stop.mjs');
+
+  const dir = mkdtempSync(join(tmpdir(), 'wk-conv-'));
+  const events = [
+    { type: 'session_meta', timestamp: '2026-07-18T19:41:45.000Z', payload: { id: 'cx-conv', timestamp: '2026-07-18T19:41:45.000Z', cwd: 'C:\p', model: 'gpt-5', model_provider: 'openai' } },
+    { type: 'event_msg', timestamp: '2026-07-18T19:42:01.000Z', payload: { type: 'task_started', turn_id: 't1' } },
+    { type: 'event_msg', timestamp: '2026-07-18T19:42:02.000Z', payload: { type: 'user_message', turn_id: 't1', message: INJECTED } },
+    { type: 'event_msg', timestamp: '2026-07-18T19:42:03.000Z', payload: { type: 'user_message', turn_id: 't1', message: REAL } },
+    { type: 'event_msg', timestamp: '2026-07-18T19:42:04.000Z', payload: { type: 'agent_message', turn_id: 't1', message: 'Analisado com sucesso.' } },
+  ];
+  const p = join(dir, 'rollout-2026-07-18T19-41-45-cx-conv.jsonl');
+  writeFileSync(p, events.map((e) => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
+
+  const tx = parseTranscript(p);
+  const block = buildIterationBlock(tx, { turn_id: 't1' });
+  assert.ok(!block.includes('recommended_plugins'), 'preâmbulo do harness não é fala do usuário');
+  assert.ok(block.includes(REAL), 'o pedido real permanece no contexto');
+  assert.ok(block.includes('Analisado com sucesso'), 'a resposta permanece');
+});
+
+test('buildIterationBlock: prompt que MENCIONA o termo atravessa o filtro inteiro', async () => {
+  // A guarda contra o filtro guloso, no caminho REAL (parseTranscript -> shouldIgnoreUserText),
+  // não só no unitário de isBootstrapPrompt: um `/recommended_plugins/` sem âncora passaria lá
+  // e ainda engoliria este pedido aqui.
+  const { mkdtempSync, writeFileSync } = await import('node:fs');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const { parseTranscript, buildIterationBlock } = await import('../hooks/session-stop.mjs');
+
+  const MENTION = 'Quais recommended_plugins devo instalar no projeto?';
+  const dir = mkdtempSync(join(tmpdir(), 'wk-conv-mention-'));
+  const events = [
+    { type: 'session_meta', timestamp: '2026-07-18T19:41:45.000Z', payload: { id: 'cx-mention', timestamp: '2026-07-18T19:41:45.000Z', cwd: 'C:\\p', model: 'gpt-5', model_provider: 'openai' } },
+    { type: 'event_msg', timestamp: '2026-07-18T19:42:01.000Z', payload: { type: 'task_started', turn_id: 't1' } },
+    { type: 'event_msg', timestamp: '2026-07-18T19:42:02.000Z', payload: { type: 'user_message', turn_id: 't1', message: MENTION } },
+    { type: 'event_msg', timestamp: '2026-07-18T19:42:03.000Z', payload: { type: 'agent_message', turn_id: 't1', message: 'Nenhum é obrigatório.' } },
+  ];
+  const p = join(dir, 'rollout-2026-07-18T19-41-45-cx-mention.jsonl');
+  writeFileSync(p, events.map((e) => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
+
+  const block = buildIterationBlock(parseTranscript(p), { turn_id: 't1' });
+  assert.ok(block.includes(MENTION), 'pedido legítimo não pode ser engolido por substring');
+});

--- a/tests/source-hygiene.test.mjs
+++ b/tests/source-hygiene.test.mjs
@@ -1,0 +1,38 @@
+// A literal control byte in a source file makes `file` classify it as binary and ripgrep
+// skip it by default — a Grep over that file silently returns nothing. It happened three
+// times before this test existed (taxonomy.mjs NUL+0x1f, token-usage.mjs 2×NUL), always the
+// same way: an escape sequence written as the raw byte. This scans everything we ship.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const DIRS = ['hooks', 'src', 'bin'];
+
+function walk(dir, out = []) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) walk(p, out);
+    else if (/\.(mjs|js|json)$/i.test(e.name)) out.push(p);
+  }
+  return out;
+}
+
+test('nenhum fonte publicado contém byte de controle literal (fora de tab/LF/CR)', () => {
+  const offenders = [];
+  for (const dir of DIRS) {
+    for (const f of walk(join(ROOT, dir))) {
+      const b = readFileSync(f);
+      for (let i = 0; i < b.length; i += 1) {
+        const c = b[i];
+        if (c < 9 || (c > 10 && c < 32 && c !== 13)) {
+          offenders.push(`${f} @${i} (0x${c.toString(16).padStart(2, '0')})`);
+          break; // um por arquivo basta pra apontar
+        }
+      }
+    }
+  }
+  assert.deepEqual(offenders, [], `escape a sequência em vez do byte cru:\n${offenders.join('\n')}`);
+});


### PR DESCRIPTION
Continuação direta do relato do Vendiva: depois da 0.46.1 recuperar os turnos, o usuário apontou que o import ainda "importava errado". Diagnóstico: dos 7 rollouts do projeto, 1 era o **subagent Lovelace** (`session_meta.source.subagent`, `parent_thread_id` → sessão-mãe) — e o import o tratou como sessão top-level.

## Os dois defeitos

1. **Nota fantasma.** Subagent herda o histórico do pai, então a "sessão" importada era a conversa da mãe inteira, duplicada, com título poluído. Fix: a descoberta expõe o marcador do `session_meta`, o import conta subagents à parte (nunca em `skipped`) e não cria nota. A entrada de registry escrita pelo import antigo é removida — **self-healing estrito**: entrada com o mesmo id mas transcript diferente é preservada (testado).

2. **`subagents_count: 0` estrutural.** `collectSubagentUsage` procura `<transcript>/subagents/` — layout do Claude. Isso quebrava a atribuição **também no hook vivo** `SubagentStop` (wirado na 0.46.0): o custo de subagent do Codex não existia no vault. Fix: `collectCodexSubagentUsage` acha os rollouts irmãos por `parent_thread_id`, no dia do pai **e no dia seguinte** — spawn que cruza a meia-noite UTC cai na pasta do outro dia, e o caso real passou a seis minutos disso. Mesmo shape de agregado, mesmo writer: vivo e import pelo mesmo caminho.

## Caronas do mesmo grupo de sintomas

- `shouldIgnoreUserText` **delegou** a `isBootstrapPrompt` em vez de duplicar a lista — as cópias tinham divergido (título limpo, Contexto conversado ainda mostrando `<recommended_plugins>` como fala do usuário). Um filtro, um lugar pro próximo bloco injetado.
- NULs literais em `token-usage.mjs` e `subagent-usage.mjs` escapados (mesma classe do #7), e `tests/source-hygiene.test.mjs` barrando byte de controle em qualquer fonte publicado — o teste pegou uma **quarta** ocorrência introduzida durante esta própria mudança.

## Verificação

23 testes novos, **452 passando**. Dois passes independentes (autor ≠ verificador): o primeiro reprovou com um mutante sobrevivente — `|| /recommended_plugins/i.test(...)` (filtro guloso por substring) passava a suíte porque o caso "menciona mas não é bootstrap" nunca atravessava o caminho real. Fechado com teste via `parseTranscript → buildIterationBlock`; segundo passe: `ok: true`, mutantes MI1-6/MO1-4/MB1-3 todos mortos.

> Merge dispara o `auto-tag.yml` (tag `v0.46.2` + Release). **npm fica com o mantenedor** — `npm publish` direto (0.46.1 ainda não foi publicada; uma publicação da 0.46.2 cobre as duas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
