### PR TITLE
fix: keep GitHub Release notes synced

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -4,8 +4,9 @@ name: auto-tag-release
 # git tag is never pushed, so `release.yml` never fires and the GitHub Releases page falls
 # behind npm/CHANGELOG. This watches main; when `package.json` carries a version with no
 # matching tag yet, it creates the tag AND the GitHub Release in one job (notes from
-# CHANGELOG via scripts/print-release-notes.mjs). The tag is a no-op if it already exists
-# (e.g. the maintainer used `npm run release`), so the two flows coexist.
+# CHANGELOG via scripts/print-release-notes.mjs). If the tag already exists (e.g. the
+# maintainer used `npm run release` or the notes were corrected later), it preserves the
+# tag and still refreshes the GitHub Release from CHANGELOG.
 
 on:
   push:
@@ -27,23 +28,26 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Tag + release when the version is new
+      - name: Ensure tag + sync release from CHANGELOG
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
           TAG="v$VERSION"
-          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "tag $TAG já existe — release fica com o fluxo do tag push"; exit 0
-          fi
           # CHANGELOG is the single source of truth — fail loud if the entry is missing.
           node scripts/print-release-notes.mjs "$VERSION" > RELEASE_NOTES.md
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "$TAG"
-          git push origin "$TAG"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "tag $TAG já existe — preservando tag e atualizando a GitHub Release"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag -a "$TAG" -m "$TAG"
+            git push origin "$TAG"
+          fi
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release edit "$TAG" --notes-file RELEASE_NOTES.md
           else
             gh release create "$TAG" --title "$TAG" --notes-file RELEASE_NOTES.md
           fi
+          gh release view "$TAG" --json body --jq .body > PUBLISHED_RELEASE_NOTES.md
+          node -e 'const fs=require("node:fs"); const norm=(path)=>fs.readFileSync(path,"utf8").replace(/\r\n/g,"\n").trimEnd(); if(norm("RELEASE_NOTES.md")!==norm("PUBLISHED_RELEASE_NOTES.md")){console.error("GitHub Release diverge do CHANGELOG");process.exit(1)}'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- wendkeep:skills:start -->
-<!-- wendkeep-version: 0.57.1; skills-sha256: c69f17a96cefc1f8a24a6bb6295bd4c0368c99f6d9f722f3ee6b95854729e8ad -->
+<!-- wendkeep-version: 0.58.0; skills-sha256: c69f17a96cefc1f8a24a6bb6295bd4c0368c99f6d9f722f3ee6b95854729e8ad -->
 ## wendkeep — process skills & loop
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. Work
@@ -38,10 +38,10 @@ CHANGELOG ↔ NPM ↔ GitHub **sempre na mesma versão**. A **tag `vX.Y.Z` é o 
 sem a tag pushada, o `release.yml` não cria a GitHub Release e a página fica atrás do npm.
 Esse foi um atrito recorrente (12/07, 16/07) — `npm publish` avulso publicava sem tag.
 
-**Automação (auto-tag-release):** `.github/workflows/auto-tag.yml` observa a `main`; quando o
-`package.json` traz uma versão sem tag correspondente, ele **cria a tag E a GitHub Release**
-(notas do CHANGELOG). Ou seja: merge de um PR que bumpa a versão → release automática. Ninguém
-mais depende de lembrar de pushar a tag.
+**Automação (auto-tag-release):** `.github/workflows/auto-tag.yml` observa a `main`, gera as
+notas da versão corrente diretamente do `CHANGELOG.md` e converge o estado remoto: cria a tag
+quando ausente e cria **ou atualiza** a GitHub Release mesmo quando a tag já existe. O job lê as
+notas publicadas de volta e falha se elas divergirem do changelog.
 
 **Fluxo do agente (só prepara):**
 1. `npm view wendkeep version` — alinhe `package.json`/`CHANGELOG`/tag a esse estado antes de bumpar.
@@ -54,6 +54,23 @@ mais depende de lembrar de pushar a tag.
 `npm publish` — neste caso a `auto-tag.yml` cobre a tag no push da `main`. Nunca deixe npm à
 frente da GitHub Release sem tag.
 
+**Fechamento obrigatório — CHANGELOG → GitHub Release:** não declare uma release concluída só
+porque npm e tag existem. A entrada `## [X.Y.Z]` do `CHANGELOG.md` deve ser o corpo efetivamente
+publicado em `vX.Y.Z`. Depois do merge/tag, confirme a execução verde do workflow e leia a Release
+de volta. Se uma entrada já publicada for corrigida, atualize a Release existente sem mover a tag:
+
+```powershell
+node scripts/print-release-notes.mjs X.Y.Z > RELEASE_NOTES.md
+gh release edit vX.Y.Z --notes-file RELEASE_NOTES.md
+gh release view vX.Y.Z --json body --jq .body
+Remove-Item RELEASE_NOTES.md
+```
+
+Para a versão corrente, `auto-tag.yml` faz create/update + readback automaticamente. Para uma
+versão histórica diferente da versão de `package.json`, o agente/mantenedor executa o fluxo acima
+explicitamente. A conclusão exige `package.json`, npm `latest`, tag e corpo da GitHub Release na
+mesma versão e com as mesmas notas relevantes do `CHANGELOG.md`.
+
 **Recuperação retroativa** (releases perdidas): `git tag -a vX.Y.Z <sha> -m "vX.Y.Z" && git push
 origin vX.Y.Z` no commit cujo `package.json` tem a versão — o `release.yml` monta a Release do
-CHANGELOG.
+CHANGELOG. Depois, aplique o fechamento obrigatório acima e confirme o corpo publicado.

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -1,6 +1,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { extractReleaseNotes } from '../src/release-changelog.mjs';
+
+const AUTO_TAG_WORKFLOW = readFileSync(new URL('../.github/workflows/auto-tag.yml', import.meta.url), 'utf8');
+const AGENT_RULES = readFileSync(new URL('../AGENTS.md', import.meta.url), 'utf8');
 
 const FIXTURE = `# Changelog
 
@@ -60,4 +64,35 @@ test('extractReleaseNotes: body is trimmed (no leading/trailing blank lines)', (
 
 test('extractReleaseNotes: throws when the version is absent', () => {
   assert.throws(() => extractReleaseNotes(FIXTURE, '9.9.9'), /9\.9\.9/);
+});
+
+test('auto-tag: existing tag still refreshes the GitHub Release from CHANGELOG', () => {
+  const tagBranch = AUTO_TAG_WORKFLOW.match(/if git rev-parse[\s\S]*?^\s*fi$/m)?.[0] || '';
+  assert.ok(tagBranch, 'workflow has an explicit existing/new tag branch');
+  assert.doesNotMatch(tagBranch, /\bexit\s+0\b/, 'an existing tag must not skip release refresh');
+  assert.ok(
+    AUTO_TAG_WORKFLOW.indexOf('scripts/print-release-notes.mjs') < AUTO_TAG_WORKFLOW.indexOf('if git rev-parse'),
+    'release notes are generated before the tag branch',
+  );
+  assert.ok(
+    AUTO_TAG_WORKFLOW.indexOf('gh release edit') > AUTO_TAG_WORKFLOW.indexOf(tagBranch),
+    'the existing-tag path reaches release edit',
+  );
+});
+
+test('auto-tag: release readback normalizes the extra newline emitted by gh', () => {
+  assert.match(AUTO_TAG_WORKFLOW, /PUBLISHED_RELEASE_NOTES\.md/);
+  assert.doesNotMatch(
+    AUTO_TAG_WORKFLOW,
+    /diff -u RELEASE_NOTES\.md PUBLISHED_RELEASE_NOTES\.md/,
+    'raw diff rejects an otherwise identical gh body because --jq appends one newline',
+  );
+  assert.match(AUTO_TAG_WORKFLOW, /trimEnd\(\)/, 'comparison canonicalizes trailing newlines');
+});
+
+test('AGENTS: release closure requires updating and reading back notes from CHANGELOG', () => {
+  assert.match(AGENT_RULES, /Fechamento obrigatório[\s\S]*CHANGELOG[\s\S]*GitHub Release/i);
+  assert.match(AGENT_RULES, /gh release edit\s+vX\.Y\.Z/);
+  assert.match(AGENT_RULES, /gh release view\s+vX\.Y\.Z/);
+  assert.match(AGENT_RULES, /não (?:declare|considere)[\s\S]*release[\s\S]*concluída/i);
 });


### PR DESCRIPTION
## Resumo
- torna obrigatório em `AGENTS.md` o fechamento CHANGELOG → GitHub Release
- faz `auto-tag.yml` atualizar a Release mesmo quando a tag já existe
- lê o corpo publicado de volta e falha se divergir das notas do changelog
- normaliza o newline extra emitido por `gh --jq` sem esconder divergência real
- adiciona regressões para o early-exit, readback e regra operacional

## Auditoria atual
- `v0.58.0`: npm/package/tag/Release alinhados; notas coincidem com o CHANGELOG
- publicação npm precedeu a Release em cerca de 63 minutos
- auditoria histórica encontrou 12 versões do changelog sem Release e 39 corpos antigos divergentes; o backfill em massa fica separado porque há versões não publicadas e tags sem commit recuperável

## Evidência
- `node --test tests/release-changelog.test.mjs`: 8/8
- `npm test`: 629/629
- `npm run check`: verde
- verify/deep: release-tests + tests verdes; verdict trivial ok
- change arquivada como ADR-0048

Sem bump de pacote: a mudança afeta governança/workflow do repositório, não o artefato npm. Sem self-merge.