### PR TITLE
feat: wendkeep note relink — backfill de proveniência das notas derivadas órfãs (0.48.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.0] — 2026-07-23
+
+### Added
+
+- **`wendkeep note relink [--apply]` — backfill de proveniência das notas derivadas
+  órfãs.** BUG/APR legadas (criadas por versão antiga, sem `source:` de sessão) ficam ilhas
+  no grafo — num vault real: 13 de 15 BUG e 3 de 8 APR sem nenhum link de entrada nem de
+  saída. A origem não está registrada no órfão, mas os irmãos não-órfãos do mesmo tipo
+  carregam a sessão-fonte real. O comando liga cada órfão herdando a sessão **modal** (mais
+  comum) dos irmãos do mesmo tipo e mês, injetando `source:` + `related:` no frontmatter.
+  Dry-run por default; `--apply` escreve; idempotente; pula e reporta o órfão sem nenhum
+  irmão-fonte pra inferir (nunca chuta). Documentado em `derived-notes` (DRV-9).
+
 ## [0.47.0] — 2026-07-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ wendkeep note new --type learning "a regex without /g only ever returns the firs
 
 It prints the created path, numbers from the current max (recursive scan), files it in the month folder for today (`--date YYYY-MM-DD` to override), and links the active session in `source:` so the graph stays connected. Agents get this rule injected at SessionStart — they call the command instead of guessing a filename.
 
+**Reconnecting legacy notes.** Derived notes created by older versions carry no `source:` session and sit as islands in the graph. `wendkeep note relink` backfills them: each orphan inherits the modal source session of its type/month cohort (the session its non-orphan siblings already point to). Dry-run by default; `--apply` writes; notes with no sibling to infer from are skipped and reported.
+
 **Migrating an existing vault.** Notes created before `0.41.0` have date-prefixed names (`2026-07-16-bug-<slug>.md`) and may sit in legacy `DIA N` subfolders. One command per tree renumbers them chronologically, moves them up into the month folder, and rewrites every wikilink across the vault:
 
 ```bash

--- a/bin/wendkeep.mjs
+++ b/bin/wendkeep.mjs
@@ -77,6 +77,9 @@ Usage:
   wendkeep renumber-learnings   Same for 06-Aprendizados/06-Learnings with APR-<NNNN>-<slug>.
   wendkeep note new --type bug|learning "<título>"  Create a numbered derived note (BUG-/APR-NNNN)
                            in the month folder and print its vault path. --date YYYY-MM-DD · --vault P.
+  wendkeep note relink [--apply]  Backfill orphan derived notes (BUG/APR without a source session),
+                           linking each to the modal source session of its type/month cohort. Dry-run
+                           by default; --apply writes; skips notes with no sibling to infer from.
   wendkeep lesson add "t" "l"   Record a project-local lesson (injected at SessionStart).
   wendkeep validate-memory [path]  Validate .brain/CORE.md against the compaction
                            protocol (cap 25, 3 sections, no secrets/PII). Uses

--- a/hooks/linked-notes.mjs
+++ b/hooks/linked-notes.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { existsSync, readFileSync, readdirSync, writeFileSync } from 'fs';
-import { basename, join } from 'path';
+import { basename, join, relative } from 'path';
 import {
   monthFolderRelFromDateStr,
   derivedContentKey,
@@ -61,6 +61,77 @@ function sessionYamlLinks(sessionRel) {
     'related:',
     `  - ${yamlQuote(link)}`,
   ].join('\n');
+}
+
+// --- note relink: backfill de proveniência das notas derivadas órfãs (DRV-9) -----
+// Nota derivada legada (BUG/APR criada por wendkeep antigo) nasce sem `source:` de sessão —
+// ilha no grafo. A origem não está registrada nela, mas os irmãos NÃO-órfãos do mesmo tipo
+// carregam a sessão-fonte real: o órfão herda a sessão MODAL (mais comum) do seu (tipo, mês).
+
+// Extrai a sessão do primeiro `source: - [[...]]` do frontmatter (vazio se não houver).
+function sourceSessionOf(content) {
+  const m = content.match(/^source:\s*\n\s*-\s*"?\[\[([^\]"|]+)/m);
+  return m ? m[1].trim() : '';
+}
+
+// Injeta source+related antes do `---` de fechamento do frontmatter. Sem frontmatter, no-op.
+function insertSourceLinks(content, sessionRel) {
+  const m = content.match(/^(---\n[\s\S]*?\n)(---\n)/);
+  if (!m) return content;
+  return `${m[1]}${sessionYamlLinks(sessionRel)}\n${m[2]}${content.slice(m[0].length)}`;
+}
+
+function modalKey(counts) {
+  const entries = Object.entries(counts || {});
+  if (!entries.length) return '';
+  entries.sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  return entries[0][0];
+}
+
+export function relinkDerivedNotes(vaultBase, { apply = false } = {}) {
+  const loc = getLocale(vaultBase);
+  const monthOf = (abs) => relative(vaultBase, abs).replaceAll('\\', '/').split('/').slice(0, 3).join('/');
+  const linked = [];
+  const skipped = [];
+  for (const [folderKey, prefix] of [['bugs', 'BUG'], ['learnings', 'APR']]) {
+    const root = join(vaultBase, loc.folders[folderKey]);
+    const files = [];
+    const walk = (dir) => {
+      let entries;
+      try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+      for (const e of entries) {
+        const p = join(dir, e.name);
+        if (e.isDirectory()) walk(p);
+        else if (e.name.endsWith('.md') && e.name.startsWith(`${prefix}-`)) files.push(p);
+      }
+    };
+    walk(root);
+    const byMonth = {};
+    const typeWide = {};
+    const orphans = [];
+    for (const p of files) {
+      let c;
+      try { c = readFileSync(p, 'utf8'); } catch { continue; }
+      const src = sourceSessionOf(c);
+      if (src) {
+        (byMonth[monthOf(p)] ??= {})[src] = ((byMonth[monthOf(p)] || {})[src] || 0) + 1;
+        typeWide[src] = (typeWide[src] || 0) + 1;
+      } else {
+        orphans.push({ p, c });
+      }
+    }
+    for (const o of orphans) {
+      const rel = relative(vaultBase, o.p).replaceAll('\\', '/');
+      const session = modalKey(byMonth[monthOf(o.p)]) || modalKey(typeWide);
+      if (!session) { skipped.push({ file: rel, reason: 'sem irmão com source para inferir' }); continue; }
+      if (apply) {
+        try { writeFileSync(o.p, insertSourceLinks(o.c, session), 'utf8'); }
+        catch { skipped.push({ file: rel, reason: 'escrita falhou' }); continue; }
+      }
+      linked.push({ file: rel, session: basename(session) });
+    }
+  }
+  return { applied: apply, linked, skipped };
 }
 
 function extractIssueRefs(tx) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "A persistent-memory harness for AI coding agents on your Obsidian vault: turn-by-turn session capture plus a native, zero-dependency spec→change→verify→archive loop (sensor-gated, independent verdict, mutation discrimination). Local-first, agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "bin": {

--- a/src/note.mjs
+++ b/src/note.mjs
@@ -14,7 +14,7 @@ import {
   toVaultRelative,
 } from '../hooks/obsidian-common.mjs';
 import { getLocale } from '../hooks/locale.mjs';
-import { buildManualBugNote, buildManualLearningNote } from '../hooks/linked-notes.mjs';
+import { buildManualBugNote, buildManualLearningNote, relinkDerivedNotes } from '../hooks/linked-notes.mjs';
 
 const TYPES = {
   bug: { folderKey: 'bugs', prefix: 'BUG', build: buildManualBugNote },
@@ -30,8 +30,23 @@ function opt(argv, name) {
 
 export function runNote(argv) {
   const [sub, ...rest] = argv;
+
+  if (sub === 'relink') {
+    const vaultRaw = opt(rest, '--vault') || process.env.OBSIDIAN_VAULT_PATH;
+    if (!vaultRaw) { process.stderr.write('wendkeep note relink: no vault (--vault or OBSIDIAN_VAULT_PATH).\n'); process.exit(2); }
+    const vaultBase = isAbsolute(vaultRaw) ? vaultRaw : resolve(process.cwd(), vaultRaw);
+    if (!existsSync(vaultBase)) { process.stderr.write(`wendkeep note relink: vault not found: ${vaultBase}\n`); process.exit(2); }
+    const r = relinkDerivedNotes(vaultBase, { apply: rest.includes('--apply') });
+    if (rest.includes('--json')) { process.stdout.write(`${JSON.stringify(r, null, 2)}\n`); process.exit(0); }
+    process.stdout.write(`${r.linked.length} nota(s) derivada(s) órfã(s)${r.applied ? ' linkadas' : ' seriam linkadas'}\n`);
+    for (const l of r.linked) process.stdout.write(`  ${l.file} -> ${l.session}\n`);
+    for (const s of r.skipped) process.stdout.write(`  pulado: ${s.file} (${s.reason})\n`);
+    if (!r.applied && r.linked.length) process.stdout.write('\ndry-run — nada escrito. Rode com --apply para injetar os backlinks.\n');
+    process.exit(0);
+  }
+
   if (sub !== 'new') {
-    process.stderr.write('wendkeep note: subcomando desconhecido (use `note new --type bug|learning "<título>"`).\n');
+    process.stderr.write('wendkeep note: subcomando desconhecido (use `note new --type bug|learning "<título>"` ou `note relink [--apply]`).\n');
     process.exit(2);
   }
 

--- a/tests/note-cli.test.mjs
+++ b/tests/note-cli.test.mjs
@@ -70,6 +70,22 @@ test('note new: active session goes into source: as wikilink', async () => {
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
 
+test('note relink --apply: backfills orphan derived notes with the modal session', () => {
+  const vault = freshVault();
+  try {
+    const bugDir = join(vault, '05-Bugs', '2026', '07-JUL');
+    mkdirSync(bugDir, { recursive: true });
+    writeFileSync(join(bugDir, 'BUG-0001-a.md'), '---\ntype: bug\nbug: 1\ncssclasses:\n  - topic-bug\n---\n\n# BUG-0001\n');
+    writeFileSync(join(bugDir, 'BUG-0002-b.md'), '---\ntype: bug\nbug: 2\nsource:\n  - "[[02-Sessões/2026/07-JUL/DIA 19/14-58-analise]]"\nrelated:\n  - "[[02-Sessões/2026/07-JUL/DIA 19/14-58-analise]]"\ncssclasses:\n  - topic-bug\n---\n\n# BUG-0002\n');
+    const dry = spawnNote(vault, ['relink']);
+    assert.equal(dry.status, 0, dry.stderr);
+    assert.ok(!readFileSync(join(bugDir, 'BUG-0001-a.md'), 'utf8').includes('source:'), 'dry-run não escreve');
+    const r = spawnNote(vault, ['relink', '--apply']);
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(readFileSync(join(bugDir, 'BUG-0001-a.md'), 'utf8'), /\[\[02-Sessões\/2026\/07-JUL\/DIA 19\/14-58-analise\]\]/);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
 test('note new: invalid input exits 2 and writes nothing', () => {
   const vault = freshVault();
   try {

--- a/tests/note-relink.test.mjs
+++ b/tests/note-relink.test.mjs
@@ -1,0 +1,71 @@
+// DRV-9 — note relink: backfill de proveniência das notas derivadas órfãs.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { relinkDerivedNotes } from '../hooks/linked-notes.mjs';
+
+const SESS_A = '02-Sessões/2026/07-JUL/DIA 19/14-58-analise';
+const SESS_B = '02-Sessões/2026/07-JUL/DIA 19/02-46-impl';
+const withSrc = (n, sess) => `---\ntype: bug\ndate: 2026-07-19\nbug: ${n}\nsource:\n  - "[[${sess}]]"\nrelated:\n  - "[[${sess}]]"\ncssclasses:\n  - topic-bug\ntags:\n  - bug\n---\n\n# BUG-000${n}\n`;
+const orphan = (n) => `---\ntype: bug\ndate: 2026-07-19\nbug: ${n}\ncssclasses:\n  - topic-bug\ntags:\n  - bug\n---\n\n# BUG-000${n}\n`;
+
+function vaultWithNotes() {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-relink-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  const bugDir = join(vault, '05-Bugs', '2026', '07-JUL');
+  mkdirSync(bugDir, { recursive: true });
+  writeFileSync(join(bugDir, 'BUG-0001-a.md'), orphan(1));
+  writeFileSync(join(bugDir, 'BUG-0002-b.md'), orphan(2));
+  // MINORITÁRIA primeiro na ordem de walk: discrimina "modal por contagem" de "primeiro-visto".
+  writeFileSync(join(bugDir, 'BUG-0003-c.md'), withSrc(3, SESS_B)); // minority, aparece antes
+  writeFileSync(join(bugDir, 'BUG-0004-d.md'), withSrc(4, SESS_A));
+  writeFileSync(join(bugDir, 'BUG-0005-e.md'), withSrc(5, SESS_A)); // majority (modal)
+  return { vault, bugDir };
+}
+
+test('relinkDerivedNotes: dry-run reports orphans, writes nothing', () => {
+  const { vault, bugDir } = vaultWithNotes();
+  try {
+    const r = relinkDerivedNotes(vault, {});
+    assert.equal(r.applied, false);
+    assert.equal(r.linked.length, 2, 'BUG-0001 e 0002 seriam linkados');
+    assert.ok(!readFileSync(join(bugDir, 'BUG-0001-a.md'), 'utf8').includes('source:'), 'dry-run não escreve');
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('relinkDerivedNotes: apply injects the MODAL source into orphans (SESS_A over SESS_B)', () => {
+  const { vault, bugDir } = vaultWithNotes();
+  try {
+    const r = relinkDerivedNotes(vault, { apply: true });
+    assert.equal(r.applied, true);
+    assert.equal(r.linked.length, 2);
+    for (const f of ['BUG-0001-a.md', 'BUG-0002-b.md']) {
+      const c = readFileSync(join(bugDir, f), 'utf8');
+      assert.match(c, /^source:\n {2}- "\[\[02-Sessões\/2026\/07-JUL\/DIA 19\/14-58-analise\]\]"$/m, `${f} herda a modal SESS_A`);
+      assert.match(c, /^related:\n {2}- "\[\[.*14-58-analise\]\]"$/m);
+      assert.doesNotMatch(c, /02-46-impl/, 'nunca a minoritária');
+      assert.ok(c.startsWith('---\n') && c.indexOf('\n---\n') > c.indexOf('source:'), 'source dentro do frontmatter');
+    }
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('relinkDerivedNotes: idempotent and skips orphans with no source sibling', () => {
+  const { vault, bugDir } = vaultWithNotes();
+  try {
+    relinkDerivedNotes(vault, { apply: true });
+    const again = relinkDerivedNotes(vault, { apply: true });
+    assert.equal(again.linked.length, 0, 'idempotente: nada a linkar na 2ª passada');
+    // 2ª passada não anexa um 2º bloco source: no arquivo já linkado.
+    const twice = readFileSync(join(bugDir, 'BUG-0001-a.md'), 'utf8');
+    assert.equal((twice.match(/^source:/gm) || []).length, 1, 'exatamente um bloco source após 2 applies');
+
+    const aprDir = join(vault, '06-Aprendizados', '2026', '07-JUL');
+    mkdirSync(aprDir, { recursive: true });
+    writeFileSync(join(aprDir, 'APR-0001-x.md'), '---\ntype: learning\ndate: 2026-07-19\napr: 1\ncssclasses:\n  - topic-learning\n---\n\n# APR-0001\n');
+    const r = relinkDerivedNotes(vault, { apply: true });
+    assert.equal(r.linked.length, 0, 'sem irmão-fonte não linka');
+    assert.ok(r.skipped.some((s) => s.file.includes('APR-0001')), 'reporta o pulado');
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Por quê

Notas derivadas legadas (BUG/APR criadas por versão antiga, sem `source:` de sessão) ficam ilhas no grafo do Obsidian. Num vault real (Vendiva): **13 de 15 BUG e 3 de 8 APR** sem nenhum link de entrada nem de saída. O código atual já grava `source`+`related` (os irmãos recentes provam) — é puro backfill de legado.

## O que muda

- **`relinkDerivedNotes`**: a origem não está no órfão, mas os irmãos não-órfãos do mesmo tipo carregam a sessão-fonte real. Cada órfão herda a sessão **modal** (mais comum) do seu (tipo, mês), injetando `source:` + `related:` no frontmatter. Dry-run default; `--apply` escreve; idempotente; pula e reporta o órfão sem irmão-fonte (nunca chuta).
- **CLI** `wendkeep note relink [--apply]` + bin help + README.
- Capability `derived-notes` (DRV-9).

## Verificação

- Passe independente (autor≠verificador): DRV-9 coberto por testes que discriminam. Ângulo cego apontado (modal vs primeiro-visto) fechado: fixture com a minoritária primeiro na ordem de walk + contagem de bloco `source` único na idempotência.
- +4 testes; suíte **465/465**; `npm run check` limpo.
- Aplicado no Vendiva: **16 órfãos → `14-58-analise`, 0 ilhas** restantes em 05-Bugs/06-Aprendizados.

Fecha `note-relink-orfaos` (ADR-0029). Bump **0.48.0** (feature aditiva).

🤖 Generated with [Claude Code](https://claude.com/claude-code)