### PR TITLE
docs: README para de recomendar pnpm add @latest (0.57.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.57.2] — 2026-07-25
+
+### Fixed
+
+- **O README deixa de recomendar um `pnpm add` que não atualiza.** A seção "Atualizar"
+  mandava rodar `pnpm add -D -w wendkeep@latest`. Medido num projeto pnpm limpo, sem
+  configuração alguma: o comando devolveu `+ wendkeep 0.49.0 (0.57.1 is available)` e saiu 0.
+  O `minimumReleaseAge` de 24h é **default do pnpm 11**, não config do projeto, e ele não
+  recusa o pacote recente — instala o anterior em silêncio, com o `(X.Y.Z is available)` como
+  única pista. Quem seguia o README ficava na versão velha achando que tinha atualizado. O
+  bloco pnpm passa a mostrar a versão exata com `--config.minimumReleaseAge=0`, e o `@latest`
+  aparece como armadilha nomeada. A nota também corrige quem escreve a exceção: o
+  `minimumReleaseAgeExclude` do `pnpm-workspace.yaml` é **manual** — o pnpm não escreve essa
+  linha, e sem ela o `pnpm install` do CI falha com
+  `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` até a versão completar 24h. Vale nos dois idiomas.
+
 ## [0.57.1] — 2026-07-25
 
 ### Fixed

--- a/README.en.md
+++ b/README.en.md
@@ -124,16 +124,28 @@ The install stays outside `sync` on purpose: a running process cannot replace it
 keep going — the code in memory would still be the old one.
 
 In a **pnpm** monorepo the install command differs (`npm` in a pnpm repo fails with
-`Cannot read properties of null (reading 'matches')`):
+`Cannot read properties of null (reading 'matches')`) and the version must be **exact**:
 
 ```bash
-pnpm add -D -w wendkeep@latest && npx --no-install wendkeep sync --project . --yes
+pnpm add -D -w wendkeep@X.Y.Z --config.minimumReleaseAge=0 && npx --no-install wendkeep sync --project . --yes
 ```
 
-> pnpm refuses packages published in the last ~24h (`minimumReleaseAge`, a supply-chain
-> guard). If you just published and need it now, ask for the exact version with
-> `--config.minimumReleaseAge=0` and record the exception under `minimumReleaseAgeExclude`
-> in `pnpm-workspace.yaml` — otherwise CI's `pnpm install` starts failing.
+> **Do not ask pnpm for `wendkeep@latest`.** pnpm 11 ignores packages published in the last
+> 24h by default (`minimumReleaseAge`, a supply-chain guard) — and it does not complain: it
+> installs the previous version, exits 0, and the only hint is a quiet `(X.Y.Z is available)`
+> in the output. You end up on the old version thinking you upgraded. Check with
+> `npx wendkeep --version`.
+>
+> After installing, record the exception in `pnpm-workspace.yaml` — **pnpm does not write
+> that line for you**:
+>
+> ```yaml
+> minimumReleaseAgeExclude:
+>   - wendkeep@X.Y.Z
+> ```
+>
+> Without it, CI's `pnpm install` fails with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` until
+> the version turns 24h old.
 
 Restart Codex and Claude Code afterwards — the generated skills are read at startup.
 

--- a/README.md
+++ b/README.md
@@ -121,16 +121,28 @@ O `install` fica de fora do `sync` de propósito: um processo não se auto-subst
 rodando — o código em execução continuaria sendo o antigo.
 
 Num monorepo **pnpm**, o comando de instalação é outro (`npm` num repositório pnpm falha com
-`Cannot read properties of null (reading 'matches')`):
+`Cannot read properties of null (reading 'matches')`) e a versão vai **exata**:
 
 ```bash
-pnpm add -D -w wendkeep@latest && npx --no-install wendkeep sync --project . --yes
+pnpm add -D -w wendkeep@X.Y.Z --config.minimumReleaseAge=0 && npx --no-install wendkeep sync --project . --yes
 ```
 
-> O pnpm recusa pacote publicado nas últimas ~24h (`minimumReleaseAge`, proteção de
-> supply-chain). Se você acabou de publicar e precisa instalar já, peça a versão exata com
-> `--config.minimumReleaseAge=0` e registre a exceção em `minimumReleaseAgeExclude` no
-> `pnpm-workspace.yaml`, senão o `pnpm install` do CI passa a falhar.
+> **Não peça `wendkeep@latest` ao pnpm.** O pnpm 11 ignora por padrão pacote publicado nas
+> últimas 24h (`minimumReleaseAge`, proteção de supply-chain) — e não reclama: instala a
+> versão anterior, sai 0, e a única pista é um discreto `(X.Y.Z is available)` no meio da
+> saída. Você fica com a versão velha achando que atualizou. Confira com
+> `npx wendkeep --version`.
+>
+> Depois de instalar, registre a exceção no `pnpm-workspace.yaml` — **o pnpm não escreve
+> essa linha por você**:
+>
+> ```yaml
+> minimumReleaseAgeExclude:
+>   - wendkeep@X.Y.Z
+> ```
+>
+> Sem ela, o `pnpm install` do CI falha com `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` até a
+> versão completar 24h.
 
 Reinicie Codex e Claude Code depois — as skills geradas são lidas no startup.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,28 @@
 {
   "name": "wendkeep",
-  "version": "0.57.1",
+  "version": "0.57.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.57.1",
+      "version": "0.57.2",
       "license": "MIT",
       "bin": {
         "wendkeep": "bin/wendkeep.mjs",
         "wk": "bin/wendkeep.mjs"
       },
       "devDependencies": {
-        "wendkeep": "^0.54.0"
+        "wendkeep": "^0.57.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/wendkeep": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/wendkeep/-/wendkeep-0.54.0.tgz",
-      "integrity": "sha512-5No3AI2+eaXk1rh86PCEV9xTbcqgU6G0lk/PBBrNKLhr3Q0wYxRraAezwKKdEzJL4AwHEYo0G1tOEhUMhhIh+g==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/wendkeep/-/wendkeep-0.57.1.tgz",
+      "integrity": "sha512-d6zPxhSoJPPCZhgBz6kxm1kWwLuD7gSZInrCtLsqgJzgsRqAKVH4J9FJpGNZCTISU00SESkKudFWsylEdKdfHg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.57.1",
+  "version": "0.57.2",
   "description": "A persistent-memory harness for AI coding agents on your Obsidian vault: turn-by-turn session capture plus a native, zero-dependency spec→change→verify→archive loop (sensor-gated, independent verdict, mutation discrimination). Local-first, agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "bin": {
@@ -49,6 +49,6 @@
     "url": "https://github.com/rogersialves/wendkeep/issues"
   },
   "devDependencies": {
-    "wendkeep": "^0.54.0"
+    "wendkeep": "^0.57.1"
   }
 }

--- a/tests/readme-packaging.test.mjs
+++ b/tests/readme-packaging.test.mjs
@@ -33,6 +33,24 @@ test('os dois idiomas viajam no pacote', () => {
   for (const f of ['README.md', 'README.en.md']) assert.ok(files.includes(f), `${f} em files`);
 });
 
+// Medido num projeto pnpm limpo, sem configuração alguma (pnpm 11.5.2):
+//   $ pnpm add -D wendkeep@latest
+//   + wendkeep 0.49.0 (0.57.1 is available)
+// Saiu 0, sem erro, e instalou a versão de dois dias antes — `minimumReleaseAge` é default
+// do pnpm 11. Um comando que falha em silêncio não pode aparecer como recomendação.
+//
+// Teste de texto, sim: o defeito que ele guarda TAMBÉM é de texto, e o erro plausível é
+// copiar o bloco npm de cima trocando o gerenciador. Ancorado em `pnpm add` de propósito —
+// o bloco npm usa `@latest` legitimamente, npm não tem cooldown.
+test('nenhum README manda instalar por pnpm com @latest', () => {
+  for (const file of ['README.md', 'README.en.md']) {
+    const text = readFileSync(join(ROOT, file), 'utf8');
+    const armadilha = text.match(/^.*pnpm add .*wendkeep@latest.*$/m);
+    assert.equal(armadilha, null,
+      `${file} recomenda um pnpm add que instala versão antiga em silêncio:\n  ${armadilha?.[0]}`);
+  }
+});
+
 // O que realmente importa: o conteúdo do tarball, e o repo intacto depois.
 test('npm pack: o tarball leva o inglês e o repositório volta ao português', () => {
   const outDir = mkdtempSync(join(tmpdir(), 'wk-pack-'));


### PR DESCRIPTION
## Problema

A seção "Atualizar" mandava rodar, em monorepo pnpm:

```bash
pnpm add -D -w wendkeep@latest && npx --no-install wendkeep sync --project . --yes
```

Esse comando **não atualiza**. Medido num projeto pnpm limpo, zero configuração:

```
$ pnpm add -D wendkeep@latest
+ wendkeep 0.49.0 (0.57.1 is available)
Done in 3.7s
```

Exit 0, sem erro, versão de dois dias antes. O `minimumReleaseAge` de 24h é **default do
pnpm 11.5.2**, não config do projeto (`pnpm config get minimumReleaseAge` devolve
`undefined`), e ele não recusa o pacote recente — instala o anterior em silêncio. A única
pista é `(0.57.1 is available)`, que se lê como aviso de novidade.

A nota existente errava em dois pontos e chegava depois do bloco de código que já tinha dado
a resposta errada: dizia que o pnpm "recusa" (não recusa) e que o pnpm registra a exceção em
`minimumReleaseAgeExclude` (não registra — no experimento o `pnpm-workspace.yaml` ficou
intocado após o `pnpm add`).

Consequência do segundo erro, medida — lock em 0.57.1, sem a linha de exceção:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  wendkeep@0.57.1 was published at 2026-07-25T16:50:10.753Z, within the minimumReleaseAge
  cutoff (2026-07-24T17:17:15.676Z)
```

Quem instalava pelo caminho documentado quebrava o próprio CI sem ser avisado.

## O que muda

- O bloco pnpm mostra a versão exata com `--config.minimumReleaseAge=0`; o `@latest` vira
  armadilha nomeada, com `npx wendkeep --version` como conferência.
- A nota traz os três fatos medidos: instalação silenciosa da versão antiga, exceção
  **manual**, e o erro exato que o CI dá sem ela.
- Vale nos dois idiomas (`README.md` e `README.en.md`).
- Teste de regressão em `tests/readme-packaging.test.mjs`: nenhum README pode conter um
  `pnpm add` com `wendkeep@latest`. Ancorado em `pnpm add` de propósito — o bloco npm usa
  `@latest` legitimamente, npm não tem cooldown.

## Por que não manter `@latest` como caminho feliz

Tentador dizer "use `@latest`; se acabou de publicar, use a versão exata". Mas o usuário não
sabe quando a versão saiu, e o modo de falha é silencioso: ele fica na versão antiga e o
`doctor` só acusa mais tarde, por outro sintoma. Um comando que falha em silêncio em parte do
tempo é pior que um um pouco mais longo que sempre funciona.

## Verificação

- 561/561 na suíte completa.
- Teste novo provado vermelho antes da correção.
- O comportamento do pnpm foi medido à mão em sandbox isolado; não dá para cobrir na suíte
  (exigiria rede, publicação recente e o relógio do registry). O teste guarda só o texto, que
  é o que o repositório controla.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
