### PR TITLE
fix: preserve legacy memory fallback (0.58.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.58.1] — 2026-07-26
+
+### Fixed
+
+- **Vaults com `SHARED_MEMORY.md` legado voltam a atualizar sem bloquear o doctor.** `init` e
+  `sync` ainda preservam todos os bytes existentes e podem criar os sidecars v2 ausentes,
+  mas sidecars vazios não ativam a memória v2. `memory status --gate` reporta o estado
+  `legacy` como aviso não bloqueante e `brain-inject` mantém CORE+DIGEST durante a janela de
+  compatibilidade.
+- **`SessionStop` não migra memória implicitamente.** Enquanto o vault permanecer legado, o
+  Stop não grava outbox, ledger, candidates nem reescreve SHARED. A transição acontece somente
+  com `wendkeep memory migrate --apply`; conteúdo com assinatura/evidência v2 corrompida continua
+  visível e bloqueante, sem fallback silencioso.
+
 ## [0.58.0] — 2026-07-26
 
 ### Added

--- a/hooks/brain-inject.mjs
+++ b/hooks/brain-inject.mjs
@@ -12,6 +12,7 @@ import { buildLessonsInjection } from './lessons-core.mjs';
 import { getLocale } from './locale.mjs';
 import { resolveSessionEntry } from './session-identity.mjs';
 import { sanitizeMemoryText, validateSharedMemory } from './memory-schema.mjs';
+import { detectMemoryMode } from './memory-mode.mjs';
 import { validateCore } from '../src/validate-core.mjs';
 
 // The process ROUTER — the enforcement layer. The wk-* skills are passive files; without a
@@ -186,7 +187,7 @@ function budgetNotice(priority, layer, message) {
 
 export function buildInjection(vaultBase, input = {}) {
   const dir = brainDir(vaultBase);
-  const brain = existsSync(join(dir, 'SHARED_MEMORY.md')) ? buildV2Memory(dir) : buildLegacyMemory(dir);
+  const brain = detectMemoryMode(vaultBase).mode === 'v2' ? buildV2Memory(dir) : buildLegacyMemory(dir);
   const router = processRouter(getLocale(vaultBase).id);
   const { identity, entry } = resolveSessionEntry(vaultBase, input);
   const focus = identity.state === 'resolved' && entry?.change_slug

--- a/hooks/memory-mode.mjs
+++ b/hooks/memory-mode.mjs
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { classifySharedMemory } from './memory-schema.mjs';
+
+export const LEGACY_MEMORY_WARNING = 'Vault legado: CORE+DIGEST permanece ativo; execute `wendkeep memory migrate --apply` quando a curadoria estiver pronta.';
+
+function readText(path) {
+  if (!existsSync(path)) return { exists: false, content: '', error: null };
+  try { return { exists: true, content: readFileSync(path, 'utf8'), error: null }; }
+  catch (error) { return { exists: true, content: '', error }; }
+}
+
+function hasOutboxEvidence(path) {
+  if (!existsSync(path)) return false;
+  try { return readdirSync(path, { withFileTypes: true }).some((entry) => entry.isFile()); }
+  catch { return true; }
+}
+
+/** A single, read-only mode decision shared by injection, health and SessionStop. */
+export function detectMemoryMode(vaultBase) {
+  const brain = join(vaultBase, '.brain');
+  const shared = readText(join(brain, 'SHARED_MEMORY.md'));
+  if (shared.error) return { mode: 'v2', reason: 'shared-unreadable' };
+  const classified = classifySharedMemory(shared.content);
+  if (classified.mode === 'v2') return classified;
+
+  const ledger = readText(join(brain, 'MEMORY_EVENTS.jsonl'));
+  if (ledger.error) return { mode: 'v2', reason: 'ledger-unreadable' };
+  const candidates = readText(join(brain, 'MEMORY_CANDIDATES.jsonl'));
+  if (candidates.error) return { mode: 'v2', reason: 'candidates-unreadable' };
+  const ledgerHasEvents = ledger.content.trim().length > 0;
+  const candidatesHaveEntries = candidates.content.trim().length > 0;
+  const outboxHasEvents = hasOutboxEvidence(join(brain, 'memory-outbox'));
+  if (ledgerHasEvents || candidatesHaveEntries || outboxHasEvents) {
+    return { mode: 'v2', reason: 'operational-evidence' };
+  }
+  return classified;
+}

--- a/hooks/memory-schema.mjs
+++ b/hooks/memory-schema.mjs
@@ -293,3 +293,18 @@ export function validateSharedMemory(content, { eventIds } = {}) {
     sections: parsed.sections,
   };
 }
+
+/**
+ * Classify SHARED from its own bytes without accepting malformed v2 as legacy.
+ * Empty v2 sidecar files are intentionally not part of this pure classification;
+ * vault-level operational evidence is handled by memory-mode.mjs.
+ */
+export function classifySharedMemory(content) {
+  const text = String(content ?? '').replace(/\r\n/g, '\n');
+  if (validateSharedMemory(text).ok) return { mode: 'v2', reason: 'valid-v2' };
+  const hasV2Signature = /^(?:schema_version|event_cursor|state_hash)\s*:/m.test(text)
+    || /^# SHARED_MEMORY\s+[—-]\s+proje[cç][aã]o operacional gerada\s*$/mi.test(text);
+  return hasV2Signature
+    ? { mode: 'v2', reason: 'v2-signature' }
+    : { mode: 'legacy', reason: text.trim() ? 'legacy-shared' : 'shared-absent' };
+}

--- a/hooks/session-stop.mjs
+++ b/hooks/session-stop.mjs
@@ -14,6 +14,7 @@ import { mutateSessionNote } from './session-note-io.mjs';
 import { applyDerivedSections, provenanceSessions } from './derived-sections.mjs';
 import { buildSessionMemoryEvents, collectLifecycleEvidence } from './memory-handoff.mjs';
 import { enqueueMemoryEvent, projectMemoryOutbox } from './memory-store.mjs';
+import { detectMemoryMode } from './memory-mode.mjs';
 import { sanitizeMemoryText } from './memory-schema.mjs';
 import {
   ensureDir,
@@ -799,6 +800,9 @@ function shouldFinalizeSession() {
 }
 
 export function commitSessionMemory(vaultBase, handoff, { projectOptions = {} } = {}) {
+  if (detectMemoryMode(vaultBase).mode === 'legacy') {
+    return { status: 'legacy', eventCount: 0, eventIds: [], checkpoint: null };
+  }
   const events = buildSessionMemoryEvents(handoff);
   const eventIds = events.map((event) => event.event_id);
   try {

--- a/hooks/vault-health.mjs
+++ b/hooks/vault-health.mjs
@@ -12,6 +12,7 @@ import {
 } from './obsidian-common.mjs';
 import { getLocale } from './locale.mjs';
 import { parseSharedMemory, validateMemoryEvent } from './memory-schema.mjs';
+import { detectMemoryMode, LEGACY_MEMORY_WARNING } from './memory-mode.mjs';
 import { reduceMemoryEvents } from './memory-store.mjs';
 import { validateMemoryBundle } from '../src/validate-memory.mjs';
 
@@ -101,7 +102,9 @@ const MEMORY_REPAIR_COMMAND = 'wendkeep memory repair --vault <vault>';
 
 function readJsonLines(path, label) {
   if (!existsSync(path)) return { items: [], errors: [] };
-  const raw = readFileSync(path, 'utf8').replace(/\r\n/g, '\n');
+  let raw;
+  try { raw = readFileSync(path, 'utf8').replace(/\r\n/g, '\n'); }
+  catch (error) { return { items: [], errors: [`${label} ilegível: ${error?.message || error}`] }; }
   const lines = raw.endsWith('\n') ? raw.split('\n').slice(0, -1) : raw.split('\n');
   const items = [];
   const errors = [];
@@ -140,6 +143,25 @@ function inspectOutbox(vaultBase, projectId) {
  */
 export function checkMemoryBundle(vaultBase) {
   const brain = join(vaultBase, '.brain');
+  const mode = detectMemoryMode(vaultBase);
+  if (mode.mode === 'legacy') {
+    return {
+      ok: true,
+      status: 'legacy',
+      failures: [],
+      warnings: [LEGACY_MEMORY_WARNING],
+      metrics: {
+        schemaVersion: null,
+        revision: null,
+        eventCursor: null,
+        stateHash: null,
+        ledgerEvents: 0,
+        pendingOutbox: 0,
+        candidates: 0,
+        activeConflicts: 0,
+      },
+    };
+  }
   const bundle = validateMemoryBundle(vaultBase);
   const failures = [];
   const warnings = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.58.0",
+      "version": "0.58.1",
       "license": "MIT",
       "bin": {
         "wendkeep": "bin/wendkeep.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "description": "A persistent-memory harness for AI coding agents on your Obsidian vault: turn-by-turn session capture plus a native, zero-dependency spec→change→verify→archive loop (sensor-gated, independent verdict, mutation discrimination). Local-first, agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "bin": {

--- a/tests/brain-inject-memory.test.mjs
+++ b/tests/brain-inject-memory.test.mjs
@@ -284,3 +284,29 @@ test('[req:MEM-HYB-9] a legacy vault keeps CORE+DIGEST for one release with an e
     assert.doesNotMatch(out, /version="2"/);
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
+
+test('[req:MEM-HYB-9] a legacy SHARED preserved by sync does not activate v2 when seeded artifacts are empty', () => {
+  const vault = makeVault({ shared: '# SHARED legado\n\n## Estado\n- não migrado\n', digest: '- DIGEST_LEGACY_FALLBACK' });
+  try {
+    writeFileSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl'), '');
+    writeFileSync(join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl'), '');
+    const out = buildInjection(vault, { source: 'startup' });
+    assert.match(out, /<wk_memory_legacy_warning>/);
+    assert.match(out, /CORE_CANONICAL_DIRECT/);
+    assert.match(out, /DIGEST_LEGACY_FALLBACK/);
+    assert.doesNotMatch(out, /version="2"|wk_memory_error layer="shared"/);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-HYB-7] unreadable SHARED stays in degraded v2 instead of silently falling back', () => {
+  const vault = makeVault({ shared: null, digest: '- MUST_NOT_MASK_V2_DAMAGE' });
+  try {
+    mkdirSync(join(vault, '.brain', 'SHARED_MEMORY.md'));
+    writeFileSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl'), '');
+    writeFileSync(join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl'), '');
+    const out = buildInjection(vault, { source: 'startup' });
+    assert.match(out, /<brain_memory version="2"/);
+    assert.match(out, /<wk_memory_error layer="shared"/);
+    assert.doesNotMatch(out, /wk_memory_legacy_warning|MUST_NOT_MASK_V2_DAMAGE/);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});

--- a/tests/identity-registry-fallback.test.mjs
+++ b/tests/identity-registry-fallback.test.mjs
@@ -8,6 +8,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { resolveSessionIdentity } from '../hooks/session-identity.mjs';
 
+const AMBIENT_CODEX_THREAD_ID = process.env.CODEX_THREAD_ID;
+test.beforeEach(() => { delete process.env.CODEX_THREAD_ID; });
+test.afterEach(() => {
+  if (AMBIENT_CODEX_THREAD_ID === undefined) delete process.env.CODEX_THREAD_ID;
+  else process.env.CODEX_THREAD_ID = AMBIENT_CODEX_THREAD_ID;
+});
+
 const SID = '019f7764-7627-79a3-b609-65abaa36eedd';
 const TX = join(tmpdir(), 'wk-fallback-rollout.jsonl');
 

--- a/tests/init-vault.test.mjs
+++ b/tests/init-vault.test.mjs
@@ -92,6 +92,9 @@ test('init preserva SHARED legado byte-idêntico e apenas semeia artefatos ausen
     assert.equal(readFileSync(join(vault, '.brain', 'SHARED_MEMORY.md'), 'utf8'), legacy);
     assert.ok(existsSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl')));
     assert.ok(existsSync(join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl')));
+    const gate = spawnSync(process.execPath, [BIN, 'memory', 'status', '--gate', '--vault', vault], { encoding: 'utf8' });
+    assert.equal(gate.status, 0, gate.stderr || gate.stdout);
+    assert.equal(JSON.parse(gate.stdout).status, 'legacy');
   } finally { rmSync(proj, { recursive: true, force: true }); }
 });
 

--- a/tests/memory-hybrid-e2e.test.mjs
+++ b/tests/memory-hybrid-e2e.test.mjs
@@ -5,6 +5,7 @@ import { mkdtempSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileS
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { renderSharedMemory } from '../hooks/memory-schema.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const STOP = join(ROOT, 'hooks', 'session-stop.mjs');
@@ -88,6 +89,8 @@ function seed({ withSeededSession = true } = {}) {
   ];
   writeFileSync(transcript, `${events.map((event) => JSON.stringify(event)).join('\n')}\n`);
   writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), '');
+  writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), '');
+  writeFileSync(join(brain, 'SHARED_MEMORY.md'), renderSharedMemory());
   if (withSeededSession) {
     writeFileSync(join(brain, 'SESSION_REGISTRY.json'), JSON.stringify({
       version: 2,

--- a/tests/session-stop-memory.test.mjs
+++ b/tests/session-stop-memory.test.mjs
@@ -1,15 +1,19 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { commitSessionMemory } from '../hooks/session-stop.mjs';
+import { renderSharedMemory } from '../hooks/memory-schema.mjs';
 
 function fixture() {
   const vault = mkdtempSync(join(tmpdir(), 'wk-stop-memory-'));
   mkdirSync(join(vault, '.brain'), { recursive: true });
   writeFileSync(join(vault, '.brain', 'PROJECT.json'), `${JSON.stringify({ schemaVersion: 2, projectId: 'vendiva' })}\n`);
+  writeFileSync(join(vault, '.brain', 'SHARED_MEMORY.md'), renderSharedMemory());
+  writeFileSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl'), '');
+  writeFileSync(join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl'), '');
   return vault;
 }
 
@@ -42,5 +46,38 @@ test('[req:MEM-HYB-7] projector failure is degraded and preserves the outbox for
 
   assert.equal(result.status, 'degraded');
   assert.match(result.error, /after-ledger/);
+  assert.ok(existsSync(join(vault, '.brain', 'memory-outbox', `${result.eventIds[0]}.json`)));
+});
+
+test('[req:MEM-HYB-1] [req:MEM-HYB-9] legacy mode makes SessionStop memory publication inert', () => {
+  const vault = fixture();
+  const sharedPath = join(vault, '.brain', 'SHARED_MEMORY.md');
+  const ledgerPath = join(vault, '.brain', 'MEMORY_EVENTS.jsonl');
+  const candidatesPath = join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl');
+  const legacy = '# SHARED legado\n\n## Próximo\n- curar antes de migrar\n';
+  writeFileSync(sharedPath, legacy);
+
+  const result = commitSessionMemory(vault, handoff);
+
+  assert.equal(result.status, 'legacy');
+  assert.equal(result.eventCount, 0);
+  assert.deepEqual(result.eventIds, []);
+  assert.equal(result.checkpoint, null);
+  assert.equal(readFileSync(sharedPath, 'utf8'), legacy);
+  assert.equal(readFileSync(ledgerPath, 'utf8'), '');
+  assert.equal(readFileSync(candidatesPath, 'utf8'), '');
+  assert.equal(existsSync(join(vault, '.brain', 'memory-outbox')), false);
+});
+
+test('[req:MEM-HYB-1] [req:MEM-HYB-7] unreadable v2 state degrades SessionStop and preserves an outbox', () => {
+  const vault = fixture();
+  const sharedPath = join(vault, '.brain', 'SHARED_MEMORY.md');
+  rmSync(sharedPath);
+  mkdirSync(sharedPath);
+
+  const result = commitSessionMemory(vault, handoff);
+
+  assert.equal(result.status, 'degraded');
+  assert.notEqual(result.error, undefined);
   assert.ok(existsSync(join(vault, '.brain', 'memory-outbox', `${result.eventIds[0]}.json`)));
 });

--- a/tests/sync-command.test.mjs
+++ b/tests/sync-command.test.mjs
@@ -162,6 +162,31 @@ test('[req:MEM-HYB-9] re-init via sync preserva CORE/SHARED/ledger/candidates by
   } finally { rmSync(project, { recursive: true, force: true }); }
 });
 
+test('[req:MEM-HYB-9] sync de SHARED legado com sidecars vazios conclui com doctor não bloqueante', () => {
+  const project = freshProject();
+  try {
+    const first = spawnWk(['sync', '--project', project, '--yes'], { cwd: project });
+    assert.ok(first.status === 0 || first.status === 1, first.stderr);
+    const vaultName = JSON.parse(readFileSync(join(project, '.wendkeep.json'), 'utf8')).vault;
+    const vault = join(project, vaultName);
+    const brain = join(vault, '.brain');
+    const legacy = '# SHARED legado\n\n## Estado\n- preservar durante upgrade\n';
+    writeFileSync(join(brain, 'SHARED_MEMORY.md'), legacy);
+    writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), '');
+    writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), '');
+
+    const second = spawnWk(['sync', '--project', project, '--yes'], { cwd: project });
+    assert.ok(second.status === 0 || second.status === 1, second.stderr || second.stdout);
+    assert.match(second.stdout, /"memoryStatus": "legacy"/);
+    assert.doesNotMatch(second.stdout, /schema_version deve ser 2|event_cursor .*n[aã]o existe no ledger/i);
+    assert.equal(readFileSync(join(brain, 'SHARED_MEMORY.md'), 'utf8'), legacy);
+
+    const gate = spawnWk(['memory', 'status', '--gate', '--vault', vault], { cwd: project });
+    assert.equal(gate.status, 0, gate.stderr || gate.stdout);
+    assert.equal(JSON.parse(gate.stdout).status, 'legacy');
+  } finally { rmSync(project, { recursive: true, force: true }); }
+});
+
 // --- PVR-SYNC-1: env bleed --------------------------------------------------
 
 // sync-defs resolve o vault por `--vault || OBSIDIAN_VAULT_PATH`. Num projeto novo, o env

--- a/tests/vault-health-memory.test.mjs
+++ b/tests/vault-health-memory.test.mjs
@@ -89,6 +89,90 @@ test('[req:DIAG-8] doctor names a healthy bundle and reports schema/revision/cur
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
 
+test('[req:MEM-HYB-9] legacy SHARED plus empty v2 artifacts remains a non-blocking compatibility state', () => {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-health-legacy-'));
+  const brain = join(vault, '.brain');
+  mkdirSync(brain, { recursive: true });
+  writeFileSync(join(brain, 'PROJECT.json'), `${JSON.stringify({ schemaVersion: 1, projectId: PROJECT_ID })}\n`);
+  writeFileSync(join(brain, 'CORE.md'), renderCoreSkeleton());
+  writeFileSync(join(brain, 'SHARED_MEMORY.md'), '# SHARED legado\n\n## Estado\n- preservar sem migrar\n');
+  writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), '');
+  writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), '');
+  try {
+    const before = byteSnapshot(vault);
+    const result = checkMemoryBundle(vault);
+    assert.equal(result.ok, true, result.failures.join('; '));
+    assert.equal(result.status, 'legacy');
+    assert.deepEqual(result.failures, []);
+    assert.match(result.warnings.join('\n'), /legado|migra/i);
+    assert.deepEqual(byteSnapshot(vault), before, 'compatibility diagnosis is read-only');
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-HYB-7] a damaged SHARED carrying a v2 signature stays blocking', () => {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-health-v2-signature-'));
+  const brain = join(vault, '.brain');
+  mkdirSync(brain, { recursive: true });
+  writeFileSync(join(brain, 'PROJECT.json'), `${JSON.stringify({ schemaVersion: 1, projectId: PROJECT_ID })}\n`);
+  writeFileSync(join(brain, 'CORE.md'), renderCoreSkeleton());
+  writeFileSync(join(brain, 'SHARED_MEMORY.md'), '---\nschema_version: 2\nstate_hash: broken\n---\n# SHARED incompleto\n');
+  writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), '');
+  writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), '');
+  try {
+    const result = checkMemoryBundle(vault);
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 'blocked');
+    assert.match(result.failures.join('\n'), /SHARED|revision|event_cursor|se[cç][oõ]es/i);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-HYB-7] non-empty v2 operational evidence prevents legacy fallback', () => {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-health-v2-evidence-'));
+  const brain = join(vault, '.brain');
+  mkdirSync(brain, { recursive: true });
+  writeFileSync(join(brain, 'PROJECT.json'), `${JSON.stringify({ schemaVersion: 1, projectId: PROJECT_ID })}\n`);
+  writeFileSync(join(brain, 'CORE.md'), renderCoreSkeleton());
+  writeFileSync(join(brain, 'SHARED_MEMORY.md'), '# forma legada incompatível com ledger ativo\n');
+  writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), `${JSON.stringify(event())}\n`);
+  writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), '');
+  try {
+    const result = checkMemoryBundle(vault);
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 'blocked');
+    assert.match(result.failures.join('\n'), /SHARED|schema_version|proje[cç][aã]o/i);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-HYB-7] unreadable SHARED is blocking instead of being downgraded to legacy', () => {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-health-shared-unreadable-'));
+  const brain = join(vault, '.brain');
+  mkdirSync(brain, { recursive: true });
+  writeFileSync(join(brain, 'PROJECT.json'), `${JSON.stringify({ schemaVersion: 1, projectId: PROJECT_ID })}\n`);
+  writeFileSync(join(brain, 'CORE.md'), renderCoreSkeleton());
+  mkdirSync(join(brain, 'SHARED_MEMORY.md'));
+  writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), '');
+  writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), '');
+  try {
+    const result = checkMemoryBundle(vault);
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 'blocked');
+    assert.match(result.failures.join('\n'), /SHARED_MEMORY\.md ileg[ií]vel/i);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-HYB-7] unreadable candidates sidecar is reported as blocking, never thrown or ignored', () => {
+  const vault = createBundle([]);
+  const candidatesPath = join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl');
+  rmSync(candidatesPath);
+  mkdirSync(candidatesPath);
+  try {
+    const result = checkMemoryBundle(vault);
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 'blocked');
+    assert.match(result.failures.join('\n'), /MEMORY_CANDIDATES\.jsonl ileg[ií]vel/i);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
 test('[req:DIAG-8] pending outbox and an ordinary candidate are warnings, not failures', () => {
   const vault = createBundle();
   try {


### PR DESCRIPTION
## Resumo
- preserva o fallback CORE+DIGEST quando sync encontra SHARED_MEMORY.md legado
- usa uma decisão única de modo para injection, health/status e SessionStop
- mantém sidecars v2 vazios neutros; somente migração explícita ativa a v2
- mantém assinatura, atividade ou erro de leitura v2 em estado fail-closed
- publica o patch como 0.58.1 com notas no CHANGELOG

## Causa raiz
A 0.58.0 escolhia v2 pela mera existência de SHARED_MEMORY.md. O sync preservava o SHARED legado e criava sidecars vazios, então doctor/injection tentavam validar o legado como v2.

## Compatibilidade
- legado + sidecars vazios: memory status --gate => status legacy, exit 0
- SessionStop legado: não cria outbox/ledger/candidates nem reescreve SHARED
- memory migrate --apply: único switch para v2
- assinatura/evidência v2 ou arquivos ilegíveis: bloqueio/degradação visível, sem fallback silencioso

## Evidência
- TDD RED inicial: 4 repros
- gap independente fail-closed: 4 novos REDs, depois corrigidos
- npm test: 636/636
- verify + verify --deep: tests, release-tests e memory-health verdes
- passe independente final: 75/75 focados, verdict.json ok:true
- pacote npm dry-run: wendkeep@0.58.1, 77 arquivos
- Vendiva real: CORE válido em 14 linhas; memory gate legacy, exit 0, sem aplicar migração

Change arquivada como ADR-0049. Sem self-merge e sem publicação npm neste PR.