### PR TITLE
feat: add bilingual command guides (0.58.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,15 @@ mantenedor. O merge na `main` é o gatilho da release (ver automação abaixo).
 3. `git push origin wk/<slug>` e abra o PR (`gh pr create`) com resumo + entrada do CHANGELOG.
 4. Mantenedor revisa e faz merge. **Não faça self-merge sem revisão se a branch protection exigir.**
 
+## Documentação bilíngue (regra do projeto)
+
+Toda alteração em comando, flag, código de saída, fluxo, hook ou comportamento observável deve
+atualizar, no mesmo commit, o resumo do `README.md`/`README.en.md` e o par de guias PT-BR/EN
+correspondente sob `docs/pt-BR/commands/` e `docs/en/commands/`. Nenhum idioma pode ficar atrás.
+
+Esta regra é exclusiva do repositório WendKeep e fica fora do bloco gerenciado acima. Ela não deve
+ser propagada por `init`, `sync` ou `sync-defs` para o `AGENTS.md` de projetos consumidores.
+
 ## Release & publicação (regra do projeto)
 
 CHANGELOG ↔ NPM ↔ GitHub **sempre na mesma versão**. A **tag `vX.Y.Z` é o elo** que fecha isso:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.58.2] — 2026-07-26
+
+### Added
+
+- **Referência completa dos comandos agora é bilíngue e orientada por tarefa.** Sete guias por
+  domínio e três guias profundos cobrem instalação, changes, verificação, memória, sessões,
+  importação, notas, custos e manutenção em PT-BR e inglês, com sintaxe, exits, exemplos,
+  resultados esperados e diagnóstico.
+- **Paridade documental virou gate automatizado.** O novo sensor `docs-bilingual` bloqueia pares
+  ausentes, comandos públicos sem cobertura, links quebrados, estrutura divergente, drift da regra
+  local e guias ausentes no tarball.
+
+### Changed
+
+- **Os READMEs agora apresentam as funcionalidades por grupos.** A referência extensa deu lugar a
+  um mapa navegável que leva ao guia correto no GitHub e no npm. O fluxo de `verify` deixa explícito
+  que exit 2 por ausência de change é contexto ocioso, não falha de saúde do projeto.
+
 ## [0.58.1] — 2026-07-26
 
 ### Fixed

--- a/README.en.md
+++ b/README.en.md
@@ -156,41 +156,23 @@ stop reporting `defs stale` without a single skill having been updated. If you h
 `wk-*`, that edit is overwritten; your own customisation belongs in a skill of your own,
 which the reseed never touches.
 
-## Commands
+## Features by group
 
-| Command | What it does |
-|---|---|
-| `wendkeep init` | Set up wendkeep in a project (vault taxonomy + settings + MCP + skills). |
-| `wendkeep sync [--project P]` | **One-command update**: runs `init` → `sync-defs` → `doctor` on the current project, stopping at the first failing step. Install the package first (a running process cannot replace itself). `--vault P` · `--yes` to skip the companions picker. |
-| `wendkeep hook <name>` | Run a session hook; invoked by `settings.json` (reads agent JSON on stdin). |
-| `wendkeep change <sub>` | Change lifecycle: `new <slug> [--simple]` / `use <slug>` (switch focus) / `continue <archived> <new> [--simple]` / `bind <slug> --session <id>` / `list` (global backlog) / `show <slug>` / `status [slug]` / `done <id> [--change slug]` / `undone <id> [--change slug]` / `relink [--apply] [--json]` (repair change wikilinks; preview by default) / `diff [slug]` / `archive [slug] [--force]` / `abandon [slug]` (drop it, no ADR) / `backlink [--apply]` (inject the proposal backlink into orphan design/tasks/spec files). `diff`, `archive` and `abandon` fall back to the active change when you omit the slug; bare `status` lists every open one. |
-| `wendkeep verify [--deep] [--change s]` | Run the change's task sensors; `--deep` assembles the independent-verification package. `--change` targets a change other than the active one; `--project <root>` runs it from outside the root. |
-| `wendkeep spec <sub>` | `list` / `show <capability>` generated contracts; `effective [--change <slug>] [--json]` (living contract + delta; defaults to the active change); `migrate`; `rebase [--accept-current]` (stops on conflicts unless you accept the living spec's side). |
-| `wendkeep sensors <sub>` | `list` / `add <id> "<command>"` with `--severity` / `--type` / `--report` / `--name` / `--description` / `--project` — view/edit `wendkeep.sensors.json` (JSON Schema shipped). |
-| `wendkeep cost [opts]` | Aggregate AI-coding spend across the vault's sessions — total, by model, by day. `--since <date>` / `--top [N]` (priciest) / `--trend [day\|week\|month]` (+ run-rate projection) / `--write` (generate `00-Custo.md`) / `--json`. |
-| `wendkeep cost rebuild [opts]` | Recalculate historical parent + subagent costs from `SESSION_REGISTRY`. Dry-run by default; `--apply` updates the notes and writes `.brain/COST_REBUILD.json`. Also `--session <id\|file>` / `--limit n` / `--json`. |
-| `wendkeep stats [--vault P]` | One shareable line: sessions · prompts · spend · span · models (`--json`). |
-| `wendkeep import [opts]` | **Retroactive memory** — backfill past **Claude + Codex** sessions into the vault (deduped by `session_id`). `--source all\|claude\|codex` / `--stamp-ids` / `--rescan-decisions` / `--from <dir>` / `--codex-from <dir>` / `--since d` / `--limit n` / `--dry-run` / `--json`. |
-| `wendkeep session list\|show\|use` | List the multi-session registry, show one conversation, or move only the human focus in `CURRENT_SESSION.md`. |
-| `wendkeep dashboard [--force]` | (Re)generate the vault's folder-filtered Bases + the `00-Dashboard` MOC. |
-| `wendkeep note new --type bug\|learning "<title>"` | Create a **numbered** derived note (`BUG-`/`APR-NNNN`) in the month folder and print its vault path. `--date YYYY-MM-DD`. |
-| `wendkeep note relink [--apply]` | Backfill provenance on orphan derived notes (BUG/APR with no source session), inheriting the modal session of their type/month cohort. Preview by default. |
-| `wendkeep note repair-frontmatter [--apply]` | Merge stacked frontmatter blocks in a session note — damage from the concurrent writes of pre-0.50 versions. Base keys from the original block, values from the newest; preview by default · `--json`. |
-| `wendkeep note repair-sections [--apply]` | Rebuild the `## Decisions/Bugs/Learnings generated in this session` sections from the linked derived notes — the body used to lag behind the closing block. Preview by default · `--json`. |
-| `wendkeep renumber-decisions` | Renumber `04-Decisões` to `ADR-NNNN-<slug>` chronologically, move notes out of legacy `DIA N` subfolders into the month folder, and rewrite wikilinks. Preview by default; `--apply` / `--json`. |
-| `wendkeep renumber-bugs` | Same for `05-Bugs` → `BUG-NNNN-<slug>`. |
-| `wendkeep renumber-learnings` | Same for `06-Aprendizados`/`06-Learnings` → `APR-NNNN-<slug>`. |
-| `wendkeep lesson add "t" "l"` | Record a project-local lesson (injected at the next SessionStart). `--change <slug>` ties the lesson to a change; `--vault P`. |
-| `wendkeep sync-defs` | Copy `.brain/agents\|skills` into `.codex/agents`, `.claude/skills`, `.agents/skills`; `--check` detects drift, `--reseed` refreshes the `wk-*` skills from the installed version's seeds. |
-| `wendkeep memory status [--gate] --vault P` | Inspect the v2 bundle without mutating it. `--gate` exits 1 only for a blocking state; warnings keep exit code 0. |
-| `wendkeep memory migrate [--apply] --vault P` | Convert a legacy `SHARED_MEMORY.md`. Dry-run by default; `--apply` creates a backup, turns legacy content into candidates, and publishes a valid v2 projection without editing CORE. |
-| `wendkeep memory repair --vault P` | Repair a partial/corrupt ledger under lock, preserving the original bytes in a `.bak`, retaining valid events, and re-projecting state. |
-| `wendkeep memory promote <candidate> --vault P` | Promote a candidate by ID by appending an auditable event; never edits the ledger in place. |
-| `wendkeep memory reject <candidate> --vault P` | Reject a candidate by ID by appending the decision to the audit history. |
-| `wendkeep validate-memory [path]` | Compatibility mode: validate `.brain/CORE.md` only (cap 25, 3 sections, no secrets/PII). Use `--vault <path>` to validate CORE + ledger + SHARED as a v2 bundle. |
-| `wendkeep theme sync [--vault P]` | Re-apply the colour system (CSS snippet + graph groups) to an existing vault — recovers a grey graph without re-running `init`. |
-| `wendkeep doctor [--vault P]` | Read-only vault health check. Beyond sessions/registry, links, notes, prices, and derived sections, it checks the v2 bundle and points to `memory status --gate` or `memory repair`; doctor never projects or repairs by itself. |
-| `wendkeep --version` / `--help` | Version / usage. |
+The README is the map; the guides provide syntax, options, exit codes, examples, and diagnosis.
+
+| Group | Use it for | Detailed guide |
+|---|---|---|
+| **Installation and updates** | `init`, `sync`, companions, and the first project↔vault binding | [Installation and first use](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/getting-started.md) |
+| **Changes and verification** | `change`, specs, sensors, TDD, evidence, and archive | [Changes and verification](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/changes-and-verification.md) |
+| **Shared memory** | CORE, SHARED, status, validation, repair, and curation | [Memory](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/memory.md) |
+| **Sessions and import** | hooks, registry, session focus, and Claude/Codex backfill | [Sessions and import](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/sessions-and-import.md) |
+| **Notes and knowledge** | BUG/APR/ADR, repairs, renumbering, lessons, and dashboard | [Notes and knowledge](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/notes-and-knowledge.md) |
+| **Costs and observability** | stats, aggregation, trends, and historical rebuild | [Costs and observability](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/costs-and-observability.md) |
+| **Maintenance and diagnostics** | doctor, definition drift, theme, version, and help | [Maintenance and diagnostics](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/maintenance-and-diagnostics.md) |
+
+Operations that deserve step-by-step guidance: [verify and exits 0/1/2](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/verify.md),
+[legacy-memory migration](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/memory-migration.md), and
+[safe retroactive import](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/retroactive-import.md).
 
 ## Shared Project Memory v2
 

--- a/README.md
+++ b/README.md
@@ -152,41 +152,23 @@ versão anterior enquanto carimba a versão nova no metadado — o `doctor` para
 `defs stale` sem nenhuma skill ter sido atualizada. Se você editou uma `wk-*` à mão, a
 edição é sobrescrita; customização própria pertence a uma skill sua, que o reseed não toca.
 
-## Comandos
+## Funcionalidades por grupo
 
-| Comando | O que faz |
-|---|---|
-| `wendkeep init` | Configura o wendkeep num projeto (taxonomia do cofre + settings + MCP + skills). |
-| `wendkeep sync [--project P]` | **Atualização em um comando**: roda `init` → `sync-defs` → `doctor` no projeto atual, parando no primeiro passo que falhar. Instale o pacote antes (um processo não se auto-substitui). `--vault P` · `--yes` para não abrir o seletor de companions. |
-| `wendkeep hook <name>` | Roda um hook de sessão; invocado pelo `settings.json` (lê o JSON do agente no stdin). |
-| `wendkeep change <sub>` | Ciclo de mudança: `new <slug> [--simple]` / `use <slug>` (troca o foco) / `continue <arquivada> <nova> [--simple]` / `bind <slug> --session <id>` / `list` (backlog global) / `show <slug>` / `status [slug]` / `done <id> [--change slug]` / `undone <id> [--change slug]` / `relink [--apply] [--json]` (conserta os wikilinks das changes; prévia por padrão) / `diff [slug]` / `archive [slug] [--force]` / `abandon [slug]` (descarta sem ADR) / `backlink [--apply]` (injeta o backlink pra proposta em design/tarefas/spec órfãos). `diff`, `archive` e `abandon` caem na change ativa quando você omite o slug; o `status` pelado lista todas as abertas. |
-| `wendkeep verify [--deep] [--change s]` | Roda os sensores das tarefas da change; `--deep` monta o pacote de verificação independente. `--change` mira uma change que não é a ativa; `--project <raiz>` roda de fora da raiz. |
-| `wendkeep spec <sub>` | Specs vivos: `list` / `show <capability>` / `effective [--change <slug>] [--json]` (contrato vivo + delta; usa a change ativa por padrão) / `migrate` / `rebase [--accept-current]` (para em conflito, a não ser que você aceite o lado do spec vivo). |
-| `wendkeep sensors <sub>` | `list` / `add <id> "<comando>"` com `--severity` / `--type` / `--report` / `--name` / `--description` / `--project` — vê/edita `wendkeep.sensors.json` (JSON Schema incluso). |
-| `wendkeep cost [opts]` | Agrega o gasto de IA nas sessões do cofre — total, por modelo, por dia · `--since <data>` · `--top [N]` · `--trend [day\|week\|month]` (+ projeção) · `--write` (gera `00-Custo.md`) · `--json`. |
-| `wendkeep cost rebuild [opts]` | Reconstrói custos históricos do transcript principal e subagents via `SESSION_REGISTRY`. Dry-run por padrão; `--apply` grava notas e `.brain/COST_REBUILD.json`. Também `--session <id\|arquivo>` / `--limit n` / `--json`. |
-| `wendkeep session list\|show\|use` | Lista o registry multi-sessão, mostra uma conversa ou muda somente o foco humano de `CURRENT_SESSION.md`. |
-| `wendkeep stats [--vault P]` | Uma linha compartilhável: sessões · prompts · gasto · período · modelos (`--json`). |
-| `wendkeep import [opts]` | **Memória retroativa** — importa sessões passadas de **Claude + Codex** pro cofre (dedup por `session_id`). `--source all\|claude\|codex` / `--stamp-ids` / `--rescan-decisions` / `--from <dir>` / `--codex-from <dir>` / `--since d` / `--limit n` / `--dry-run` / `--json`. |
-| `wendkeep dashboard [--force]` | (Re)gera os Bases filtrados por pasta + o MOC `00-Dashboard`. |
-| `wendkeep note new --type bug\|learning "<título>"` | Cria uma nota derivada **numerada** (`BUG-`/`APR-NNNN`) na pasta do mês e imprime o caminho no cofre. `--date YYYY-MM-DD`. |
-| `wendkeep note relink [--apply]` | Preenche a proveniência das notas derivadas órfãs (BUG/APR sem sessão de origem), herdando a sessão modal dos irmãos do mesmo tipo e mês. Prévia por padrão. |
-| `wendkeep note repair-frontmatter [--apply]` | Funde blocos de frontmatter empilhados numa nota de sessão — dano de escrita concorrente das versões anteriores à 0.50. Chaves-base do bloco original, valores do mais recente; prévia por padrão · `--json`. |
-| `wendkeep note repair-sections [--apply]` | Reconstrói as seções `## Decisões/Bugs/Aprendizados gerados nesta sessão` a partir das notas derivadas ligadas — o corpo ficava para trás do `## Encerramento`. Prévia por padrão · `--json`. |
-| `wendkeep renumber-decisions` | Renumera `04-Decisões` pra `ADR-NNNN-<slug>` em ordem cronológica, tira as notas de subpastas legadas `DIA N` pra pasta do mês e reescreve os wikilinks. Prévia por padrão; `--apply` / `--json`. |
-| `wendkeep renumber-bugs` | Idem pra `05-Bugs` → `BUG-NNNN-<slug>`. |
-| `wendkeep renumber-learnings` | Idem pra `06-Aprendizados`/`06-Learnings` → `APR-NNNN-<slug>`. |
-| `wendkeep lesson add "t" "l"` | Registra uma lição local do projeto (injetada no próximo SessionStart). `--change <slug>` amarra a lição a uma change; `--vault P`. |
-| `wendkeep sync-defs` | Copia `.brain/agents\|skills` pro projeto (`.codex/agents`, `.claude/skills`, `.agents/skills`); `--check` detecta drift, `--reseed` ressemeia as skills `wk-*` com os seeds da versão instalada. |
-| `wendkeep memory status [--gate] --vault P` | Inspeciona o bundle v2 sem mutá-lo. `--gate` sai com código 1 apenas para estado bloqueante; avisos mantêm código 0. |
-| `wendkeep memory migrate [--apply] --vault P` | Converte um `SHARED_MEMORY.md` legado. É dry-run por padrão; `--apply` cria backup, transforma conteúdo legado em candidates e publica uma projeção v2 válida sem editar o CORE. |
-| `wendkeep memory repair --vault P` | Repara ledger parcial/corrompido sob lock, preservando os bytes originais em `.bak`, retendo eventos válidos e reprojetando o estado. |
-| `wendkeep memory promote <candidate> --vault P` | Promove um candidate por ID anexando um evento auditável; não edita o ledger no lugar. |
-| `wendkeep memory reject <candidate> --vault P` | Rejeita um candidate por ID anexando a decisão ao histórico auditável. |
-| `wendkeep validate-memory [path]` | Compatibilidade: valida somente `.brain/CORE.md` (cap 25, 3 seções, sem segredos/PII). Use `--vault <path>` para validar CORE + ledger + SHARED como bundle v2. |
-| `wendkeep theme sync [--vault P]` | Reaplica o sistema de cores (snippet CSS + grupos do grafo) num cofre existente — recupera o grafo cinza sem refazer o `init`. |
-| `wendkeep doctor [--vault P]` | Check read-only do cofre. Além de sessões/registry, links, notas, preços e derivadas, verifica o bundle v2 e indica `memory status --gate` ou `memory repair` quando necessário; o doctor nunca projeta nem repara por conta própria. |
-| `wendkeep --version` / `--help` | Versão / uso. |
+O README mostra o mapa; os guias trazem sintaxe, opções, códigos de saída, exemplos e diagnóstico.
+
+| Grupo | Use para | Guia detalhado |
+|---|---|---|
+| **Instalação e atualização** | `init`, `sync`, companions e primeiro vínculo projeto↔cofre | [Instalação e primeiro uso](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/getting-started.md) |
+| **Changes e verificação** | `change`, specs, sensores, TDD, evidência e archive | [Changes e verificação](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/changes-and-verification.md) |
+| **Memória compartilhada** | CORE, SHARED, status, validação, repair e curadoria | [Memória](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/memory.md) |
+| **Sessões e importação** | hooks, registry, foco de sessão e backfill Claude/Codex | [Sessões e importação](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/sessions-and-import.md) |
+| **Notas e conhecimento** | BUG/APR/ADR, reparos, renumeração, lessons e dashboard | [Notas e conhecimento](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/notes-and-knowledge.md) |
+| **Custos e observabilidade** | stats, agregação, tendências e rebuild histórico | [Custos e observabilidade](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/costs-and-observability.md) |
+| **Manutenção e diagnóstico** | doctor, drift de defs, tema, versão e ajuda | [Manutenção e diagnóstico](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/maintenance-and-diagnostics.md) |
+
+Operações que merecem instrução passo a passo: [verify e seus exits 0/1/2](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/verify.md),
+[migração de memória legada](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/memory-migration.md) e
+[importação retroativa segura](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/retroactive-import.md).
 
 ## Shared Project Memory v2
 

--- a/docs/.npmignore
+++ b/docs/.npmignore
@@ -1,0 +1,1 @@
+README.md

--- a/docs/en/commands/changes-and-verification.md
+++ b/docs/en/commands/changes-and-verification.md
@@ -1,0 +1,79 @@
+# Changes, specs, sensors, and archive
+
+**English** · [Português](../../pt-BR/commands/changes-and-verification.md)
+
+## Purpose
+
+Carry a change from recorded intent to an archived decision, linking requirements, tasks,
+sensors, evidence, and verdict in the vault graph.
+
+## When to use
+
+Use for any non-trivial implementation or fix that must leave auditable proof.
+
+## When not to use
+
+Do not create a change merely to inspect health, import sessions, or run read-only maintenance.
+
+## Prerequisites
+
+Initialize the project, keep the vault healthy, and provide a valid `wendkeep.sensors.json`.
+
+## Syntax
+
+```bash
+npx wendkeep change new <slug>
+npx wendkeep change status [slug]
+npx wendkeep spec effective --change <slug>
+npx wendkeep sensors list
+npx wendkeep verify [--deep] [--change <slug>]
+npx wendkeep change archive <slug>
+```
+
+## Options and exit codes
+
+- `wendkeep change new <slug> [--simple]` creates proposal, design, tasks, and active pointer.
+- `change use`, `list`, `show`, `status`, `diff`, `done`, and `undone` inspect or update work
+  without archiving it.
+- `change continue <archived> <new>` starts follow-up work without inheriting stale proof.
+- `change bind <slug> --session <id>` attaches an existing session.
+- `change relink [--apply]` and `change backlink [--apply]` repair graph links; preview is default.
+- `change abandon <slug>` drops work without an ADR; `archive --force` needs explicit human choice.
+- `wendkeep spec list|show|effective|migrate|rebase` manages living contracts and deltas.
+- `wendkeep sensors list|add` manages executable proof.
+- Exit `0` means completion; gates use exit `1` for red proof and exit `2` for invalid
+  context/usage.
+
+## Examples
+
+```bash
+npx wendkeep change new tenant-login
+npx wendkeep spec effective --change tenant-login
+npx wendkeep change done 1.1 --change tenant-login
+npx wendkeep verify --change tenant-login
+npx wendkeep verify --deep --change tenant-login
+npx wendkeep change archive tenant-login
+```
+
+Add a sensor:
+
+```bash
+npx wendkeep sensors add api-contracts "npm run test:contracts" --severity critical
+```
+
+## Expected result
+
+An archived change promotes its delta into the living spec, preserves proposal/design/tasks/proof,
+and mints an ADR. Archive passes only with closed tasks, green required sensors, and a fresh verdict.
+
+## Common errors and diagnosis
+
+- `no change`: select one with `change use <slug>` or pass `--change`.
+- `spec_impact: pending`: choose `required` with a delta or `none` with a real reason.
+- Sensor not executed: keep `[sensor:id]` on the same checkbox line as the task.
+- Stale evidence: rerun `verify` and `verify --deep` after task/spec edits.
+- Rebase conflict: resolve the delta or use `--accept-current` only when that is the decision.
+
+## Next steps
+
+Read the deep [verify guide](verify.md) and [maintenance and diagnostics](maintenance-and-diagnostics.md).

--- a/docs/en/commands/costs-and-observability.md
+++ b/docs/en/commands/costs-and-observability.md
@@ -1,0 +1,65 @@
+# Costs and observability
+
+**English** · [Português](../../pt-BR/commands/costs-and-observability.md)
+
+## Purpose
+
+Measure sessions, prompts, models, and AI spend, and rebuild historical costs from canonical
+transcripts when required.
+
+## When to use
+
+Use `stats` for a quick view, `cost` for analysis, and `cost rebuild` when older notes lack
+trustworthy costs.
+
+## When not to use
+
+Do not apply rebuild before validating each session's provider and transcript. Do not compare
+projects whose registries are mixed.
+
+## Prerequisites
+
+A consistent registry, complete price table, and transcript access for rebuilt sessions.
+
+## Syntax
+
+```bash
+npx wendkeep stats [--vault <vault>] [--json]
+npx wendkeep cost [--since <date>] [--top [N]] [--trend day|week|month] [--write] [--json]
+npx wendkeep cost rebuild [--session <id|file>] [--limit N] [--apply] [--json]
+```
+
+## Options and exit codes
+
+- `wendkeep stats` emits one shareable line or JSON.
+- `wendkeep cost` aggregates total/model/day; `--trend` adds projection and `--write` refreshes
+  `00-Custo.md`.
+- `wendkeep cost rebuild` is dry-run by default; `--apply` writes notes and
+  `.brain/COST_REBUILD.json`.
+- Exit `0` means a consistent calculation; non-zero reports insufficient registry, price,
+  transcript, or parsing state.
+
+## Examples
+
+```bash
+npx wendkeep stats --vault .MyApp-vault
+npx wendkeep cost --since 2026-07-01 --top 10 --trend week
+npx wendkeep cost rebuild --session 019abc --json
+```
+
+## Expected result
+
+Totals retain input/output/cache/reasoning dimensions by model and period. Rebuild shows a preview
+before changing notes and leaves a reproducible report when applied.
+
+## Common errors and diagnosis
+
+- Model without a price: update the table before accepting totals.
+- Wrong-provider costs: validate the session identity chain.
+- Missing transcript: do not estimate silently; keep the gap visible.
+- Duplicated parent/subagent/fork totals: verify registry relationships and deduplication.
+
+## Next steps
+
+See [sessions and import](sessions-and-import.md), [retroactive import](retroactive-import.md), and
+[maintenance](maintenance-and-diagnostics.md).

--- a/docs/en/commands/getting-started.md
+++ b/docs/en/commands/getting-started.md
@@ -1,0 +1,82 @@
+# Installation and first use
+
+**English** · [Português](../../pt-BR/commands/getting-started.md)
+
+## Purpose
+
+Install WendKeep, bind the project to the correct vault, and enable capture, memory, and skills
+without overwriting existing configuration.
+
+## When to use
+
+Use `wendkeep init` for the first installation and `wendkeep sync` after updating the package.
+
+## When not to use
+
+Do not run `init --force` as a generic repair for memory or unreadable configuration. Run
+`wendkeep doctor` first and follow the repair command it reports.
+
+## Prerequisites
+
+- Node.js 18 or newer.
+- A local project and write access to the vault.
+- Claude Code or Codex; Obsidian is optional at runtime and recommended for graph navigation.
+
+## Syntax
+
+```bash
+npm install --save-dev wendkeep
+npx wendkeep init [options]
+npx wendkeep sync [--project <root>] [--vault <vault>] [--yes]
+```
+
+## Options and exit codes
+
+- `--vault <path>` selects the vault; otherwise the local `.wendkeep.json` binding wins.
+- `--project <path>` selects the project root.
+- `--no-mcp`, `--no-colors`, and `--no-companions` disable optional integrations.
+- `--companions <csv>` explicitly enables companion integrations.
+- `--yes` accepts non-interactive defaults; `--force` refreshes managed blocks only.
+- Exit `0` means setup/sync completed. Any other exit identifies the failed stage. `sync` stops at
+  `init`, `sync-defs`, or `doctor` instead of hiding the error.
+
+## Examples
+
+First installation in the current project:
+
+```bash
+npm install --save-dev wendkeep
+npx wendkeep init --no-companions
+```
+
+Later update:
+
+```bash
+npm install --save-dev wendkeep@latest
+npx wendkeep sync --yes
+```
+
+With pnpm, pin a concrete version because minimum-release-age policies may keep `latest` silently
+behind:
+
+```bash
+pnpm add -D wendkeep@0.58.2
+pnpm exec wendkeep sync --yes
+```
+
+## Expected result
+
+The project receives `.wendkeep.json`, managed Claude/Codex hooks, skill definitions, and an
+initialized vault. Existing files are merged or preserved, and the selected vault is printed.
+
+## Common errors and diagnosis
+
+- Wrong vault: inspect `.wendkeep.json` and run `wendkeep doctor --vault <path>`.
+- Codex hooks do not run: approve **Hooks need review** on the next startup.
+- `defs stale`: run `wendkeep sync-defs --reseed`, then restart the agents.
+- `sync` stops at doctor: read the failing section; do not retry with `--force` blindly.
+
+## Next steps
+
+Continue with [maintenance and diagnostics](maintenance-and-diagnostics.md),
+[sessions and import](sessions-and-import.md), and [shared memory](memory.md).

--- a/docs/en/commands/maintenance-and-diagnostics.md
+++ b/docs/en/commands/maintenance-and-diagnostics.md
@@ -1,0 +1,66 @@
+# Maintenance and diagnostics
+
+**English** · [Português](../../pt-BR/commands/maintenance-and-diagnostics.md)
+
+## Purpose
+
+Inspect vault health and keep definitions, theme, and package version aligned without treating
+change commands as global checks.
+
+## When to use
+
+Use after install/update, when hooks emit warnings, or before starting a change.
+
+## When not to use
+
+Do not run `wendkeep verify` when no change is active. It proves a change's tasks; it is not a
+replacement for doctor.
+
+## Prerequisites
+
+Run from the project root or provide `--project` and `--vault` explicitly.
+
+## Syntax
+
+```bash
+npx wendkeep doctor [--vault <vault>]
+npx wendkeep sync-defs [--check|--reseed] --vault <vault> --project <root>
+npx wendkeep theme sync --vault <vault>
+npx wendkeep --version
+npx wendkeep --help
+```
+
+## Options and exit codes
+
+- `doctor` is read-only; exit `0` accepts recoverable warnings, while non-zero means failure.
+- `sync-defs --check` detects drift without writes; `--reseed` restores packaged `wk-*` skills.
+- `theme sync` reapplies the CSS snippet and graph groups without recreating the vault.
+- `wendkeep --version` prints the running version; `wendkeep --help` lists the public interface.
+
+## Examples
+
+Post-update checklist:
+
+```bash
+npx wendkeep --version
+npx wendkeep sync-defs --check --vault .MyApp-vault --project .
+npx wendkeep doctor --vault .MyApp-vault
+npx wendkeep memory status --gate --vault .MyApp-vault
+```
+
+## Expected result
+
+Doctor names sessions, registry, links, notes, prices, derived sections, and memory as healthy or
+provides a specific diagnostic/repair command. It never repairs implicitly.
+
+## Common errors and diagnosis
+
+- `no vault`: run from the bound root or pass `--vault`.
+- `defs stale`: confirm the version and run `sync-defs --reseed`.
+- Legacy vault: this is a non-blocking warning; plan `memory migrate --apply` separately.
+- Corrupt bundle: preserve evidence and run `memory status --gate` before `memory repair`.
+
+## Next steps
+
+See [installation and first use](getting-started.md), [memory](memory.md), and
+[change verification](verify.md).

--- a/docs/en/commands/memory-migration.md
+++ b/docs/en/commands/memory-migration.md
@@ -1,0 +1,64 @@
+# Legacy-to-v2 memory migration
+
+**English** · [Português](../../pt-BR/commands/memory-migration.md)
+
+## Purpose
+
+Convert a legacy `SHARED_MEMORY.md` into an auditable v2 bundle without overwriting CORE or
+silently promoting old reports.
+
+## When to use
+
+Use when `memory status` reports `legacy` and the team is ready to curate converted content.
+
+## When not to use
+
+Do not migrate automatically during `init`, `sync`, SessionStop, or merely to silence a warning.
+Do not apply until the backup and expected state are understood.
+
+## Prerequisites
+
+- Valid CORE and preserved legacy bytes.
+- No partially corrupt v2 bundle.
+- Human review of the candidates that will be created.
+
+## Syntax
+
+```bash
+npx wendkeep memory status --gate --vault <vault>
+npx wendkeep memory migrate --vault <vault>
+npx wendkeep memory migrate --apply --vault <vault>
+```
+
+## Options and exit codes
+
+- Without `--apply`, `wendkeep memory migrate` is a zero-write dry run.
+- `--apply` creates a backup, converts legacy content into candidates, and publishes valid v2.
+- Exit `0` means a consistent preview/application; non-zero preserves original state and reports
+  the failure.
+
+## Examples
+
+```bash
+npx wendkeep memory migrate --vault .MyApp-vault
+# review the preview
+npx wendkeep memory migrate --apply --vault .MyApp-vault
+npx wendkeep memory status --gate --vault .MyApp-vault
+```
+
+## Expected result
+
+The vault receives a coherent v2 ledger/projection, a backup of legacy SHARED, and candidates for
+unsupported facts. CORE is untouched and unverified content is not activated automatically.
+
+## Common errors and diagnosis
+
+- Dry run says already v2: do not apply again.
+- Partial/corrupt v2 bundle: use status and repair; migration is not a corruption tool.
+- Many candidates: curate gradually with `memory promote`/`memory reject`.
+- Legacy warning remains after apply: verify the selected vault and project binding.
+
+## Next steps
+
+Return to [memory and curation](memory.md) and run
+[maintenance and diagnostics](maintenance-and-diagnostics.md).

--- a/docs/en/commands/memory.md
+++ b/docs/en/commands/memory.md
@@ -1,0 +1,67 @@
+# Shared memory and curation
+
+**English** · [Português](../../pt-BR/commands/memory.md)
+
+## Purpose
+
+Inspect and curate CORE, SHARED, ledger, outbox, and candidates without confusing canonical
+authorship with generated operational state.
+
+## When to use
+
+Use in CI, before verify/archive, after doctor warnings, or when deciding candidates.
+
+## When not to use
+
+Do not hand-edit `SHARED_MEMORY.md` or `MEMORY_EVENTS.jsonl`. Do not repair a healthy legacy vault
+that merely awaits migration.
+
+## Prerequisites
+
+Pass the vault explicitly in automation. Preserve backups and evidence before repair.
+
+## Syntax
+
+```bash
+npx wendkeep memory status [--gate] --vault <vault>
+npx wendkeep memory repair --vault <vault>
+npx wendkeep memory promote <candidate> --vault <vault>
+npx wendkeep memory reject <candidate> --vault <vault>
+npx wendkeep validate-memory [CORE-path]
+npx wendkeep validate-memory --vault <v2-vault>
+```
+
+## Options and exit codes
+
+- `memory status` is read-only; `--gate` exits `1` only for blocking state.
+- A valid legacy vault warns and exits `0`; corruption, lag/hash mismatch, or active blocking
+  conflict exits `1`.
+- `memory repair` locks, writes a `.bak`, retains valid events, and reprojects state.
+- `promote`/`reject` append auditable decisions and never rewrite the ledger in place.
+- `validate-memory <CORE.md>` checks the 25-line cap, required sections, and secrets.
+- `validate-memory --vault` requires a complete v2 bundle and is not the legacy-vault gate.
+
+## Examples
+
+```bash
+npx wendkeep memory status --gate --vault .MyApp-vault
+npx wendkeep validate-memory .MyApp-vault/.brain/CORE.md
+npx wendkeep memory promote candidate-123 --vault .MyApp-vault
+```
+
+## Expected result
+
+Status prints schema, revision, cursor, hash, events, outbox, candidates, and conflicts. CORE stays
+hand-curated and canonical; SHARED stays a verifiable operational projection.
+
+## Common errors and diagnosis
+
+- `legacy`: follow the migration guide; this is not corruption.
+- Ordinary pending candidate: recoverable warning, requiring human choice when appropriate.
+- Missing `event_cursor` or mismatched v2 hash: preserve the bundle and assess `memory repair`.
+- `validate-memory --vault` fails on legacy: validate CORE only or migrate first.
+
+## Next steps
+
+Read [memory migration](memory-migration.md), [maintenance](maintenance-and-diagnostics.md), and
+[verify](verify.md).

--- a/docs/en/commands/notes-and-knowledge.md
+++ b/docs/en/commands/notes-and-knowledge.md
@@ -1,0 +1,70 @@
+# Derived notes and knowledge graph
+
+**English** · [Português](../../pt-BR/commands/notes-and-knowledge.md)
+
+## Purpose
+
+Create, repair, number, and navigate decisions, bugs, and learnings while preserving provenance
+and wikilinks.
+
+## When to use
+
+Use to record durable knowledge or repair historical notes diagnosed by doctor.
+
+## When not to use
+
+Do not hand-edit numbering or wikilinks in bulk. Do not use `--apply` before reviewing the preview.
+
+## Prerequisites
+
+A bound vault, identifiable source session, and backup before broad renumbering.
+
+## Syntax
+
+```bash
+npx wendkeep dashboard [--force]
+npx wendkeep note new --type bug|learning "<title>"
+npx wendkeep note relink [--apply]
+npx wendkeep note repair-frontmatter [--apply]
+npx wendkeep note repair-sections [--apply]
+npx wendkeep renumber-decisions [--apply]
+npx wendkeep renumber-bugs [--apply]
+npx wendkeep renumber-learnings [--apply]
+npx wendkeep lesson add "<title>" "<lesson>"
+```
+
+## Options and exit codes
+
+- `note new` creates a monthly `BUG-NNNN` or `APR-NNNN` and accepts `--date`.
+- `note relink`, `repair-frontmatter`, `repair-sections`, and `renumber-*` default to dry-run;
+  `--apply` writes and `--json` supports audit.
+- `dashboard --force` regenerates Bases/MOC when required.
+- `lesson add` accepts `--change <slug>` and `--vault` to bind local learning.
+- Exit `0` means a consistent preview/application; non-zero makes incomplete repair explicit.
+
+## Examples
+
+```bash
+npx wendkeep note new --type bug "refresh expires during upload"
+npx wendkeep note relink --json
+npx wendkeep renumber-decisions --json
+# review before repeating with --apply
+npx wendkeep dashboard --force
+```
+
+## Expected result
+
+Derived notes live in the month folder, use global per-type numbering, and link back to the source
+session. Repairs preserve valid frontmatter and rewrite wikilinks when files move.
+
+## Common errors and diagnosis
+
+- Orphan note without a modal source: `note relink` reports it and does not invent provenance.
+- Stacked frontmatter: repair under the same lock used by hooks.
+- Grey links after renumber/archive: preview relink and inspect ambiguities.
+- Sensitive title: remove secrets/PII before persistence.
+
+## Next steps
+
+See [sessions and import](sessions-and-import.md), [costs and observability](costs-and-observability.md),
+and [maintenance](maintenance-and-diagnostics.md).

--- a/docs/en/commands/retroactive-import.md
+++ b/docs/en/commands/retroactive-import.md
@@ -1,0 +1,67 @@
+# Safe retroactive import
+
+**English** · [Português](../../pt-BR/commands/retroactive-import.md)
+
+## Purpose
+
+Import historical Claude and Codex sessions with bounded scope, stable identity, and review before
+writes.
+
+## When to use
+
+Use when installing WendKeep in an existing project, recovering a date range, or rescanning
+decisions without importing every transcript on the machine.
+
+## When not to use
+
+Do not use `--source all` without dry-run on machines with many projects, forks, or subagent
+rollouts. Do not treat imported conversation history as current implementation evidence.
+
+## Prerequisites
+
+Confirm project, vault, provider, source directory, and date window. Back up the registry if it
+already contains manual repairs.
+
+## Syntax
+
+```bash
+npx wendkeep import --dry-run --json
+npx wendkeep import --source claude|codex|all [--since <date>] [--limit <n>]
+npx wendkeep import --from <claude-dir> --codex-from <codex-dir>
+npx wendkeep import --stamp-ids | --rescan-decisions
+```
+
+## Options and exit codes
+
+- `--source` bounds provider; `--since` and `--limit` bound volume.
+- `--from`/`--codex-from` override discovered directories.
+- `--dry-run` performs zero writes; `--json` emits an auditable report.
+- `--stamp-ids` fills IDs in existing notes; `--rescan-decisions` reruns prose extraction.
+- Exit `0` means a consistent scan/import; non-zero requires fixing source, parsing, or identity
+  before retrying.
+
+## Examples
+
+```bash
+npx wendkeep import --source codex --since 2026-07-20 --limit 20 --dry-run --json
+# inspect accepted/skipped/forks
+npx wendkeep import --source codex --since 2026-07-20 --limit 20
+```
+
+## Expected result
+
+Accepted sessions enter once per `session_id` with matching provider/transcript. Canonical
+duplicates are skipped; forks/subagents retain origin relationships instead of copying inherited
+history into another full independent conversation.
+
+## Common errors and diagnosis
+
+- Cross-project contamination: stop and verify cwd, binding, and filters before cleaning notes.
+- Ordinary fork imported as full session: inspect `forked_from_id` and source payload.
+- Note without `session_id`: use `--stamp-ids` only after dry-run.
+- Missing decisions in an imported note: prefer `--rescan-decisions` over duplicating the session.
+
+## Next steps
+
+Return to [sessions and hooks](sessions-and-import.md), generate [costs](costs-and-observability.md),
+and review [derived notes](notes-and-knowledge.md).

--- a/docs/en/commands/sessions-and-import.md
+++ b/docs/en/commands/sessions-and-import.md
@@ -1,0 +1,69 @@
+# Sessions, hooks, and import
+
+**English** · [Português](../../pt-BR/commands/sessions-and-import.md)
+
+## Purpose
+
+Understand how hooks capture live sessions, how the registry selects conversations, and when to
+use retroactive import.
+
+## When to use
+
+Use `session` to inspect/focus a conversation and `import` to recover sessions from before setup or
+outside the current registry.
+
+## When not to use
+
+Do not invoke hooks manually without their expected JSON envelope. Do not run broad imports before
+a preview when forks/subagents may duplicate history.
+
+## Prerequisites
+
+Installed hooks for live capture; for imports, local access to Claude/Codex transcript directories
+and a vault bound to the correct project.
+
+## Syntax
+
+```bash
+npx wendkeep hook <name>
+npx wendkeep session list
+npx wendkeep session show <id>
+npx wendkeep session use <id>
+npx wendkeep import [options]
+```
+
+## Options and exit codes
+
+- `wendkeep hook <name>` reads the agent payload from stdin; valid names are listed by `--help`.
+- `session list` reads `SESSION_REGISTRY`; `show` displays one session and `use` only changes human
+  focus in `CURRENT_SESSION.md`.
+- `import --source all|claude|codex`, `--since`, `--limit`, `--from`, and `--codex-from` bound scope.
+- `--dry-run`/`--json` support audit before writes; `--stamp-ids` and `--rescan-decisions` address
+  specific historical gaps.
+- Exit `0` means consistent processing; non-zero reports invalid source/config/write instead of
+  presenting silent partial success.
+
+## Examples
+
+```bash
+npx wendkeep session list
+npx wendkeep session show 019abc-session-id
+npx wendkeep import --source codex --since 2026-07-01 --dry-run --json
+```
+
+## Expected result
+
+Each canonical session points to the matching provider, transcript, note file, and costs. Repeated
+imports of the same `session_id` deduplicate; human focus does not close or re-identify live hooks.
+
+## Common errors and diagnosis
+
+- Missing session: verify provider, transcript path, and registry before importing again.
+- Fork duplicates: bound source/date and inspect `forked_from_id`/`source.subagent`.
+- Codex does not capture: approve hooks and start a new session after `sync`.
+- Contaminated cost: validate `session_id → session_file → transcript_path → provider`.
+
+## Next steps
+
+Read [retroactive import](retroactive-import.md), [costs and observability](costs-and-observability.md),
+and [notes](notes-and-knowledge.md).

--- a/docs/en/commands/verify.md
+++ b/docs/en/commands/verify.md
@@ -1,0 +1,86 @@
+# Verify and independent verification
+
+**English** · [Português](../../pt-BR/commands/verify.md)
+
+## Purpose
+
+Run the sensors required by a change's tasks, persist fresh evidence, and assemble the
+self-contained package consumed by the independent `wk-verify` pass.
+
+## When to use
+
+Run after implementing tasks and again whenever tasks, specs, or tests change.
+
+## When not to use
+
+Do not use it as a post-install health check or when no change exists. Run `wendkeep doctor` and
+`wendkeep memory status --gate` instead.
+
+## Prerequisites
+
+- An open change selected through `CURRENT_CHANGE.md` or `--change <slug>`.
+- A placeholder-free `tarefas.md` with `[req:]` and `[sensor:]` tags on checkbox lines.
+- Sensors declared in `wendkeep.sensors.json`.
+
+## Syntax
+
+```bash
+npx wendkeep verify [--change <slug>] [--project <root>] [--vault <vault>]
+npx wendkeep verify --deep [--change <slug>]
+npx wendkeep change use <slug>
+```
+
+## Options and exit codes
+
+- `--change <slug>` targets a change without changing the active pointer.
+- `change use <slug>` persists focus for following commands.
+- `--project <root>` selects the sensor cwd; `--vault` selects where proof is stored.
+- **Exit 0:** all required sensors passed and evidence was written.
+- **Exit 1:** the gate ran, but at least one critical sensor was red or a mutant survived.
+- **Exit 2:** invalid usage/context, including `no change (--change or active)`, missing vault,
+  unknown change, or invalid `wendkeep.sensors.json`.
+
+`verify --deep` writes `verificacao.json`; it does not replace the reviewer. The `wk-verify` skill
+must be run by a different author and writes `verdict.json`.
+
+## Examples
+
+Active change:
+
+```bash
+npx wendkeep verify
+npx wendkeep verify --deep
+```
+
+Explicit change:
+
+```bash
+npx wendkeep verify --change tenant-login
+npx wendkeep verify --deep --change tenant-login
+```
+
+Project with no open change:
+
+```bash
+npx wendkeep doctor --vault .MyApp-vault
+npx wendkeep memory status --gate --vault .MyApp-vault
+```
+
+## Expected result
+
+`evidencia.json` contains sensor results and a seal binds proof to the current `tarefas.md` hash.
+Deep mode packages requirements, tasks, and evidence for read-only review; the verdict covers every
+`[req:]` before archive.
+
+## Common errors and diagnosis
+
+- `no change`: this is exit 2 and a valid idle state; create/use a change or skip verify.
+- Zero sensors: inspect same-line tags and `sensors list`.
+- Red gate: fix the cause and rerun; never choose `archive --force` on your own.
+- Missing/stale verdict: regenerate `--deep` and request a fresh independent pass.
+- Surviving mutants: strengthen the discriminating test; after three rounds, review manually.
+
+## Next steps
+
+Return to the [change lifecycle](changes-and-verification.md) for archive, or use
+[maintenance](maintenance-and-diagnostics.md) when no change exists.

--- a/docs/pt-BR/commands/changes-and-verification.md
+++ b/docs/pt-BR/commands/changes-and-verification.md
@@ -1,0 +1,80 @@
+# Changes, specs, sensores e archive
+
+**PT-BR** · [English](../../en/commands/changes-and-verification.md)
+
+## Objetivo
+
+Conduzir uma mudança desde a intenção registrada até uma decisão arquivada, ligando requisitos,
+tarefas, sensores, evidência e verdict no grafo do cofre.
+
+## Quando usar
+
+Use para qualquer implementação não trivial ou correção que precise deixar prova auditável.
+
+## Quando não usar
+
+Não crie uma change para consultar saúde, importar sessões ou executar manutenção read-only.
+
+## Pré-requisitos
+
+Tenha o projeto inicializado, um vault saudável e `wendkeep.sensors.json` válido na raiz.
+
+## Sintaxe
+
+```bash
+npx wendkeep change new <slug>
+npx wendkeep change status [slug]
+npx wendkeep spec effective --change <slug>
+npx wendkeep sensors list
+npx wendkeep verify [--deep] [--change <slug>]
+npx wendkeep change archive <slug>
+```
+
+## Opções e códigos de saída
+
+- `wendkeep change new <slug> [--simple]` cria proposta, design, tarefas e ponteiro ativo.
+- `change use`, `list`, `show`, `status`, `diff`, `done` e `undone` inspecionam ou atualizam o
+  trabalho sem arquivar.
+- `change continue <arquivada> <nova>` abre continuação sem herdar evidência antiga.
+- `change bind <slug> --session <id>` liga uma sessão existente.
+- `change relink [--apply]` e `change backlink [--apply]` reparam o grafo; dry-run é o padrão.
+- `change abandon <slug>` descarta sem ADR; `archive --force` exige decisão humana explícita.
+- `wendkeep spec list|show|effective|migrate|rebase` administra contratos vivos e deltas.
+- `wendkeep sensors list|add` administra provas executáveis.
+- Exit `0` indica comando concluído; os gates usam exit `1` para prova vermelha e exit `2` para
+  contexto/uso inválido.
+
+## Exemplos
+
+```bash
+npx wendkeep change new login-tenant
+npx wendkeep spec effective --change login-tenant
+npx wendkeep change done 1.1 --change login-tenant
+npx wendkeep verify --change login-tenant
+npx wendkeep verify --deep --change login-tenant
+npx wendkeep change archive login-tenant
+```
+
+Para adicionar um sensor:
+
+```bash
+npx wendkeep sensors add api-contracts "npm run test:contracts" --severity critical
+```
+
+## Resultado esperado
+
+A change arquivada move seu delta para o spec vivo, preserva proposta/design/tarefas/evidência e
+gera um ADR. O archive só passa com tarefas fechadas, sensores exigidos verdes e verdict atual.
+
+## Erros comuns e diagnóstico
+
+- `no change`: selecione com `change use <slug>` ou informe `--change`.
+- `spec_impact: pending`: defina `required` com delta ou `none` com justificativa real.
+- Sensor não executado: mantenha `[sensor:id]` na mesma linha do checkbox da tarefa.
+- Evidência stale: rode novamente `verify` e `verify --deep` depois de alterar tarefas/spec.
+- Rebase em conflito: resolva o delta ou use `--accept-current` apenas quando isso for a decisão.
+
+## Próximos passos
+
+Leia o guia profundo de [verify](verify.md) e a referência de
+[manutenção e diagnóstico](maintenance-and-diagnostics.md).

--- a/docs/pt-BR/commands/costs-and-observability.md
+++ b/docs/pt-BR/commands/costs-and-observability.md
@@ -1,0 +1,65 @@
+# Custos e observabilidade
+
+**PT-BR** · [English](../../en/commands/costs-and-observability.md)
+
+## Objetivo
+
+Medir sessões, prompts, modelos e custo de IA, além de reconstruir históricos a partir dos
+transcripts canônicos quando necessário.
+
+## Quando usar
+
+Use `stats` para visão rápida, `cost` para análise e `cost rebuild` quando notas antigas não têm
+custos confiáveis.
+
+## Quando não usar
+
+Não aplique rebuild antes de validar provider e transcript de cada sessão. Não compare custos de
+projetos com registries misturados.
+
+## Pré-requisitos
+
+Registry consistente, tabela de preços completa e acesso aos transcripts das sessões reconstruídas.
+
+## Sintaxe
+
+```bash
+npx wendkeep stats [--vault <cofre>] [--json]
+npx wendkeep cost [--since <data>] [--top [N]] [--trend day|week|month] [--write] [--json]
+npx wendkeep cost rebuild [--session <id|arquivo>] [--limit N] [--apply] [--json]
+```
+
+## Opções e códigos de saída
+
+- `wendkeep stats` gera uma linha compartilhável ou JSON.
+- `wendkeep cost` agrega total/modelo/dia; `--trend` inclui projeção e `--write` atualiza
+  `00-Custo.md`.
+- `wendkeep cost rebuild` é dry-run por padrão; `--apply` grava notas e
+  `.brain/COST_REBUILD.json`.
+- Exit `0` indica cálculo consistente; não zero indica registry, preço, transcript ou parsing
+  insuficiente.
+
+## Exemplos
+
+```bash
+npx wendkeep stats --vault .MeuApp-vault
+npx wendkeep cost --since 2026-07-01 --top 10 --trend week
+npx wendkeep cost rebuild --session 019abc --json
+```
+
+## Resultado esperado
+
+Totais preservam dimensões de input/output/cache/reasoning por modelo e período. Rebuild mostra a
+prévia antes de alterar notas e deixa um relatório reproduzível quando aplicado.
+
+## Erros comuns e diagnóstico
+
+- Modelo sem preço: atualize a tabela antes de aceitar o total.
+- Custos de provider errado: valide a cadeia de identidade da sessão.
+- Transcript ausente: não estime silenciosamente; mantenha a lacuna visível.
+- Total duplicado por subagent/fork: confirme relação pai/subagent e deduplicação do registry.
+
+## Próximos passos
+
+Veja [sessões e importação](sessions-and-import.md), [importação retroativa](retroactive-import.md)
+e [manutenção](maintenance-and-diagnostics.md).

--- a/docs/pt-BR/commands/getting-started.md
+++ b/docs/pt-BR/commands/getting-started.md
@@ -1,0 +1,83 @@
+# Instalação e primeiro uso
+
+**PT-BR** · [English](../../en/commands/getting-started.md)
+
+## Objetivo
+
+Instalar o WendKeep, vincular o projeto ao cofre correto e ativar captura, memória e skills sem
+sobrescrever configurações existentes.
+
+## Quando usar
+
+Use `wendkeep init` na primeira instalação e `wendkeep sync` depois de atualizar o pacote.
+
+## Quando não usar
+
+Não rode `init --force` para tentar reparar memória ou uma configuração ilegível. Use primeiro
+`wendkeep doctor` e o comando de reparo indicado.
+
+## Pré-requisitos
+
+- Node.js 18 ou mais recente.
+- Projeto local e permissão de escrita no cofre.
+- Claude Code ou Codex; Obsidian é opcional para execução e recomendado para navegar no grafo.
+
+## Sintaxe
+
+```bash
+npm install --save-dev wendkeep
+npx wendkeep init [opções]
+npx wendkeep sync [--project <raiz>] [--vault <cofre>] [--yes]
+```
+
+## Opções e códigos de saída
+
+- `--vault <path>` escolhe o cofre; sem ele, o vínculo local `.wendkeep.json` prevalece.
+- `--project <path>` aponta a raiz do projeto.
+- `--no-mcp`, `--no-colors` e `--no-companions` desativam integrações opcionais.
+- `--companions <csv>` habilita companions explicitamente.
+- `--yes` aceita defaults não interativos; `--force` atualiza apenas blocos gerenciados.
+- Exit `0` indica instalação/sincronização concluída; exit diferente de zero identifica a etapa
+  que falhou. `sync` para em `init`, `sync-defs` ou `doctor`, sem esconder o erro.
+
+## Exemplos
+
+Primeira instalação no projeto atual:
+
+```bash
+npm install --save-dev wendkeep
+npx wendkeep init --no-companions
+```
+
+Atualização posterior:
+
+```bash
+npm install --save-dev wendkeep@latest
+npx wendkeep sync --yes
+```
+
+Com pnpm, informe uma versão concreta porque políticas de idade mínima podem manter `latest`
+atrasado silenciosamente:
+
+```bash
+pnpm add -D wendkeep@0.58.2
+pnpm exec wendkeep sync --yes
+```
+
+## Resultado esperado
+
+O projeto recebe `.wendkeep.json`, hooks gerenciados de Claude/Codex, definições de skills e um
+cofre inicializado. Arquivos preexistentes são mesclados ou preservados; o comando informa o
+cofre efetivamente selecionado.
+
+## Erros comuns e diagnóstico
+
+- Cofre errado: confira `.wendkeep.json` e rode `wendkeep doctor --vault <path>`.
+- Hooks do Codex não executam: aprove o aviso **Hooks need review** no próximo startup.
+- `defs stale`: rode `wendkeep sync-defs --reseed` e reinicie os agentes.
+- `sync` para no doctor: leia a seção que falhou; não repita com `--force` sem entender a causa.
+
+## Próximos passos
+
+Veja [manutenção e diagnóstico](maintenance-and-diagnostics.md),
+[sessões e importação](sessions-and-import.md) e [memória compartilhada](memory.md).

--- a/docs/pt-BR/commands/maintenance-and-diagnostics.md
+++ b/docs/pt-BR/commands/maintenance-and-diagnostics.md
@@ -1,0 +1,66 @@
+# Manutenção e diagnóstico
+
+**PT-BR** · [English](../../en/commands/maintenance-and-diagnostics.md)
+
+## Objetivo
+
+Inspecionar a saúde do cofre e manter definições, tema e versão alinhados sem usar comandos de
+change como teste global.
+
+## Quando usar
+
+Use depois de instalar/atualizar, diante de warnings dos hooks ou antes de iniciar uma change.
+
+## Quando não usar
+
+Não use `wendkeep verify` quando nenhuma change estiver ativa. Ele prova tarefas de uma change;
+não substitui o doctor.
+
+## Pré-requisitos
+
+Execute na raiz do projeto ou informe `--project`/`--vault` explicitamente.
+
+## Sintaxe
+
+```bash
+npx wendkeep doctor [--vault <cofre>]
+npx wendkeep sync-defs [--check|--reseed] --vault <cofre> --project <raiz>
+npx wendkeep theme sync --vault <cofre>
+npx wendkeep --version
+npx wendkeep --help
+```
+
+## Opções e códigos de saída
+
+- `doctor` é read-only; exit `0` aceita warnings recuperáveis e exit não zero indica falha.
+- `sync-defs --check` detecta drift sem gravar; `--reseed` restaura skills `wk-*` do pacote.
+- `theme sync` reaplica snippet CSS e grupos do grafo sem recriar o cofre.
+- `wendkeep --version` imprime a versão executada; `wendkeep --help` lista a interface pública.
+
+## Exemplos
+
+Checklist pós-atualização:
+
+```bash
+npx wendkeep --version
+npx wendkeep sync-defs --check --vault .MeuApp-vault --project .
+npx wendkeep doctor --vault .MeuApp-vault
+npx wendkeep memory status --gate --vault .MeuApp-vault
+```
+
+## Resultado esperado
+
+O doctor nomeia sessões, registry, links, notas, preços, derivadas e memória como saudáveis ou
+fornece um comando específico de diagnóstico/reparo. Nenhum reparo é aplicado implicitamente.
+
+## Erros comuns e diagnóstico
+
+- `no vault`: execute da raiz vinculada ou passe `--vault`.
+- `defs stale`: confirme a versão e rode `sync-defs --reseed`.
+- Vault legado: é warning não bloqueante; planeje `memory migrate --apply` separadamente.
+- Bundle corrompido: preserve a evidência e use `memory status --gate` antes de `memory repair`.
+
+## Próximos passos
+
+Veja [instalação e primeiro uso](getting-started.md), [memória](memory.md) e
+[verificação de changes](verify.md).

--- a/docs/pt-BR/commands/memory-migration.md
+++ b/docs/pt-BR/commands/memory-migration.md
@@ -1,0 +1,64 @@
+# Migração de memória legada para v2
+
+**PT-BR** · [English](../../en/commands/memory-migration.md)
+
+## Objetivo
+
+Converter um `SHARED_MEMORY.md` legado em bundle v2 auditável sem sobrescrever CORE nem promover
+relatos antigos silenciosamente.
+
+## Quando usar
+
+Use quando `memory status` retorna `legacy` e a equipe está pronta para curar o conteúdo convertido.
+
+## Quando não usar
+
+Não migre automaticamente durante `init`, `sync`, SessionStop ou como tentativa de silenciar um
+warning. Não aplique enquanto um backup/estado esperado não estiver claro.
+
+## Pré-requisitos
+
+- CORE válido e bytes legados preservados.
+- Vault sem corrupção v2 parcial.
+- Revisão humana dos candidates que serão criados.
+
+## Sintaxe
+
+```bash
+npx wendkeep memory status --gate --vault <cofre>
+npx wendkeep memory migrate --vault <cofre>
+npx wendkeep memory migrate --apply --vault <cofre>
+```
+
+## Opções e códigos de saída
+
+- Sem `--apply`, `wendkeep memory migrate` é dry-run e não grava.
+- `--apply` cria backup, converte conteúdo legado em candidates e publica bundle v2 válido.
+- Exit `0` indica prévia/aplicação consistente; exit diferente de zero preserva o estado original
+  e informa a falha.
+
+## Exemplos
+
+```bash
+npx wendkeep memory migrate --vault .MeuApp-vault
+# revise a prévia
+npx wendkeep memory migrate --apply --vault .MeuApp-vault
+npx wendkeep memory status --gate --vault .MeuApp-vault
+```
+
+## Resultado esperado
+
+O vault recebe ledger/projeção v2 coerentes, backup do SHARED legado e candidates para fatos sem
+evidência. CORE não é editado e conteúdo não verificado não vira estado ativo automaticamente.
+
+## Erros comuns e diagnóstico
+
+- Dry-run mostra vault já v2: não aplique novamente.
+- Bundle v2 parcial/corrompido: use status e repair; migração não é ferramenta de corrupção.
+- Candidates numerosos: curate gradualmente com `memory promote`/`memory reject`.
+- Warning legado após apply: confirme o vault efetivamente selecionado e o vínculo do projeto.
+
+## Próximos passos
+
+Volte para [memória e curadoria](memory.md) e execute
+[manutenção e diagnóstico](maintenance-and-diagnostics.md).

--- a/docs/pt-BR/commands/memory.md
+++ b/docs/pt-BR/commands/memory.md
@@ -1,0 +1,67 @@
+# Memória compartilhada e curadoria
+
+**PT-BR** · [English](../../en/commands/memory.md)
+
+## Objetivo
+
+Inspecionar e curar CORE, SHARED, ledger, outbox e candidates sem confundir autoria canônica com
+estado operacional gerado.
+
+## Quando usar
+
+Use no CI, antes de verify/archive, diante de avisos do doctor ou para decidir candidates.
+
+## Quando não usar
+
+Não edite `SHARED_MEMORY.md` ou `MEMORY_EVENTS.jsonl` à mão. Não use repair em vault legado que
+apenas aguarda migração.
+
+## Pré-requisitos
+
+Informe o vault explicitamente em automações. Preserve backups e evidências antes de reparar.
+
+## Sintaxe
+
+```bash
+npx wendkeep memory status [--gate] --vault <cofre>
+npx wendkeep memory repair --vault <cofre>
+npx wendkeep memory promote <candidate> --vault <cofre>
+npx wendkeep memory reject <candidate> --vault <cofre>
+npx wendkeep validate-memory [caminho-do-CORE]
+npx wendkeep validate-memory --vault <cofre-v2>
+```
+
+## Opções e códigos de saída
+
+- `memory status` é read-only; `--gate` retorna exit `1` apenas para estado bloqueante.
+- Vault legado válido gera warning e exit `0`; corrupção, lag/hash divergente ou conflito ativo
+  bloqueante gera exit `1`.
+- `memory repair` trabalha sob lock, salva `.bak`, retém eventos válidos e reprojeta.
+- `promote`/`reject` acrescentam decisão auditável; nunca reescrevem o ledger no lugar.
+- `validate-memory <CORE.md>` valida cap de 25 linhas, seções e segredos.
+- `validate-memory --vault` exige bundle v2 completo; não é o gate correto para vault legado.
+
+## Exemplos
+
+```bash
+npx wendkeep memory status --gate --vault .MeuApp-vault
+npx wendkeep validate-memory .MeuApp-vault/.brain/CORE.md
+npx wendkeep memory promote candidate-123 --vault .MeuApp-vault
+```
+
+## Resultado esperado
+
+O status imprime schema, revision, cursor, hash, eventos, outbox, candidates e conflitos. CORE
+permanece canônico e curado à mão; SHARED permanece projeção operacional verificável.
+
+## Erros comuns e diagnóstico
+
+- `legacy`: siga o guia de migração; não é corrupção.
+- Candidate pendente comum: warning recuperável, exige decisão humana quando apropriado.
+- `event_cursor` ausente ou hash divergente em v2: preserve o bundle e avalie `memory repair`.
+- `validate-memory --vault` falha no legado: valide apenas CORE ou migre primeiro.
+
+## Próximos passos
+
+Leia [migração de memória](memory-migration.md), [manutenção](maintenance-and-diagnostics.md) e
+[verify](verify.md).

--- a/docs/pt-BR/commands/notes-and-knowledge.md
+++ b/docs/pt-BR/commands/notes-and-knowledge.md
@@ -1,0 +1,69 @@
+# Notas derivadas e grafo de conhecimento
+
+**PT-BR** · [English](../../en/commands/notes-and-knowledge.md)
+
+## Objetivo
+
+Criar, reparar, numerar e navegar decisões, bugs e aprendizados mantendo proveniência e wikilinks.
+
+## Quando usar
+
+Use para registrar conhecimento durável ou reparar notas históricas diagnosticadas pelo doctor.
+
+## Quando não usar
+
+Não edite numeração e wikilinks em massa à mão. Não use `--apply` sem conferir a prévia.
+
+## Pré-requisitos
+
+Vault vinculado, sessão de origem identificável e backup antes de renumerações amplas.
+
+## Sintaxe
+
+```bash
+npx wendkeep dashboard [--force]
+npx wendkeep note new --type bug|learning "<título>"
+npx wendkeep note relink [--apply]
+npx wendkeep note repair-frontmatter [--apply]
+npx wendkeep note repair-sections [--apply]
+npx wendkeep renumber-decisions [--apply]
+npx wendkeep renumber-bugs [--apply]
+npx wendkeep renumber-learnings [--apply]
+npx wendkeep lesson add "<título>" "<lição>"
+```
+
+## Opções e códigos de saída
+
+- `note new` cria `BUG-NNNN` ou `APR-NNNN` no mês e aceita `--date`.
+- `note relink`, `repair-frontmatter`, `repair-sections` e `renumber-*` são dry-run por padrão;
+  `--apply` grava e `--json` facilita auditoria.
+- `dashboard --force` regenera Bases/MOC quando necessário.
+- `lesson add` aceita `--change <slug>` e `--vault` para ligar aprendizado local.
+- Exit `0` indica prévia/aplicação consistente; não zero deixa o reparo incompleto explícito.
+
+## Exemplos
+
+```bash
+npx wendkeep note new --type bug "refresh expira durante upload"
+npx wendkeep note relink --json
+npx wendkeep renumber-decisions --json
+# revise antes de repetir com --apply
+npx wendkeep dashboard --force
+```
+
+## Resultado esperado
+
+Notas derivadas vivem na pasta do mês, têm numeração global do tipo e backlink para a sessão. Os
+reparos preservam frontmatter válido e reescrevem wikilinks quando arquivos mudam.
+
+## Erros comuns e diagnóstico
+
+- Nota órfã sem fonte modal: `note relink` informa que não consegue inferir e não inventa vínculo.
+- Frontmatter empilhado: use repair sob o mesmo lock dos hooks.
+- Links cinza após renumber/archive: rode prévia de relink e confirme ambiguidades.
+- Título sensível: remova secrets/PII antes de persistir.
+
+## Próximos passos
+
+Veja [sessões e importação](sessions-and-import.md),
+[custos e observabilidade](costs-and-observability.md) e [manutenção](maintenance-and-diagnostics.md).

--- a/docs/pt-BR/commands/retroactive-import.md
+++ b/docs/pt-BR/commands/retroactive-import.md
@@ -1,0 +1,67 @@
+# Importação retroativa segura
+
+**PT-BR** · [English](../../en/commands/retroactive-import.md)
+
+## Objetivo
+
+Importar sessões históricas de Claude e Codex com escopo controlado, identidade estável e revisão
+antes da escrita.
+
+## Quando usar
+
+Use ao instalar o WendKeep num projeto existente, recuperar uma faixa de datas ou reprocessar
+decisões sem importar o mundo inteiro.
+
+## Quando não usar
+
+Não use `--source all` sem dry-run em máquinas com muitos projetos, forks ou rollouts de subagents.
+Não trate transcript importado como evidência de implementação atual.
+
+## Pré-requisitos
+
+Confirme projeto, vault, provider, diretório fonte e janela temporal. Faça backup se o registry já
+contiver reparos manuais.
+
+## Sintaxe
+
+```bash
+npx wendkeep import --dry-run --json
+npx wendkeep import --source claude|codex|all [--since <data>] [--limit <n>]
+npx wendkeep import --from <claude-dir> --codex-from <codex-dir>
+npx wendkeep import --stamp-ids | --rescan-decisions
+```
+
+## Opções e códigos de saída
+
+- `--source` limita provider; `--since` e `--limit` limitam volume.
+- `--from`/`--codex-from` substituem diretórios descobertos.
+- `--dry-run` não grava e `--json` produz relatório auditável.
+- `--stamp-ids` preenche IDs em notas existentes; `--rescan-decisions` reaplica extração de prosa.
+- Exit `0` indica varredura/importação consistente; exit diferente de zero exige resolver fonte,
+  parsing ou identidade antes de repetir.
+
+## Exemplos
+
+```bash
+npx wendkeep import --source codex --since 2026-07-20 --limit 20 --dry-run --json
+# confira accepted/skipped/forks
+npx wendkeep import --source codex --since 2026-07-20 --limit 20
+```
+
+## Resultado esperado
+
+Sessões aceitas entram uma vez por `session_id`, com provider e transcript corretos. Duplicatas
+canônicas são ignoradas; forks/subagents preservam relação de origem em vez de copiar toda a
+história herdada como uma nova conversa independente.
+
+## Erros comuns e diagnóstico
+
+- Contaminação entre projetos: pare e confira cwd, binding e filtros antes de limpar qualquer nota.
+- Fork comum importado como sessão cheia: inspecione `forked_from_id` e payload de origem.
+- Nota sem `session_id`: use `--stamp-ids` somente após dry-run.
+- Decisões faltantes em nota já importada: prefira `--rescan-decisions` a duplicar a sessão.
+
+## Próximos passos
+
+Volte para [sessões e hooks](sessions-and-import.md), gere [custos](costs-and-observability.md) e
+revise [notas derivadas](notes-and-knowledge.md).

--- a/docs/pt-BR/commands/sessions-and-import.md
+++ b/docs/pt-BR/commands/sessions-and-import.md
@@ -1,0 +1,70 @@
+# Sessões, hooks e importação
+
+**PT-BR** · [English](../../en/commands/sessions-and-import.md)
+
+## Objetivo
+
+Entender como hooks capturam sessões ao vivo, como o registry seleciona conversas e quando usar a
+importação retroativa.
+
+## Quando usar
+
+Use `session` para inspecionar/focar uma conversa e `import` para recuperar sessões anteriores à
+instalação ou fora do registry atual.
+
+## Quando não usar
+
+Não invoque hooks manualmente sem o envelope JSON esperado. Não use import amplo antes de uma
+prévia quando existirem forks/subagents possivelmente duplicados.
+
+## Pré-requisitos
+
+Hooks instalados para captura ao vivo; para import, acesso local aos diretórios de transcripts do
+Claude/Codex e um vault vinculado ao projeto correto.
+
+## Sintaxe
+
+```bash
+npx wendkeep hook <nome>
+npx wendkeep session list
+npx wendkeep session show <id>
+npx wendkeep session use <id>
+npx wendkeep import [opções]
+```
+
+## Opções e códigos de saída
+
+- `wendkeep hook <name>` lê o payload do agente em stdin; nomes válidos aparecem em `--help`.
+- `session list` lê `SESSION_REGISTRY`; `show` exibe uma sessão e `use` muda apenas o foco humano
+  em `CURRENT_SESSION.md`.
+- `import --source all|claude|codex`, `--since`, `--limit`, `--from` e `--codex-from` limitam escopo.
+- `--dry-run`/`--json` permitem auditar antes de gravar; `--stamp-ids` e `--rescan-decisions`
+  corrigem históricos específicos.
+- Exit `0` indica processamento consistente; exit não zero indica configuração, fonte ou escrita
+  inválida sem transformar isso em sucesso parcial silencioso.
+
+## Exemplos
+
+```bash
+npx wendkeep session list
+npx wendkeep session show 019abc-session-id
+npx wendkeep import --source codex --since 2026-07-01 --dry-run --json
+```
+
+## Resultado esperado
+
+Cada sessão canônica aponta para provider, transcript, arquivo de nota e custos correspondentes.
+Importações repetidas do mesmo `session_id` são deduplicadas; o foco humano não encerra nem altera
+a identidade da sessão ativa dos hooks.
+
+## Erros comuns e diagnóstico
+
+- Sessão ausente: confira provider, path do transcript e registry antes de importar novamente.
+- Duplicatas de forks: limite por fonte/data e revise `forked_from_id`/`source.subagent`.
+- Codex não captura: aprove os hooks e reinicie a sessão após `sync`.
+- Custo contaminado: valide `session_id → session_file → transcript_path → provider`.
+
+## Próximos passos
+
+Leia [importação retroativa](retroactive-import.md),
+[custos e observabilidade](costs-and-observability.md) e [notas](notes-and-knowledge.md).

--- a/docs/pt-BR/commands/verify.md
+++ b/docs/pt-BR/commands/verify.md
@@ -1,0 +1,87 @@
+# Verify e verificação independente
+
+**PT-BR** · [English](../../en/commands/verify.md)
+
+## Objetivo
+
+Executar os sensores exigidos pelas tarefas de uma change, persistir evidência fresca e montar o
+pacote autocontido usado pelo passe independente `wk-verify`.
+
+## Quando usar
+
+Use depois de implementar as tarefas e novamente sempre que tarefas, specs ou testes mudarem.
+
+## Quando não usar
+
+Não use como health check pós-instalação ou quando não existe change. Nesse caso, rode
+`wendkeep doctor` e `wendkeep memory status --gate`.
+
+## Pré-requisitos
+
+- Change aberta selecionada por `CURRENT_CHANGE.md` ou `--change <slug>`.
+- `tarefas.md` sem placeholders, com tags `[req:]` e `[sensor:]` na linha do checkbox.
+- Sensores declarados em `wendkeep.sensors.json`.
+
+## Sintaxe
+
+```bash
+npx wendkeep verify [--change <slug>] [--project <raiz>] [--vault <cofre>]
+npx wendkeep verify --deep [--change <slug>]
+npx wendkeep change use <slug>
+```
+
+## Opções e códigos de saída
+
+- `--change <slug>` mira uma change sem alterar o ponteiro ativo.
+- `change use <slug>` troca o foco persistido para comandos seguintes.
+- `--project <raiz>` define onde os sensores executam; `--vault` define onde a prova é gravada.
+- **Exit 0:** todos os sensores exigidos passaram e a evidência foi gravada.
+- **Exit 1:** o gate executou, mas ao menos um sensor crítico ficou vermelho ou um mutante
+  sobreviveu.
+- **Exit 2:** uso/contexto inválido, como `no change (--change or active)`, vault ausente,
+  change inexistente ou `wendkeep.sensors.json` inválido.
+
+`verify --deep` gera `verificacao.json`; ele não substitui o verificador. A skill `wk-verify`
+precisa ser executada por autor diferente e grava `verdict.json`.
+
+## Exemplos
+
+Change ativa:
+
+```bash
+npx wendkeep verify
+npx wendkeep verify --deep
+```
+
+Change explícita:
+
+```bash
+npx wendkeep verify --change tenant-login
+npx wendkeep verify --deep --change tenant-login
+```
+
+Projeto sem change aberta:
+
+```bash
+npx wendkeep doctor --vault .MeuApp-vault
+npx wendkeep memory status --gate --vault .MeuApp-vault
+```
+
+## Resultado esperado
+
+`evidencia.json` contém resultados dos sensores e um selo liga a prova ao hash atual de
+`tarefas.md`. No deep, o pacote contém requisitos, tarefas e evidência suficientes para revisão
+read-only; o verdict cobre cada `[req:]` antes do archive.
+
+## Erros comuns e diagnóstico
+
+- `no change`: isso é exit 2 e estado ocioso válido; crie/use uma change ou não rode verify.
+- Zero sensores: confira tags na mesma linha e `sensors list`.
+- Gate vermelho: corrija a causa e repita; não use `archive --force` por conta própria.
+- Verdict stale/ausente: regenere `--deep` e peça novo passe independente.
+- Mutantes sobreviventes: fortaleça o teste discriminante; após três rodadas, revise manualmente.
+
+## Próximos passos
+
+Volte ao [ciclo de changes](changes-and-verification.md) para archive ou consulte
+[manutenção](maintenance-and-diagnostics.md) quando não houver change.

--- a/docs/superpowers/specs/2026-07-26-bilingual-command-guides-design.md
+++ b/docs/superpowers/specs/2026-07-26-bilingual-command-guides-design.md
@@ -1,0 +1,169 @@
+# Design — guias bilíngues dos comandos WendKeep
+
+**Status:** aprovado em conversa em 2026-07-26  
+**Escopo:** exclusivamente o repositório `C:\GitHub\WendKeep`
+
+## Problema
+
+Os READMEs em PT-BR e inglês acumulam instalação, visão de produto, referência de comandos
+e procedimentos operacionais extensos. A tabela única não deixa claro quando cada comando
+deve ser usado, confunde `verify` com um health check global e torna difícil manter exemplos,
+códigos de saída e diagnóstico em paridade entre os idiomas.
+
+## Objetivos
+
+1. Transformar `README.md` e `README.en.md` em vitrines curtas, navegáveis e agrupadas.
+2. Documentar todos os comandos públicos em guias detalhados, espelhados em PT-BR e inglês.
+3. Dar páginas próprias aos fluxos complexos de verificação, migração de memória e importação
+   retroativa.
+4. Impedir drift entre idiomas, links quebrados e documentação ausente no pacote npm.
+5. Tornar obrigatória a atualização da documentação quando a interface observável mudar.
+
+## Fora do escopo
+
+- Alterar comportamento, flags ou códigos de saída do CLI.
+- Traduzir o acervo histórico já existente em `docs/`.
+- Criar site, gerador estático ou tradução automática.
+- Documentar APIs internas que não fazem parte do CLI público.
+- Alterar `AGENTS.md`, vaults ou arquivos de Vendiva, NutriGym-Vision ou qualquer outro projeto
+  consumidor do WendKeep.
+
+## Abordagens consideradas
+
+1. **Um arquivo por grupo:** poucos arquivos, mas fluxos complexos continuam longos e difíceis
+   de linkar com precisão.
+2. **Um arquivo por comando:** navegação precisa, porém dezenas de pares bilíngues e alto custo
+   de manutenção.
+3. **Híbrida — escolhida:** sete guias temáticos e três páginas profundas para operações que
+   exigem contexto, estados e recuperação detalhada.
+
+## Arquitetura de arquivos
+
+Os diretórios de idiomas são espelhados e usam os mesmos slugs para permitir validação
+mecânica de paridade:
+
+```text
+README.md
+README.en.md
+docs/
+├── pt-BR/commands/
+│   ├── getting-started.md
+│   ├── changes-and-verification.md
+│   ├── memory.md
+│   ├── sessions-and-import.md
+│   ├── notes-and-knowledge.md
+│   ├── costs-and-observability.md
+│   ├── maintenance-and-diagnostics.md
+│   ├── verify.md
+│   ├── memory-migration.md
+│   └── retroactive-import.md
+└── en/commands/
+    └── os mesmos dez arquivos
+```
+
+## Responsabilidade de cada guia
+
+| Guia | Superfície pública |
+|---|---|
+| `getting-started.md` | instalação, `init`, `sync`, opções iniciais e atualização segura |
+| `changes-and-verification.md` | `change`, `spec`, `sensors` e visão do ciclo `verify`/archive |
+| `memory.md` | `memory status`, `repair`, `promote`, `reject` e `validate-memory` |
+| `sessions-and-import.md` | `hook`, `session` e visão geral de `import` |
+| `notes-and-knowledge.md` | `dashboard`, `note`, `renumber-*` e `lesson` |
+| `costs-and-observability.md` | `cost`, `cost rebuild` e `stats` |
+| `maintenance-and-diagnostics.md` | `doctor`, `sync-defs`, `theme sync`, `--version` e `--help` |
+| `verify.md` | requisitos de contexto, sensores, `--deep`, códigos de saída e diagnóstico |
+| `memory-migration.md` | legado versus v2, dry-run, apply, backup, candidates e recuperação |
+| `retroactive-import.md` | fontes Claude/Codex, deduplicação, forks, dry-run e limites de escopo |
+
+## Contrato editorial dos guias
+
+Cada par usa a mesma ordem de seções e cobre o mesmo comportamento:
+
+1. Objetivo.
+2. Quando usar e quando não usar.
+3. Pré-requisitos.
+4. Sintaxe.
+5. Opções e códigos de saída.
+6. Exemplos executáveis.
+7. Resultado esperado.
+8. Erros comuns e diagnóstico.
+9. Próximos passos e guias relacionados.
+
+A tradução precisa ser semanticamente equivalente, mas não precisa ser linha a linha. Termos
+técnicos, comandos e caminhos permanecem literais.
+
+## Tratamento específico de `verify`
+
+O guia individual deve separar explicitamente:
+
+- `exit 0`: sensores exigidos pela change passaram;
+- `exit 1`: o gate foi executado e ficou vermelho;
+- `exit 2`: contexto ou uso inválido, inclusive ausência de `--change` e de change ativa;
+- `verify`/`verify --deep`: provas de uma change, não health check global;
+- `doctor`/`memory status --gate`: checks apropriados quando não existe change;
+- `--change <slug>` e `change use <slug>`: seleção explícita versus ponteiro ativo.
+
+## READMEs e navegação
+
+Os READMEs preservam proposta de valor, requisitos, instalação e primeiro uso. A tabela longa
+de comandos vira uma visão por grupos contendo finalidade, dois ou três comandos representativos
+e links para o guia no idioma correspondente. Fluxos complexos recebem links diretos para suas
+páginas profundas.
+
+Links dos READMEs para os guias usam URLs absolutas do GitHub, de modo que funcionem tanto no
+repositório quanto na página do npm. Os guias usam links relativos para navegar entre páginas e
+oferecem um link visível para o par no outro idioma.
+
+## Distribuição npm
+
+`package.json` passa a incluir somente `docs/pt-BR/commands/` e `docs/en/commands/` além dos
+arquivos já publicados. O acervo histórico de `docs/` permanece fora do tarball. O teste de
+empacotamento prova que os vinte guias e os dois READMEs estão presentes.
+
+Como os READMEs e novos guias alteram o artefato distribuído, a entrega recebe bump patch para
+`0.58.2` e uma entrada de documentação no `CHANGELOG.md` conforme a regra de release.
+
+## Regra permanente do repositório
+
+Fora do bloco gerenciado de `AGENTS.md`, será adicionada uma regra exclusiva do WendKeep:
+
+> Toda alteração em comando, flag, código de saída, fluxo, hook ou comportamento observável deve
+> atualizar, no mesmo commit, o resumo do README e o par PT-BR/EN correspondente. Nenhum idioma
+> pode ficar atrás do outro.
+
+Essa regra não entra nos seeds de skills nem é propagada por `init`, `sync` ou `sync-defs` aos
+projetos consumidores.
+
+## Validação automatizada
+
+Um teste dedicado deve:
+
+1. Comparar o conjunto de arquivos em `docs/pt-BR/commands/` e `docs/en/commands/`.
+2. Exigir a estrutura mínima do contrato editorial em cada guia.
+3. Validar todos os links Markdown locais nos READMEs e nos vinte guias.
+4. Garantir que cada README aponte apenas para os guias do próprio idioma e para o alternador
+   de idioma correto.
+5. Manter um inventário dos comandos públicos e exigir presença em ambos os idiomas.
+6. Exigir no `AGENTS.md` a regra de atualização bilíngue fora do bloco gerenciado.
+
+O teste de empacotamento existente será estendido para abrir o tarball e confirmar os guias.
+Os sensores normais do projeto continuam responsáveis pela suíte completa e pelo release gate.
+
+## Falhas e manutenção
+
+- Guia ausente em um idioma: teste vermelho com o caminho complementar esperado.
+- Link quebrado: teste vermelho com arquivo, alvo e link de origem.
+- Comando público sem documentação: teste vermelho nomeando o comando ausente.
+- Estrutura divergente: teste vermelho nomeando a seção obrigatória ausente.
+- Guia ausente no tarball: teste de empacotamento vermelho antes da publicação.
+
+## Critérios de aceite
+
+1. Os READMEs apresentam as funcionalidades por grupos e levam aos guias corretos.
+2. Existem dez guias PT-BR e dez guias EN com paridade estrutural e sem links quebrados.
+3. `verify` não pode mais ser interpretado como health check pós-instalação.
+4. Todos os comandos públicos atuais aparecem nos dois idiomas.
+5. `AGENTS.md` obriga manutenção bilíngue apenas neste repositório.
+6. O tarball `0.58.2` contém os READMEs e os vinte guias.
+7. Testes focados, suíte, `wendkeep verify` e `verify --deep` ficam verdes antes do archive.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.58.1",
+  "version": "0.58.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.58.1",
+      "version": "0.58.2",
       "license": "MIT",
       "bin": {
         "wendkeep": "bin/wendkeep.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.58.1",
+  "version": "0.58.2",
   "description": "A persistent-memory harness for AI coding agents on your Obsidian vault: turn-by-turn session capture plus a native, zero-dependency spec→change→verify→archive loop (sensor-gated, independent verdict, mutation discrimination). Local-first, agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "bin": {
@@ -12,6 +12,8 @@
     "src",
     "hooks",
     "schema",
+    "docs/pt-BR/commands/*.md",
+    "docs/en/commands/*.md",
     "README.md",
     "README.en.md",
     "CHANGELOG.md"

--- a/tests/docs-bilingual.test.mjs
+++ b/tests/docs-bilingual.test.mjs
@@ -1,0 +1,269 @@
+// DOC-1..DOC-7 — the public CLI documentation is a bilingual, navigable package surface.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const GUIDES = [
+  'getting-started.md',
+  'changes-and-verification.md',
+  'memory.md',
+  'sessions-and-import.md',
+  'notes-and-knowledge.md',
+  'costs-and-observability.md',
+  'maintenance-and-diagnostics.md',
+  'verify.md',
+  'memory-migration.md',
+  'retroactive-import.md',
+];
+const GUIDE_DIR = {
+  pt: join(ROOT, 'docs', 'pt-BR', 'commands'),
+  en: join(ROOT, 'docs', 'en', 'commands'),
+};
+const REQUIRED_SECTIONS = {
+  pt: [
+    'Objetivo', 'Quando usar', 'Quando não usar', 'Pré-requisitos', 'Sintaxe',
+    'Opções e códigos de saída', 'Exemplos', 'Resultado esperado',
+    'Erros comuns e diagnóstico', 'Próximos passos',
+  ],
+  en: [
+    'Purpose', 'When to use', 'When not to use', 'Prerequisites', 'Syntax',
+    'Options and exit codes', 'Examples', 'Expected result',
+    'Common errors and diagnosis', 'Next steps',
+  ],
+};
+const README_GROUPS = [
+  { pt: 'Instalação e atualização', en: 'Installation and updates', guide: 'getting-started.md' },
+  { pt: 'Changes e verificação', en: 'Changes and verification', guide: 'changes-and-verification.md' },
+  { pt: 'Memória compartilhada', en: 'Shared memory', guide: 'memory.md' },
+  { pt: 'Sessões e importação', en: 'Sessions and import', guide: 'sessions-and-import.md' },
+  { pt: 'Notas e conhecimento', en: 'Notes and knowledge', guide: 'notes-and-knowledge.md' },
+  { pt: 'Custos e observabilidade', en: 'Costs and observability', guide: 'costs-and-observability.md' },
+  { pt: 'Manutenção e diagnóstico', en: 'Maintenance and diagnostics', guide: 'maintenance-and-diagnostics.md' },
+];
+const DEEP_GUIDES = ['verify.md', 'memory-migration.md', 'retroactive-import.md'];
+const GUIDE_FOR_FAMILY = new Map([
+  ['wendkeep init', 'getting-started.md'], ['wendkeep sync', 'getting-started.md'],
+  ['wendkeep hook', 'sessions-and-import.md'], ['wendkeep doctor', 'maintenance-and-diagnostics.md'],
+  ['wendkeep change', 'changes-and-verification.md'], ['wendkeep theme sync', 'maintenance-and-diagnostics.md'],
+  ['wendkeep session', 'sessions-and-import.md'], ['wendkeep spec', 'changes-and-verification.md'],
+  ['wendkeep sensors', 'changes-and-verification.md'], ['wendkeep cost', 'costs-and-observability.md'],
+  ['wendkeep cost rebuild', 'costs-and-observability.md'], ['wendkeep stats', 'costs-and-observability.md'],
+  ['wendkeep import', 'sessions-and-import.md'], ['wendkeep verify', 'changes-and-verification.md'],
+  ['wendkeep dashboard', 'notes-and-knowledge.md'], ['wendkeep renumber-decisions', 'notes-and-knowledge.md'],
+  ['wendkeep renumber-bugs', 'notes-and-knowledge.md'], ['wendkeep renumber-learnings', 'notes-and-knowledge.md'],
+  ['wendkeep note new', 'notes-and-knowledge.md'], ['wendkeep note relink', 'notes-and-knowledge.md'],
+  ['wendkeep note repair-frontmatter', 'notes-and-knowledge.md'],
+  ['wendkeep note repair-sections', 'notes-and-knowledge.md'], ['wendkeep lesson add', 'notes-and-knowledge.md'],
+  ['wendkeep memory', 'memory.md'], ['wendkeep validate-memory', 'memory.md'],
+  ['wendkeep sync-defs', 'maintenance-and-diagnostics.md'], ['wendkeep --version', 'maintenance-and-diagnostics.md'],
+  ['wendkeep --help', 'maintenance-and-diagnostics.md'],
+]);
+const SEMANTIC_CONCEPTS = {
+  'getting-started.md': { pt: [/instala/i, /atualiza/i, /vínculo|vincul/i], en: [/install/i, /updat/i, /bind/i] },
+  'changes-and-verification.md': { pt: [/change/i, /sensor/i, /evidência/i], en: [/change/i, /sensor/i, /evidence/i] },
+  'memory.md': { pt: [/canônic/i, /operacional/i, /curadoria/i], en: [/canonical/i, /operational/i, /curation/i] },
+  'sessions-and-import.md': { pt: [/sess/i, /registro|registry/i, /import/i], en: [/session/i, /registry/i, /import/i] },
+  'notes-and-knowledge.md': { pt: [/nota/i, /renumer/i, /conhecimento/i], en: [/note/i, /renumber/i, /knowledge/i] },
+  'costs-and-observability.md': { pt: [/custo/i, /tendência|projeção|trend/i, /históric/i], en: [/cost/i, /trend/i, /historical/i] },
+  'maintenance-and-diagnostics.md': { pt: [/diagnóstic/i, /drift/i, /versão/i], en: [/diagnos/i, /drift/i, /version/i] },
+  'verify.md': { pt: [/sensor/i, /evidência/i, /independente/i], en: [/sensor/i, /evidence/i, /independent/i] },
+  'memory-migration.md': { pt: [/legad/i, /migra/i, /dry[- ]run/i], en: [/legacy/i, /migrat/i, /dry[- ]run/i] },
+  'retroactive-import.md': { pt: [/retroativ/i, /deduplic|duplicata/i, /fork/i], en: [/retroactive/i, /deduplic|duplicate/i, /fork/i] },
+};
+
+const markdownLinks = (text) => [...text.matchAll(/\[[^\]]*\]\(([^)]+)\)/g)].map((m) => m[1]);
+
+function anchorFor(heading) {
+  return heading
+    .trim()
+    .toLowerCase()
+    .replace(/<[^>]+>/g, '')
+    .replace(/[`*_~]/g, '')
+    .replace(/[^\p{L}\p{N}\s-]/gu, '')
+    .replace(/\s/g, '-');
+}
+
+function assertLocalLinksResolve(sourcePath) {
+  const source = readFileSync(sourcePath, 'utf8');
+  for (const rawLink of markdownLinks(source)) {
+    if (/^(?:https?:|mailto:)/i.test(rawLink)) continue;
+    const [rawTarget, rawAnchor = ''] = rawLink.split('#', 2);
+    const targetPath = rawTarget
+      ? resolve(dirname(sourcePath), decodeURIComponent(rawTarget))
+      : sourcePath;
+    assert.ok(existsSync(targetPath), `${sourcePath}: link local ausente: ${rawLink}`);
+    assert.ok(statSync(targetPath).isFile(), `${sourcePath}: link local não aponta para arquivo: ${rawLink}`);
+    if (rawAnchor) {
+      const target = readFileSync(targetPath, 'utf8');
+      const anchors = [...target.matchAll(/^#{1,6}\s+(.+)$/gm)].map((m) => anchorFor(m[1]));
+      assert.ok(anchors.includes(decodeURIComponent(rawAnchor)),
+        `${sourcePath}: âncora local ausente: ${rawLink}`);
+    }
+  }
+}
+
+function section(text, heading) {
+  const lines = text.split(/\r?\n/);
+  const start = lines.indexOf(`## ${heading}`);
+  if (start < 0) return '';
+  const relativeEnd = lines.slice(start + 1).findIndex((line) => line.startsWith('## '));
+  const end = relativeEnd < 0 ? lines.length : start + 1 + relativeEnd;
+  return lines.slice(start + 1, end).join('\n');
+}
+
+function normalizedCommandSurface(text, heading) {
+  return section(text, heading)
+    .split(/\r?\n/)
+    .filter((line) => /\bwendkeep\b/.test(line))
+    .map((line) => line.trim().replace(/^npx\s+/, '')
+      .replace(/<[^>]+>/g, '<arg>')
+      .replace(/"<[^"]+>"/g, '"<arg>"')
+      .replace(/\[(?:opções|options|caminho-do-CORE|CORE-path)\]/gi, '[arg]'))
+    .sort();
+}
+
+function assertReadmeGroups(text, locale) {
+  const body = section(text, locale === 'pt' ? 'Funcionalidades por grupo' : 'Features by group');
+  const rows = body.split(/\r?\n/).filter((line) => /^\| \*\*/.test(line));
+  assert.equal(rows.length, README_GROUPS.length, `${locale}: deve haver exatamente sete grupos`);
+  README_GROUPS.forEach((group, index) => {
+    assert.match(rows[index], new RegExp(`\\*\\*${group[locale]}\\*\\*`), `${locale}: grupo ${index + 1}`);
+    assert.ok(rows[index].includes(`/docs/${locale === 'pt' ? 'pt-BR' : 'en'}/commands/${group.guide}`),
+      `${locale}: ${group[locale]} deve apontar para ${group.guide}`);
+  });
+  for (const guide of DEEP_GUIDES) assert.ok(body.includes(`/commands/${guide}`), `${locale}: guia profundo ${guide}`);
+}
+
+function helpFamilies() {
+  const result = spawnSync(process.execPath, [join(ROOT, 'bin', 'wendkeep.mjs'), '--help'], {
+    cwd: ROOT, encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return [...result.stdout.matchAll(/^\s{2}(wendkeep\s+.+?)\s{2,}/gm)].map((match) => {
+    const usage = match[1].trim();
+    if (/^wendkeep --(?:version|help)$/.test(usage)) return usage;
+    const tokens = usage.split(/\s+/);
+    const literals = [tokens.shift()];
+    for (const token of tokens) {
+      if (/^(?:--|\[|<|")/.test(token)) break;
+      literals.push(token);
+    }
+    return literals.join(' ');
+  });
+}
+
+function assertVerifyExitSemantics(text, locale) {
+  const expectations = locale === 'pt'
+    ? { 0: /todos os sensores[\s\S]*passaram[\s\S]*evidência foi gravada/i,
+        1: /sensor crítico[\s\S]*(?:vermelho|mutante)/i,
+        2: /uso\/contexto inválido[\s\S]*no change/i }
+    : { 0: /all required sensors passed[\s\S]*evidence was written/i,
+        1: /critical sensor[\s\S]*(?:red|mutant)/i,
+        2: /invalid usage\/context[\s\S]*no change/i };
+  for (const [code, meaning] of Object.entries(expectations)) {
+    const line = text.match(new RegExp(`^\\- \\*\\*Exit ${code}:\\*\\*.*(?:\\r?\\n  .*|\\r?\\n    .*)*`, 'mi'))?.[0] ?? '';
+    assert.match(line, meaning, `${locale}: exit ${code} mudou de significado`);
+  }
+}
+
+test('DOC-2: PT-BR e EN têm exatamente os mesmos dez guias', () => {
+  for (const dir of Object.values(GUIDE_DIR)) assert.ok(existsSync(dir), `diretório ausente: ${dir}`);
+  const pt = readdirSync(GUIDE_DIR.pt).filter((f) => f.endsWith('.md')).sort();
+  const en = readdirSync(GUIDE_DIR.en).filter((f) => f.endsWith('.md')).sort();
+  assert.deepEqual(pt, [...GUIDES].sort(), 'inventário PT-BR divergiu do contrato');
+  assert.deepEqual(en, [...GUIDES].sort(), 'inventário EN divergiu do contrato');
+  assert.deepEqual(pt, en, 'os diretórios de idiomas não estão espelhados');
+});
+
+test('DOC-2: cada par mantém estrutura editorial e alternador de idioma', () => {
+  for (const guide of GUIDES) {
+    const ptPath = join(GUIDE_DIR.pt, guide);
+    const enPath = join(GUIDE_DIR.en, guide);
+    const pt = readFileSync(ptPath, 'utf8');
+    const en = readFileSync(enPath, 'utf8');
+    for (const section of REQUIRED_SECTIONS.pt) assert.match(pt, new RegExp(`^## ${section}$`, 'm'), `${guide}: seção PT-BR ${section}`);
+    for (const section of REQUIRED_SECTIONS.en) assert.match(en, new RegExp(`^## ${section}$`, 'm'), `${guide}: seção EN ${section}`);
+    assert.match(pt, new RegExp(`\\.\\./\\.\\./en/commands/${guide.replace('.', '\\.')}`), `${guide}: link PT→EN`);
+    assert.match(en, new RegExp(`\\.\\./\\.\\./pt-BR/commands/${guide.replace('.', '\\.')}`), `${guide}: link EN→PT-BR`);
+    assert.deepEqual(normalizedCommandSurface(pt, 'Sintaxe'), normalizedCommandSurface(en, 'Syntax'),
+      `${guide}: as superfícies de comando PT-BR/EN devem ser semanticamente equivalentes`);
+    for (const locale of ['pt', 'en']) {
+      for (const concept of SEMANTIC_CONCEPTS[guide][locale]) {
+        assert.match(locale === 'pt' ? pt : en, concept, `${guide}: conceito ${locale} ausente: ${concept}`);
+      }
+    }
+  }
+});
+
+test('DOC-1: READMEs preservam primeiro uso e navegam pelos dez guias do próprio idioma', () => {
+  const pt = readFileSync(join(ROOT, 'README.md'), 'utf8');
+  const en = readFileSync(join(ROOT, 'README.en.md'), 'utf8');
+  assert.match(pt, /^## Instalar & configurar$/m);
+  assert.match(en, /^## Install & set up$/m);
+  assert.match(pt, /^## Funcionalidades por grupo$/m);
+  assert.match(en, /^## Features by group$/m);
+  assertReadmeGroups(pt, 'pt');
+  assertReadmeGroups(en, 'en');
+  for (const guide of GUIDES) {
+    assert.match(pt, new RegExp(`docs/pt-BR/commands/${guide.replace('.', '\\.')}`), `README PT-BR → ${guide}`);
+    assert.match(en, new RegExp(`docs/en/commands/${guide.replace('.', '\\.')}`), `README EN → ${guide}`);
+  }
+  assert.doesNotMatch(pt, /docs\/en\/commands\//, 'README PT-BR não deve navegar para guias EN');
+  assert.doesNotMatch(en, /docs\/pt-BR\/commands\//, 'README EN não deve navegar para guias PT-BR');
+});
+
+test('DOC-3: verify documenta contexto, alternativas de saúde e exits 0/1/2', () => {
+  for (const locale of ['pt', 'en']) {
+    const text = readFileSync(join(GUIDE_DIR[locale], 'verify.md'), 'utf8');
+    for (const token of ['--change', 'change use', 'verify --deep', 'doctor', 'memory status --gate']) {
+      assert.match(text, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), `${locale}: ${token}`);
+    }
+    for (const code of ['exit 0', 'exit 1', 'exit 2']) assert.match(text, new RegExp(code, 'i'), `${locale}: ${code}`);
+    assert.match(text, /no change|sem change/i, `${locale}: ausência de change`);
+    assertVerifyExitSemantics(text, locale);
+  }
+});
+
+test('DOC-4: todas as famílias derivadas do help aparecem na sintaxe do guia correto', () => {
+  const families = helpFamilies();
+  assert.ok(families.length >= 28, 'o parser do help deve encontrar todas as famílias públicas');
+  assert.equal(new Set(families).size, families.length, 'o help não deve produzir famílias duplicadas');
+  for (const family of families) {
+    const guide = GUIDE_FOR_FAMILY.get(family);
+    assert.ok(guide, `família nova do --help sem guia designado: ${family}`);
+    for (const [locale, dir] of Object.entries(GUIDE_DIR)) {
+      const text = readFileSync(join(dir, guide), 'utf8');
+      const syntax = normalizedCommandSurface(text, locale === 'pt' ? 'Sintaxe' : 'Syntax').join('\n');
+      assert.ok(syntax.includes(family), `${locale}: sintaxe de ${guide} não cobre ${family}`);
+      for (const heading of [
+        locale === 'pt' ? 'Quando usar' : 'When to use',
+        locale === 'pt' ? 'Resultado esperado' : 'Expected result',
+        locale === 'pt' ? 'Erros comuns e diagnóstico' : 'Common errors and diagnosis',
+      ]) assert.ok(section(text, heading).trim(), `${locale}: ${guide} não explica ${heading}`);
+    }
+  }
+});
+
+test('DOC-6: AGENTS exige atualização bilíngue somente fora do bloco gerenciado', () => {
+  const agents = readFileSync(join(ROOT, 'AGENTS.md'), 'utf8');
+  const managedEnd = agents.indexOf('<!-- wendkeep:skills:end -->');
+  assert.ok(managedEnd >= 0, 'marcador final do bloco gerenciado ausente');
+  const localRules = agents.slice(managedEnd);
+  assert.match(localRules, /documenta/i);
+  assert.match(localRules, /PT-BR/);
+  assert.match(localRules, /EN|inglês/i);
+  assert.match(localRules, /mesmo commit/i);
+  assert.match(localRules, /comando|flag|código de saída|hook/i);
+  assert.match(localRules, /não[\s\S]*(?:propag|consumidor)/i);
+});
+
+test('DOC-7: links Markdown locais resolvem para arquivos e âncoras existentes', () => {
+  for (const file of ['README.md', 'README.en.md']) assertLocalLinksResolve(join(ROOT, file));
+  for (const dir of Object.values(GUIDE_DIR)) {
+    for (const guide of GUIDES) assertLocalLinksResolve(join(dir, guide));
+  }
+});

--- a/tests/readme-packaging.test.mjs
+++ b/tests/readme-packaging.test.mjs
@@ -14,6 +14,20 @@ import { fileURLToPath } from 'node:url';
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const isPt = (s) => /Seu agente de código esquece/.test(s);
 const isEn = (s) => /Your AI coding agent forgets/.test(s);
+const GUIDE_SLUGS = [
+  'getting-started.md', 'changes-and-verification.md', 'memory.md',
+  'sessions-and-import.md', 'notes-and-knowledge.md', 'costs-and-observability.md',
+  'maintenance-and-diagnostics.md', 'verify.md', 'memory-migration.md',
+  'retroactive-import.md',
+];
+
+function filesUnder(dir, base = dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const absolute = join(dir, entry.name);
+    if (entry.isDirectory()) return filesUnder(absolute, base);
+    return [absolute.slice(base.length + 1).replaceAll('\\', '/')];
+  });
+}
 
 test('o repositório guarda o português como README.md e o inglês ao lado', () => {
   assert.ok(isPt(readFileSync(join(ROOT, 'README.md'), 'utf8')), 'README.md em português (GitHub)');
@@ -31,6 +45,13 @@ test('os dois READMEs apontam um para o outro, sem link morto', () => {
 test('os dois idiomas viajam no pacote', () => {
   const files = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')).files;
   for (const f of ['README.md', 'README.en.md']) assert.ok(files.includes(f), `${f} em files`);
+});
+
+test('DOC-5: somente os diretórios de guias bilíngues são adicionados ao pacote', () => {
+  const files = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')).files;
+  assert.ok(files.includes('docs/pt-BR/commands/*.md'), 'glob PT-BR em files');
+  assert.ok(files.includes('docs/en/commands/*.md'), 'glob EN em files');
+  assert.ok(!files.includes('docs'), 'o acervo histórico inteiro não pode viajar por acidente');
 });
 
 // Medido num projeto pnpm limpo, sem configuração alguma (pnpm 11.5.2):
@@ -71,9 +92,22 @@ test('npm pack: o tarball leva o inglês e o repositório volta ao português', 
     assert.equal(untar.status, 0, untar.stderr);
 
     const pkg = join(outDir, 'package');
+    const packedManifest = JSON.parse(readFileSync(join(pkg, 'package.json'), 'utf8'));
+    assert.equal(packedManifest.version, '0.58.2', 'DOC-5: o tarball deve declarar exatamente a release 0.58.2');
     assert.ok(isEn(readFileSync(join(pkg, 'README.md'), 'utf8')),
       'o README.md DO TARBALL é o inglês — é o que a página do npm renderiza');
     assert.ok(existsSync(join(pkg, 'README.en.md')), 'e o inglês também viaja pelo nome próprio');
+    for (const locale of ['pt-BR', 'en']) {
+      for (const guide of GUIDE_SLUGS) {
+        assert.ok(existsSync(join(pkg, 'docs', locale, 'commands', guide)),
+          `guia ausente no tarball: docs/${locale}/commands/${guide}`);
+      }
+    }
+    const expectedDocs = ['pt-BR', 'en']
+      .flatMap((locale) => GUIDE_SLUGS.map((guide) => `${locale}/commands/${guide}`))
+      .sort();
+    assert.deepEqual(filesUnder(join(pkg, 'docs')).sort(), expectedDocs,
+      'o tarball não pode incluir o acervo histórico de docs');
 
     // O prepack troca os arquivos; o postpack tem de restaurar.
     assert.ok(isPt(readFileSync(join(ROOT, 'README.md'), 'utf8')),

--- a/wendkeep.sensors.json
+++ b/wendkeep.sensors.json
@@ -32,6 +32,14 @@
       "severity": "critical",
       "type": "command",
       "command": "node bin/wendkeep.mjs memory status --gate --vault .WendKeep-vault"
+    },
+    {
+      "id": "docs-bilingual",
+      "name": "Bilingual command documentation",
+      "description": "Checks mirrored PT-BR/EN guides, public command coverage, navigation, governance and tarball contents",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test tests/docs-bilingual.test.mjs tests/readme-packaging.test.mjs"
     }
   ]
 }


### PR DESCRIPTION
## Resumo

- reorganiza `README.md` e `README.en.md` em sete grupos de funcionalidades
- adiciona dez guias detalhados espelhados em PT-BR e EN
- documenta o contexto de `verify`, exits 0/1/2 e alternativas de health check
- inclui os vinte guias no tarball 0.58.2 sem publicar o acervo histórico de `docs/`
- torna obrigatória a manutenção bilíngue no `AGENTS.md` local do WendKeep

## Impacto

O README passa a ser o mapa conciso das funcionalidades; cada grupo aponta para instruções completas no idioma correspondente. A regra não é propagada para projetos consumidores.

## Validação

- `node --test tests/docs-bilingual.test.mjs tests/readme-packaging.test.mjs`: 13/13
- `npm test`: 647/647
- `npm run check`: verde
- `wendkeep verify`: verde
- `wendkeep verify --deep` + verificação independente: DOC-1..DOC-7, 7/7
- tarball: versão 0.58.2, dois READMEs, vinte guias, zero doc histórico acidental
- change arquivada como ADR-0050