### PR TITLE
feat: doctor surfaça órfãos do grafo + sinaliza sessão em background (0.49.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.0] — 2026-07-23
+
+### Added
+
+- **`wendkeep doctor` agora surfaça os órfãos do grafo com o comando de reparo.** Nova seção
+  `[links]`: conta notas derivadas sem sessão-fonte (→ `note relink`), artefatos de change
+  sem backlink (→ `change backlink`) e o estado das cores do grafo (→ `theme sync`); quando
+  tudo conectado, diz `grafo conectado`. Reusa as funções de reparo em dry-run — zero lógica
+  nova de detecção. Antes o dono do vault só descobria os órfãos olhando o grafo no Obsidian
+  e não sabia qual comando rodava.
+- **Sessão não mente "inativa" com atividade recente.** Nova seção `[sessão]`: quando o
+  control marca `inactive` mas a nota da sessão foi escrita há pouco, o doctor sinaliza
+  possível workflow/subagente em segundo plano — o control só reflete o lifecycle da
+  sessão-mãe, não a atividade de background. Capability `vault-doctor` (DIAG-1..4).
+
 ## [0.48.0] — 2026-07-23
 
 ### Added

--- a/hooks/harness-doctor.mjs
+++ b/hooks/harness-doctor.mjs
@@ -1,10 +1,12 @@
 // hooks/harness-doctor.mjs — integrity checks for the a2 harness state (Wave B).
 // Pure-ish (fs reads only). `wendkeep doctor` reports errors (exit 1) + warnings.
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
-import { activeChange, parseTasks } from './change-core.mjs';
+import { activeChange, parseTasks, backfillArtifactLinks } from './change-core.mjs';
+import { relinkDerivedNotes } from './linked-notes.mjs';
 import { buildEffectiveRequirementPackage, checkSpecsState, evaluateVerdict, tasksHashOf, validateSpecImpact } from './spec-core.mjs';
 import { getLocale } from './locale.mjs';
+import { readControl } from './obsidian-common.mjs';
 
 export function checkHarness(vaultBase, projectRoot) {
   const loc = getLocale(vaultBase);
@@ -62,4 +64,38 @@ export function checkHarness(vaultBase, projectRoot) {
   }
 
   return { errors, warnings };
+}
+
+// --- diagnóstico de links do grafo (read-only, reusa os reparos em dry-run) -----
+// Surfaça os órfãos que o doctor não enxergava: notas derivadas sem sessão-fonte,
+// artefatos de change sem backlink, e o estado das cores do grafo. Cada não-zero tem um
+// comando de reparo (note relink / change backlink / theme sync).
+export function checkVaultLinks(vaultBase) {
+  let derivedOrphans = 0;
+  try { derivedOrphans = relinkDerivedNotes(vaultBase, {}).linked.length; } catch { /* sem notas derivadas */ }
+  let artifactOrphans = 0;
+  try { artifactOrphans = backfillArtifactLinks(vaultBase, {}).changed.length; } catch { /* sem changes */ }
+  let graphColors = null; // true=com grupos · false=vazio/ausente de cores · null=sem graph.json
+  try {
+    const g = JSON.parse(readFileSync(join(vaultBase, '.obsidian', 'graph.json'), 'utf8'));
+    graphColors = Array.isArray(g.colorGroups) && g.colorGroups.length > 0;
+  } catch { graphColors = null; }
+  return { derivedOrphans, artifactOrphans, graphColors };
+}
+
+const unquoteControl = (v) => String(v ?? '').replace(/^"(.*)"$/, '$1').trim();
+
+// O control marca `inactive` quando a sessão-mãe encerra, mesmo com um workflow/subagente
+// ainda vivo em background. Se a nota da sessão foi escrita há pouco apesar do `inactive`,
+// sinaliza a atividade recente — o doctor deixa de dizer "inativa" quando não está.
+export function checkSessionActivity(vaultBase, { now = Date.now(), windowMs = 5 * 60000 } = {}) {
+  const control = readControl(vaultBase);
+  const active = unquoteControl(control.status) === 'active';
+  const sessionRel = unquoteControl(active ? control.session_file : (control.last_session_file || control.session_file));
+  let ageMs = null;
+  if (sessionRel) {
+    try { ageMs = now - statSync(join(vaultBase, sessionRel)).mtimeMs; } catch { ageMs = null; }
+  }
+  const backgroundSuspected = !active && sessionRel !== '' && ageMs !== null && ageMs >= 0 && ageMs < windowMs;
+  return { lastSession: sessionRel, active, ageMs, backgroundSuspected };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "A persistent-memory harness for AI coding agents on your Obsidian vault: turn-by-turn session capture plus a native, zero-dependency spec→change→verify→archive loop (sensor-gated, independent verdict, mutation discrimination). Local-first, agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "bin": {

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -4,7 +4,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { checkHarness } from '../hooks/harness-doctor.mjs';
+import { checkHarness, checkVaultLinks, checkSessionActivity } from '../hooks/harness-doctor.mjs';
 import { checkSyncDefs } from './sync-defs.mjs';
 import { resolveProjectVault } from './project-vault.mjs';
 
@@ -59,6 +59,26 @@ export function runDoctor(argv) {
   process.stdout.write(`\n[harness] ${errors.length} erro(s), ${warnings.length} aviso(s)\n`);
   for (const e of errors) process.stdout.write(`  ✗ ${e}\n`);
   for (const w of warnings) process.stdout.write(`  ! ${w}\n`);
+
+  // 3. Link/graph health — órfãos que o grafo do Obsidian mostraria, com o comando de reparo.
+  const links = checkVaultLinks(vaultBase);
+  const graphLabel = links.graphColors === true ? 'com cores' : links.graphColors === false ? 'sem cores' : 'sem graph.json';
+  process.stdout.write(`\n[links] ${links.derivedOrphans} derivada(s) órfã(s) · ${links.artifactOrphans} artefato(s) órfão(s) · grafo: ${graphLabel}\n`);
+  if (links.derivedOrphans) process.stdout.write('  → wendkeep note relink --apply\n');
+  if (links.artifactOrphans) process.stdout.write('  → wendkeep change backlink --apply\n');
+  if (links.graphColors === false) process.stdout.write('  → wendkeep theme sync (feche o Obsidian antes)\n');
+  if (!links.derivedOrphans && !links.artifactOrphans && links.graphColors !== false) process.stdout.write('  grafo conectado ✓\n');
+
+  // 4. Sessão: não mente "inativa" quando há atividade recente (workflow/subagente em background).
+  const act = checkSessionActivity(vaultBase);
+  if (act.lastSession) {
+    const label = act.active
+      ? 'ativa'
+      : act.backgroundSuspected
+        ? `inativa no control, mas escrita há ${Math.round((act.ageMs || 0) / 1000)}s — possível workflow/subagente em background`
+        : 'inativa';
+    process.stdout.write(`[sessão] última: ${act.lastSession} (${label})\n`);
+  }
 
   process.exit(healthStatus !== 0 || errors.length ? 1 : 0);
 }

--- a/tests/doctor-links.test.mjs
+++ b/tests/doctor-links.test.mjs
@@ -1,0 +1,82 @@
+// DIAG-1..4 — doctor surfaça órfãos do grafo + sinaliza sessão inativa com atividade recente.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { checkVaultLinks, checkSessionActivity } from '../hooks/harness-doctor.mjs';
+
+const BIN = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'wendkeep.mjs');
+
+test('checkVaultLinks: counts derived + artifact orphans and empty graph colors', () => {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-diag-'));
+  try {
+    mkdirSync(join(vault, '.brain'), { recursive: true });
+    const bugDir = join(vault, '05-Bugs', '2026', '07-JUL');
+    mkdirSync(bugDir, { recursive: true });
+    writeFileSync(join(bugDir, 'BUG-0001-a.md'), '---\ntype: bug\nbug: 1\ncssclasses:\n  - topic-bug\n---\n\n# BUG-0001\n');
+    writeFileSync(join(bugDir, 'BUG-0002-b.md'), '---\ntype: bug\nbug: 2\nsource:\n  - "[[02-Sessões/2026/07-JUL/DIA 19/14-58-analise]]"\ncssclasses:\n  - topic-bug\n---\n\n# BUG-0002\n');
+    // change 'x': design.md órfão (sem backlink) → conta. change 'y': design.md JÁ linkado → não conta.
+    const chX = join(vault, '08-Mudanças', 'x');
+    mkdirSync(chX, { recursive: true });
+    writeFileSync(join(chX, 'proposta.md'), '# x\n');
+    writeFileSync(join(chX, 'design.md'), '# x — design\n\n## Abordagem\n');
+    const chY = join(vault, '08-Mudanças', 'y');
+    mkdirSync(chY, { recursive: true });
+    writeFileSync(join(chY, 'proposta.md'), '# y\n');
+    writeFileSync(join(chY, 'design.md'), '# y — design\n\n> Mudança: [[08-Mudanças/y/proposta]]\n\n## Abordagem\n');
+    mkdirSync(join(vault, '.obsidian'), { recursive: true });
+    writeFileSync(join(vault, '.obsidian', 'graph.json'), JSON.stringify({ colorGroups: [] }));
+
+    const r = checkVaultLinks(vault);
+    assert.equal(r.derivedOrphans, 1, 'BUG-0001 é a única órfã');
+    assert.equal(r.artifactOrphans, 1, 'só o design.md de x é órfão; o de y já linka (exclusão)');
+    assert.equal(r.graphColors, false, 'colorGroups vazio = sem cores');
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('checkVaultLinks: graphColors true with groups, null without graph.json', () => {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-diag2-'));
+  try {
+    mkdirSync(join(vault, '.brain'), { recursive: true });
+    assert.equal(checkVaultLinks(vault).graphColors, null, 'sem graph.json = null');
+    mkdirSync(join(vault, '.obsidian'), { recursive: true });
+    writeFileSync(join(vault, '.obsidian', 'graph.json'), JSON.stringify({ colorGroups: [{ query: 'path:"05-Bugs"', color: { a: 1, rgb: 1 } }] }));
+    assert.equal(checkVaultLinks(vault).graphColors, true, 'com grupos = true');
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('checkSessionActivity: flags inactive control with a recently-written session note', async () => {
+  const { writeControl } = await import('../hooks/obsidian-common.mjs');
+  const vault = mkdtempSync(join(tmpdir(), 'wk-sess-'));
+  try {
+    const sess = '02-Sessões/2026/07-JUL/DIA 23/02-05-x.md';
+    mkdirSync(join(vault, '02-Sessões', '2026', '07-JUL', 'DIA 23'), { recursive: true });
+    writeFileSync(join(vault, sess), '# sessão\n');
+    writeControl(vault, { status: 'inactive', session_file: '', last_session_file: sess });
+    const mtime = statSync(join(vault, sess)).mtimeMs;
+
+    const recent = checkSessionActivity(vault, { now: mtime + 1000, windowMs: 5 * 60000 });
+    assert.equal(recent.active, false);
+    assert.equal(recent.backgroundSuspected, true, 'inativa + escrita recente = suspeita de background');
+
+    const old = checkSessionActivity(vault, { now: mtime + 10 * 60000, windowMs: 5 * 60000 });
+    assert.equal(old.backgroundSuspected, false, 'inativa + antiga = sem suspeita');
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('doctor: prints the [links] section with a repair command when orphans exist', () => {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-doc-'));
+  try {
+    mkdirSync(join(vault, '.brain'), { recursive: true });
+    const bugDir = join(vault, '05-Bugs', '2026', '07-JUL');
+    mkdirSync(bugDir, { recursive: true });
+    writeFileSync(join(bugDir, 'BUG-0001-a.md'), '---\ntype: bug\nbug: 1\ncssclasses:\n  - topic-bug\n---\n\n# BUG-0001\n');
+    writeFileSync(join(bugDir, 'BUG-0002-b.md'), '---\ntype: bug\nbug: 2\nsource:\n  - "[[02-Sessões/2026/07-JUL/DIA 19/14-58-analise]]"\ncssclasses:\n  - topic-bug\n---\n\n# BUG-0002\n');
+    const r = spawnSync(process.execPath, [BIN, 'doctor', '--vault', vault], { encoding: 'utf8' });
+    assert.match(r.stdout, /\[links\]/, 'imprime a seção [links]');
+    assert.match(r.stdout, /note relink/, 'sugere o comando de reparo das derivadas');
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Por quê

`wendkeep doctor` reportava integridade de sessão/harness mas **não enxergava os órfãos do grafo** — o dono do vault só descobria olhando o Obsidian e não sabia qual comando rodava. E o control marca `inactive` quando a sessão-mãe encerra, **mesmo com um workflow/subagente ainda vivo em background** (visto em produção), então o doctor "mentia" inativa.

## O que muda

Capability nova `vault-doctor` (DIAG-1..4):

- **`checkVaultLinks`** (seção `[links]`): conta notas derivadas órfãs (→ `note relink`), artefatos de change órfãos (→ `change backlink`) e o estado das cores do grafo (→ `theme sync`). Reusa as funções de reparo em **dry-run** — zero lógica de detecção nova. Tudo conectado → `grafo conectado ✓`.
- **`checkSessionActivity`** (seção `[sessão]`): control `inactive` + nota da sessão escrita há pouco → sinaliza possível workflow/subagente em background.

## Verificação

- Passe independente (autor≠verificador): 4/4 reqs cobertos por testes que discriminam. Ressalva DIAG-2 (`>=1` sem provar exclusão) fechada: fixture ganhou uma change já linkada + asserção exata `=== 1`.
- +4 testes; suíte **469/469**; `npm run check` limpo.
- Rodado no Vendiva (já curado): mostra `grafo conectado ✓`.

Bug da lacuna profunda registrado (control não reflete background) para follow-up. Fecha `doctor-orfaos-clareza` (ADR-0031). Bump **0.49.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)