### PR TITLE
fix: make SessionStop memory publication durable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.58.3] — 2026-07-26
+
+### Fixed
+
+- **O primeiro `SessionStop` elegível após a migração legacy → v2 volta a publicar o handoff.**
+  A activation passa a representar um epoch com múltiplos Stops, e `UserPromptSubmit` recupera
+  uma única activation ausente sob lock. Identidade nativa de sessão/turno e a ordem física do
+  transcript impedem que Stops duplicados, atrasados ou de uma activation anterior publiquem de
+  novo ou sobrescrevam checkpoints mais recentes.
+- **A publicação de memória ficou durável e observável de ponta a ponta.** O evento é enfileirado
+  antes de registrar `enqueued`, a projeção ocorre fora do lock e retries reutilizam a tentativa
+  congelada. Falhas preservam a outbox como `degraded`, enquanto retornos ambíguos deixam evidência
+  diagnóstica em vez de encerrar silenciosamente.
+- **`wendkeep doctor` agora detecta memória v2 realmente estagnada sem acusar uma migração nova.**
+  O diagnóstico correlaciona tentativa, ledger, outbox, revisão e checkpoint; revision 0 logo após
+  uma migração válida continua saudável, mas perda causal, ambiguidade e divergência bloqueiam.
+
+### Changed
+
+- **Os guias bilíngues de memória, sessões, migração e diagnóstico descrevem o lifecycle real.**
+  A documentação cobre epochs multi-Stop, recuperação única, retries idempotentes, estados
+  `enqueued|projected|degraded|ambiguous` e como interpretar revision 0.
+
+### Security
+
+- **Fixtures persistíveis de lifecycle são integralmente sintéticas.** Um gate de privacidade
+  verifica arquivos rastreados e novos e reporta somente arquivo, linha e categoria, evitando que
+  caminhos ou identificadores locais entrem em testes, commits e artefatos.
+
 ## [0.58.2] — 2026-07-26
 
 ### Added

--- a/README.en.md
+++ b/README.en.md
@@ -180,10 +180,16 @@ Hot memory now separates human authorship, operational state, and evidence:
 
 - **`CORE.md` is canonical.** It is the short, hand-curated nucleus for durable preferences, active patterns, and open issues; no projector may infer or overwrite it.
 - **`SHARED_MEMORY.md` is generated operational state.** The `Stop` hook turns the session handoff into sanitized events; the projector deterministically reduces the ledger and publishes a verifiable revision, cursor, and hash. Facts are `verified` only with local evidence; unsupported reports remain `reported`, and disagreements become candidates for human judgment.
-- **`MEMORY_EVENTS.jsonl` is the append-only authority.** Producers publish to the outbox with exclusive creation, then the projector serializes append + projection under a lock. Repeating an identical `event_id`/payload is a no-op; reusing the ID with different bytes is observable corruption.
+- **`MEMORY_EVENTS.jsonl` is the append-only authority.** `Stop` makes events durable in the outbox before acknowledging the attempt; the projector runs outside the registry lock and retries reuse the same IDs. Repeating an identical `event_id`/payload is a no-op; reusing the ID with different bytes is observable corruption.
 - **`MEMORY_CANDIDATES.jsonl` is the curation queue.** Conflicts and legacy content are never silently promoted. `promote` and `reject` record the decision as a new event.
 
 Artifacts stay under `.brain/` only. Sanitization strips secrets, tokens, local paths, transcripts, and harness payloads both before persistence and before injection. Events carry a `project_id`, and one vault never accepts another project's events.
+
+Lifecycle in brief: each `SessionStart` opens an epoch that spans multiple `Stop` events;
+`UserPromptSubmit` advances the native turn and recovers exactly one closed legacy activation.
+Codex uses `session_id`/`turn_id` plus transcript order, with no artificial causal fields. See
+[sessions and hooks](docs/en/commands/sessions-and-import.md) and
+[memory](docs/en/commands/memory.md).
 
 ### Injection and budgets
 
@@ -199,7 +205,11 @@ wendkeep memory migrate --apply --vault .MyApp-vault  # backup + candidates + v2
 
 ### Health and recovery
 
-Use `wendkeep memory status --gate --vault <vault>` in CI and before `verify`/`archive`. The critical `memory-health` sensor blocks ledger/outbox/bundle corruption, revision/cursor/hash lag, and active conflicts. A valid pending outbox or ordinary candidate is recoverable and remains a warning rather than blocking.
+Use `wendkeep memory status --gate --vault <vault>` in CI and before `verify`/`archive`. Revision 0
+immediately after valid migration is healthy. The gate correlates `last_memory_attempt`, outbox,
+ledger, SHARED, and checkpoint: `degraded` with a durable outbox is a warning; an ambiguous attempt,
+lost publication, or mismatched checkpoint blocks. See [migration](docs/en/commands/memory-migration.md)
+and [diagnostics](docs/en/commands/maintenance-and-diagnostics.md).
 
 If status blocks, preserve the evidence and run `wendkeep memory repair --vault <vault>` to save a backup of the corrupt ledger, retain valid lines, and re-project. Then run `status --gate` again. Conflicts require explicit curation with `memory promote <id>` or `memory reject <id>`; doctor only diagnoses.
 

--- a/README.md
+++ b/README.md
@@ -176,10 +176,16 @@ A memória quente agora separa claramente autoria humana, estado operacional e e
 
 - **`CORE.md` é canônico.** É o núcleo curto, curado à mão, com preferências duráveis, padrões ativos e pendências que nenhum projetor pode inferir ou sobrescrever.
 - **`SHARED_MEMORY.md` é operacional e gerado.** O hook `Stop` transforma o handoff da sessão em eventos sanitizados; o projetor reduz o ledger de modo determinístico e publica revision, cursor e hash verificáveis. Fatos só entram como `verified` quando há evidência local; relatos sem prova ficam `reported`, e disputas viram candidates para decisão humana.
-- **`MEMORY_EVENTS.jsonl` é a autoridade append-only.** Produtores publicam primeiro na outbox por criação exclusiva e o projetor serializa append + projeção sob lock. Repetir o mesmo `event_id`/payload é no-op; reutilizar o ID com bytes diferentes é corrupção observável.
+- **`MEMORY_EVENTS.jsonl` é a autoridade append-only.** O `Stop` torna os eventos duráveis na outbox antes de reconhecer o attempt; o projector roda fora do lock do registry e retries reutilizam os mesmos IDs. Repetir o mesmo `event_id`/payload é no-op; reutilizar o ID com bytes diferentes é corrupção observável.
 - **`MEMORY_CANDIDATES.jsonl` é a fila de curadoria.** Conflitos e conteúdo legado não são promovidos silenciosamente. `promote` e `reject` registram a decisão como novo evento.
 
 Os artefatos ficam somente em `.brain/`; a sanitização remove secrets, tokens, paths locais, transcripts e payloads de harness tanto antes da persistência quanto antes da injeção. Eventos carregam `project_id`, e um vault nunca aceita eventos de outro projeto.
+
+Lifecycle resumido: cada `SessionStart` abre um epoch que atravessa vários `Stop`;
+`UserPromptSubmit` avança o turno nativo e recupera uma única activation legada fechada. Codex usa
+`session_id`/`turn_id` + ordem do transcript, sem campos causais artificiais. Veja os guias de
+[sessões e hooks](docs/pt-BR/commands/sessions-and-import.md) e
+[memória](docs/pt-BR/commands/memory.md).
 
 ### Injeção e budgets
 
@@ -195,7 +201,11 @@ wendkeep memory migrate --apply --vault .MeuApp-vault  # backup + candidates + b
 
 ### Saúde e recuperação
 
-Use `wendkeep memory status --gate --vault <cofre>` no CI e antes de `verify`/`archive`. O sensor crítico `memory-health` bloqueia corrupção do ledger/outbox/bundle, lag de revision/cursor/hash e conflitos ativos. Outbox válida pendente ou candidate comum é recuperável e fica como warning, sem bloquear.
+Use `wendkeep memory status --gate --vault <cofre>` no CI e antes de `verify`/`archive`. Revision 0
+logo após migração válida é saudável. O gate correlaciona `last_memory_attempt`, outbox, ledger,
+SHARED e checkpoint: `degraded` com outbox durável é warning; attempt ambíguo, publicação perdida
+ou checkpoint divergente bloqueiam. Veja [migração](docs/pt-BR/commands/memory-migration.md) e
+[diagnóstico](docs/pt-BR/commands/maintenance-and-diagnostics.md).
 
 Se o status bloquear, preserve a evidência e rode `wendkeep memory repair --vault <cofre>` para salvar backup do ledger corrompido, reter linhas válidas e reprojetar. Depois rode `status --gate` novamente. Conflitos exigem curadoria explícita com `memory promote <id>` ou `memory reject <id>`; o doctor apenas diagnostica.
 

--- a/docs/en/commands/maintenance-and-diagnostics.md
+++ b/docs/en/commands/maintenance-and-diagnostics.md
@@ -33,6 +33,12 @@ npx wendkeep --help
 ## Options and exit codes
 
 - `doctor` is read-only; exit `0` accepts recoverable warnings, while non-zero means failure.
+- In v2, `doctor`/`memory status --gate` correlate `last_memory_attempt` (mode, disposition, event
+  IDs, and checkpoint) with outbox, ledger, and SHARED; they do not infer health from revision alone.
+- `revision: 0` after a valid migration, with no v2 attempt, is healthy. A `degraded` attempt whose
+  events remain durable in the outbox/ledger is a recoverable warning.
+- An ambiguous attempt, a lost event ID (absent from ledger and outbox), `projected` state found
+  only in the outbox, or a mismatched checkpoint is blocking.
 - `sync-defs --check` detects drift without writes; `--reseed` restores packaged `wk-*` skills.
 - `theme sync` reapplies the CSS snippet and graph groups without recreating the vault.
 - `wendkeep --version` prints the running version; `wendkeep --help` lists the public interface.
@@ -51,13 +57,18 @@ npx wendkeep memory status --gate --vault .MyApp-vault
 ## Expected result
 
 Doctor names sessions, registry, links, notes, prices, derived sections, and memory as healthy or
-provides a specific diagnostic/repair command. It never repairs implicitly.
+provides a specific diagnostic/repair command. For memory, it distinguishes a valid initial empty
+state, recoverable pending replay, and lost/divergent lifecycle state. It never repairs implicitly
+or echoes private projector-error content into its report.
 
 ## Common errors and diagnosis
 
 - `no vault`: run from the bound root or pass `--vault`.
 - `defs stale`: confirm the version and run `sync-defs --reseed`.
 - Legacy vault: this is a non-blocking warning; plan `memory migrate --apply` separately.
+- `degraded` plus an intact outbox: warning; preserve the outbox and allow idempotent replay.
+- `ambiguous`, lost publication, or a mismatched checkpoint: blocking; preserve registry, ledger,
+  outbox, and SHARED so `last_memory_attempt` can be correlated before repair.
 - Corrupt bundle: preserve evidence and run `memory status --gate` before `memory repair`.
 
 ## Next steps

--- a/docs/en/commands/memory-migration.md
+++ b/docs/en/commands/memory-migration.md
@@ -34,6 +34,8 @@ npx wendkeep memory migrate --apply --vault <vault>
 
 - Without `--apply`, `wendkeep memory migrate` is a zero-write dry run.
 - `--apply` creates a backup, converts legacy content into candidates, and publishes valid v2.
+- A newly migrated bundle may start healthy at `revision: 0`: no v2 attempt or eligible event has
+  happened yet, so zero does not mean the lifecycle is stalled.
 - Exit `0` means a consistent preview/application; non-zero preserves original state and reports
   the failure.
 
@@ -50,11 +52,18 @@ npx wendkeep memory status --gate --vault .MyApp-vault
 
 The vault receives a coherent v2 ledger/projection, a backup of legacy SHARED, and candidates for
 unsupported facts. CORE is untouched and unverified content is not activated automatically.
+After migration, the next `UserPromptSubmit` opens exactly one recovery activation when the
+legacy registry was closed; the first transcript-proven `Stop` publishes once and advances SHARED
+to revision 1. Replaying that prompt or Stop does not duplicate the event/revision.
 
 ## Common errors and diagnosis
 
 - Dry run says already v2: do not apply again.
+- `revision: 0` immediately after a valid apply: this is healthy; wait for an eligible prompt and
+  Stop instead of repairing or repeating migration.
 - Partial/corrupt v2 bundle: use status and repair; migration is not a corruption tool.
+- First post-migration Stop is `ambiguous`: verify that its `turn_id` belongs to the transcript and
+  that `UserPromptSubmit` opened/advanced the recovery activation.
 - Many candidates: curate gradually with `memory promote`/`memory reject`.
 - Legacy warning remains after apply: verify the selected vault and project binding.
 

--- a/docs/en/commands/memory.md
+++ b/docs/en/commands/memory.md
@@ -4,8 +4,8 @@
 
 ## Purpose
 
-Inspect and curate CORE, SHARED, ledger, outbox, and candidates without confusing canonical
-authorship with generated operational state.
+Inspect and curate CORE, SHARED, ledger, outbox, attempts, and candidates without confusing
+canonical authorship with generated operational state.
 
 ## When to use
 
@@ -34,8 +34,16 @@ npx wendkeep validate-memory --vault <v2-vault>
 ## Options and exit codes
 
 - `memory status` is read-only; `--gate` exits `1` only for blocking state.
-- A valid legacy vault warns and exits `0`; corruption, lag/hash mismatch, or active blocking
-  conflict exits `1`.
+- `Stop` writes events to the outbox before acknowledging `last_memory_attempt: enqueued`, then the
+  projector runs outside the registry lock. Retrying the same attempt reuses its frozen event IDs
+  and can project them at most once.
+- A busy/failed projector persists `degraded`, preserves the outbox, and reports replay. A later
+  Stop/retry reuses that attempt instead of rebuilding its handoff from new transient data.
+- The outcome updates `memory_status`/checkpoint only while activation, epoch, turn, and attempt
+  still match exactly. A stale/superseded result cannot clear or overwrite a newer checkpoint.
+- A valid legacy vault warns and exits `0`. For v2, status correlates `last_memory_attempt`,
+  disposition, outbox, ledger, SHARED, and checkpoint: an ambiguous attempt, lost publication, or
+  mismatched checkpoint blocks; `degraded` with an intact outbox is a warning.
 - `memory repair` locks, writes a `.bak`, retains valid events, and reprojects state.
 - `promote`/`reject` append auditable decisions and never rewrite the ledger in place.
 - `validate-memory <CORE.md>` checks the 25-line cap, required sections, and secrets.
@@ -51,12 +59,21 @@ npx wendkeep memory promote candidate-123 --vault .MyApp-vault
 
 ## Expected result
 
-Status prints schema, revision, cursor, hash, events, outbox, candidates, and conflicts. CORE stays
-hand-curated and canonical; SHARED stays a verifiable operational projection.
+Status prints schema, revision, cursor, hash, events, outbox, candidates, conflicts, and the causal
+state of the last attempt. CORE stays hand-curated and canonical; SHARED stays a verifiable
+operational projection. After successful projection, an attempt checkpoint may be a valid prefix
+of a global projection that has already advanced with concurrent events.
 
 ## Common errors and diagnosis
 
 - `legacy`: follow the migration guide; this is not corruption.
+- `revision: 0` immediately after a valid migration, with no v2 attempt, is healthy; do not run
+  repair merely to manufacture the first event.
+- `degraded` with every event ID present in either the ledger or an intact outbox is recoverable;
+  let idempotent replay finish. An event ID absent from both locations means lost publication.
+- An `ambiguous` attempt, an `applied` attempt without event IDs, a `projected` event found only in
+  the outbox, or a mismatched checkpoint is blocking: preserve the artifacts and investigate
+  before repair.
 - Ordinary pending candidate: recoverable warning, requiring human choice when appropriate.
 - Missing `event_cursor` or mismatched v2 hash: preserve the bundle and assess `memory repair`.
 - `validate-memory --vault` fails on legacy: validate CORE only or migrate first.

--- a/docs/en/commands/sessions-and-import.md
+++ b/docs/en/commands/sessions-and-import.md
@@ -4,8 +4,8 @@
 
 ## Purpose
 
-Understand how hooks capture live sessions, how the registry selects conversations, and when to
-use retroactive import.
+Understand how hooks capture live sessions, how activation/turn state preserves causality in the
+registry, and when to use retroactive import.
 
 ## When to use
 
@@ -35,6 +35,16 @@ npx wendkeep import [options]
 ## Options and exit codes
 
 - `wendkeep hook <name>` reads the agent payload from stdin; valid names are listed by `--help`.
+- `SessionStart` opens an activation: an epoch that remains active across multiple `Stop` events;
+  only a new `SessionStart` supersedes the previous epoch.
+- `UserPromptSubmit` advances the active activation's native turn. If it finds a legacy registry
+  with a closed epoch, it opens exactly one recovery activation; replaying the same prompt does
+  not open another one.
+- On Codex, `session_id`, the native `turn_id`, and observed transcript order are enough to resolve
+  the turn. Hook payloads do not need invented `activation_id` or `turn_sequence` fields.
+- `Stop` accepts only a transcript-proven turn from the compatible active activation. Duplicates
+  are no-ops; stale/superseded Stops neither publish memory nor overwrite a newer epoch's
+  checkpoint.
 - `session list` reads `SESSION_REGISTRY`; `show` displays one session and `use` only changes human
   focus in `CURRENT_SESSION.md`.
 - `import --source all|claude|codex`, `--since`, `--limit`, `--from`, and `--codex-from` bound scope.
@@ -53,12 +63,18 @@ npx wendkeep import --source codex --since 2026-07-01 --dry-run --json
 
 ## Expected result
 
-Each canonical session points to the matching provider, transcript, note file, and costs. Repeated
-imports of the same `session_id` deduplicate; human focus does not close or re-identify live hooks.
+Each canonical session points to the matching provider, transcript, note file, and costs. The
+registry keeps one `SessionStart` epoch per activation plus the latest native turn; multiple
+`Stop` events may acknowledge turns in that epoch without closing it. Repeated imports of the
+same `session_id` deduplicate; human focus does not close or re-identify live hooks.
 
 ## Common errors and diagnosis
 
 - Missing session: verify provider, transcript path, and registry before importing again.
+- `Stop ambiguous`: the transcript did not prove the `turn_id`, or no compatible active activation
+  was found; the attempt remains observable but does not publish memory.
+- A late Stop reports `stale_turn`/`superseded`: the newer epoch and checkpoint are preserved; do
+  not force the old payload to apply.
 - Fork duplicates: bound source/date and inspect `forked_from_id`/`source.subagent`.
 - Codex does not capture: approve hooks and start a new session after `sync`.
 - Contaminated cost: validate `session_id → session_file → transcript_path → provider`.

--- a/docs/pt-BR/commands/maintenance-and-diagnostics.md
+++ b/docs/pt-BR/commands/maintenance-and-diagnostics.md
@@ -33,6 +33,12 @@ npx wendkeep --help
 ## Opções e códigos de saída
 
 - `doctor` é read-only; exit `0` aceita warnings recuperáveis e exit não zero indica falha.
+- Em v2, `doctor`/`memory status --gate` correlacionam `last_memory_attempt` (mode, disposition,
+  event IDs e checkpoint) com outbox, ledger e SHARED; não inferem saúde só pela revision atual.
+- `revision: 0` após migração válida, sem attempt v2, é saudável. Attempt `degraded` cujos eventos
+  continuam duráveis na outbox/ledger é warning recuperável.
+- Attempt ambíguo, event ID perdido (ausente de ledger e outbox), estado `projected` apenas na
+  outbox ou checkpoint divergente são falhas bloqueantes.
 - `sync-defs --check` detecta drift sem gravar; `--reseed` restaura skills `wk-*` do pacote.
 - `theme sync` reaplica snippet CSS e grupos do grafo sem recriar o cofre.
 - `wendkeep --version` imprime a versão executada; `wendkeep --help` lista a interface pública.
@@ -51,13 +57,18 @@ npx wendkeep memory status --gate --vault .MeuApp-vault
 ## Resultado esperado
 
 O doctor nomeia sessões, registry, links, notas, preços, derivadas e memória como saudáveis ou
-fornece um comando específico de diagnóstico/reparo. Nenhum reparo é aplicado implicitamente.
+fornece um comando específico de diagnóstico/reparo. Na memória, ele distingue vazio inicial
+válido, replay pendente recuperável e lifecycle perdido/divergente. Nenhum reparo é aplicado
+implicitamente nem o conteúdo privado do erro do projector é reproduzido no relatório.
 
 ## Erros comuns e diagnóstico
 
 - `no vault`: execute da raiz vinculada ou passe `--vault`.
 - `defs stale`: confirme a versão e rode `sync-defs --reseed`.
 - Vault legado: é warning não bloqueante; planeje `memory migrate --apply` separadamente.
+- `degraded` + outbox íntegra: warning; preserve a outbox e permita replay idempotente.
+- `ambiguous`, publicação perdida ou checkpoint divergente: bloqueante; preserve registry, ledger,
+  outbox e SHARED para correlacionar `last_memory_attempt` antes de reparar.
 - Bundle corrompido: preserve a evidência e use `memory status --gate` antes de `memory repair`.
 
 ## Próximos passos

--- a/docs/pt-BR/commands/memory-migration.md
+++ b/docs/pt-BR/commands/memory-migration.md
@@ -34,6 +34,8 @@ npx wendkeep memory migrate --apply --vault <cofre>
 
 - Sem `--apply`, `wendkeep memory migrate` é dry-run e não grava.
 - `--apply` cria backup, converte conteúdo legado em candidates e publica bundle v2 válido.
+- Um bundle recém-migrado pode começar saudável em `revision: 0`: ainda não houve attempt v2 nem
+  evento elegível, portanto zero não significa estagnação.
 - Exit `0` indica prévia/aplicação consistente; exit diferente de zero preserva o estado original
   e informa a falha.
 
@@ -50,11 +52,18 @@ npx wendkeep memory status --gate --vault .MeuApp-vault
 
 O vault recebe ledger/projeção v2 coerentes, backup do SHARED legado e candidates para fatos sem
 evidência. CORE não é editado e conteúdo não verificado não vira estado ativo automaticamente.
+Após a migração, o próximo `UserPromptSubmit` recupera uma única activation se o registry legado
+estava fechado; o primeiro `Stop` cujo turno for comprovado publica uma vez e avança SHARED para
+revision 1. Repetir esse prompt ou Stop não duplica evento/revision.
 
 ## Erros comuns e diagnóstico
 
 - Dry-run mostra vault já v2: não aplique novamente.
+- `revision: 0` imediatamente após apply válido: estado saudável; aguarde um prompt e Stop
+  elegíveis, não rode repair nem repita a migração.
 - Bundle v2 parcial/corrompido: use status e repair; migração não é ferramenta de corrupção.
+- Primeiro Stop pós-migração fica `ambiguous`: confirme que o `turn_id` pertence ao transcript e
+  que `UserPromptSubmit` abriu/avançou a activation de recuperação.
 - Candidates numerosos: curate gradualmente com `memory promote`/`memory reject`.
 - Warning legado após apply: confirme o vault efetivamente selecionado e o vínculo do projeto.
 

--- a/docs/pt-BR/commands/memory.md
+++ b/docs/pt-BR/commands/memory.md
@@ -4,8 +4,8 @@
 
 ## Objetivo
 
-Inspecionar e curar CORE, SHARED, ledger, outbox e candidates sem confundir autoria canônica com
-estado operacional gerado.
+Inspecionar e curar CORE, SHARED, ledger, outbox, attempts e candidates sem confundir autoria
+canônica com estado operacional gerado.
 
 ## Quando usar
 
@@ -34,8 +34,16 @@ npx wendkeep validate-memory --vault <cofre-v2>
 ## Opções e códigos de saída
 
 - `memory status` é read-only; `--gate` retorna exit `1` apenas para estado bloqueante.
-- Vault legado válido gera warning e exit `0`; corrupção, lag/hash divergente ou conflito ativo
-  bloqueante gera exit `1`.
+- O `Stop` grava os eventos na outbox antes de reconhecer `last_memory_attempt: enqueued`; depois o
+  projector roda fora do lock do registry. Retry do mesmo attempt reutiliza os event IDs congelados
+  e pode projetá-los no máximo uma vez.
+- Projector busy/falho persiste `degraded`, preserva a outbox e avisa que há replay. Um Stop/retry
+  seguinte reaproveita essa tentativa; não reconstrói o handoff com dados transitórios novos.
+- O outcome só atualiza `memory_status`/checkpoint se activation, epoch, turno e attempt ainda forem
+  exatamente os mesmos. Resultado stale/superseded não apaga nem sobrescreve checkpoint mais novo.
+- Vault legado válido gera warning e exit `0`. Em v2, o status correlaciona
+  `last_memory_attempt`, disposition, outbox, ledger, SHARED e checkpoint: attempt ambíguo,
+  publicação perdida ou checkpoint divergente bloqueiam; `degraded` com outbox íntegra é warning.
 - `memory repair` trabalha sob lock, salva `.bak`, retém eventos válidos e reprojeta.
 - `promote`/`reject` acrescentam decisão auditável; nunca reescrevem o ledger no lugar.
 - `validate-memory <CORE.md>` valida cap de 25 linhas, seções e segredos.
@@ -51,12 +59,20 @@ npx wendkeep memory promote candidate-123 --vault .MeuApp-vault
 
 ## Resultado esperado
 
-O status imprime schema, revision, cursor, hash, eventos, outbox, candidates e conflitos. CORE
-permanece canônico e curado à mão; SHARED permanece projeção operacional verificável.
+O status imprime schema, revision, cursor, hash, eventos, outbox, candidates, conflitos e o estado
+causal do último attempt. CORE permanece canônico e curado à mão; SHARED permanece projeção
+operacional verificável. Depois de uma projeção bem-sucedida, o checkpoint do attempt pode ser um
+prefixo válido de uma projeção global que já avançou com eventos concorrentes.
 
 ## Erros comuns e diagnóstico
 
 - `legacy`: siga o guia de migração; não é corrupção.
+- `revision: 0` logo após migração válida, sem attempt v2, é saudável; não rode repair só para
+  fabricar o primeiro evento.
+- `degraded` com todos os event IDs presentes no ledger ou na outbox íntegra é recuperável; deixe o
+  replay idempotente concluir. Event ID ausente nos dois lugares indica publicação perdida.
+- Attempt `ambiguous`, attempt `applied` sem event IDs, evento `projected` apenas na outbox ou
+  checkpoint divergente são bloqueantes: preserve os artefatos e investigue antes de repair.
 - Candidate pendente comum: warning recuperável, exige decisão humana quando apropriado.
 - `event_cursor` ausente ou hash divergente em v2: preserve o bundle e avalie `memory repair`.
 - `validate-memory --vault` falha no legado: valide apenas CORE ou migre primeiro.

--- a/docs/pt-BR/commands/sessions-and-import.md
+++ b/docs/pt-BR/commands/sessions-and-import.md
@@ -4,8 +4,8 @@
 
 ## Objetivo
 
-Entender como hooks capturam sessões ao vivo, como o registry seleciona conversas e quando usar a
-importação retroativa.
+Entender como os hooks capturam sessões ao vivo, como activation/turno preservam causalidade no
+registry e quando usar a importação retroativa.
 
 ## Quando usar
 
@@ -35,6 +35,16 @@ npx wendkeep import [opções]
 ## Opções e códigos de saída
 
 - `wendkeep hook <name>` lê o payload do agente em stdin; nomes válidos aparecem em `--help`.
+- `SessionStart` abre uma activation, isto é, um epoch que continua ativo por vários `Stop`; só um
+  novo `SessionStart` torna o epoch anterior superseded.
+- `UserPromptSubmit` avança o turno nativo da activation ativa. Se encontrar um registry legado
+  com o epoch fechado, abre exatamente uma activation de recuperação; repetir o mesmo prompt não
+  abre outra.
+- No Codex, `session_id`, o `turn_id` nativo e a ordem observada no transcript bastam para resolver
+  o turno. O payload do hook não precisa inventar `activation_id` nem `turn_sequence`.
+- `Stop` aceita somente o turno comprovado pelo transcript e pela activation ativa compatível.
+  Duplicatas são no-op; Stops stale/superseded não publicam memória nem sobrescrevem o checkpoint
+  de um epoch mais novo.
 - `session list` lê `SESSION_REGISTRY`; `show` exibe uma sessão e `use` muda apenas o foco humano
   em `CURRENT_SESSION.md`.
 - `import --source all|claude|codex`, `--since`, `--limit`, `--from` e `--codex-from` limitam escopo.
@@ -54,12 +64,17 @@ npx wendkeep import --source codex --since 2026-07-01 --dry-run --json
 ## Resultado esperado
 
 Cada sessão canônica aponta para provider, transcript, arquivo de nota e custos correspondentes.
-Importações repetidas do mesmo `session_id` são deduplicadas; o foco humano não encerra nem altera
-a identidade da sessão ativa dos hooks.
+O registry mantém um epoch de `SessionStart` por activation e o turno nativo mais recente; vários
+`Stop` podem confirmar turnos do mesmo epoch sem fechá-lo. Importações repetidas do mesmo
+`session_id` são deduplicadas; o foco humano não encerra nem altera a identidade dos hooks.
 
 ## Erros comuns e diagnóstico
 
 - Sessão ausente: confira provider, path do transcript e registry antes de importar novamente.
+- `Stop ambiguous`: o `turn_id` não foi comprovado pelo transcript ou nenhuma activation ativa
+  compatível foi encontrada; o attempt fica observável, mas não publica memória.
+- Stop atrasado aparece como `stale_turn`/`superseded`: o epoch mais novo e seu checkpoint são
+  preservados; não force a reaplicação do payload antigo.
 - Duplicatas de forks: limite por fonte/data e revise `forked_from_id`/`source.subagent`.
 - Codex não captura: aprove os hooks e reinicie a sessão após `sync`.
 - Custo contaminado: valide `session_id → session_file → transcript_path → provider`.

--- a/hooks/obsidian-common.mjs
+++ b/hooks/obsidian-common.mjs
@@ -355,7 +355,7 @@ export function mutateSessionRegistry(vaultBase, mutator, { timeoutMs = 2000 } =
 function meaningfulPatch(patch = {}) {
   const protectedNonEmpty = new Set(['session_file', 'transcript_path', 'transcript_id', 'provider', 'started_at', 'change_slug', 'activation_id']);
   return Object.fromEntries(Object.entries(patch).filter(([key, value]) => {
-    if (key === 'advance_turn_sequence' || key === 'turn_sequence') return false;
+    if (['advance_turn_sequence', 'turn_sequence', 'turn_id', 'last_turn_sequence', 'recovery_activation_id', 'recovery_started_at'].includes(key)) return false;
     if (value === undefined || value === null) return false;
     if (value === '' && protectedNonEmpty.has(key)) return false;
     return true;
@@ -390,9 +390,13 @@ export function openActivation(registry, session = {}, explicitActivationId = ''
 
   const current = next.sessions[sessionId] || {};
   const activations = { ...(current.activations || {}) };
+  const openedAfterSequence = nonNegativeSequence(
+    session.opened_after_turn_sequence,
+    nonNegativeSequence(current.last_turn_sequence, 0),
+  );
   const requestedSequence = nonNegativeSequence(
     session.turn_sequence ?? session.last_turn_sequence,
-    0,
+    openedAfterSequence,
   );
 
   if (current.active_activation_id === activationId && activations[activationId]?.status === 'active') {
@@ -430,7 +434,9 @@ export function openActivation(registry, session = {}, explicitActivationId = ''
     epoch,
     status: 'active',
     started_at: session.activation_started_at || session.started_at || '',
-    last_turn_sequence: requestedSequence,
+    opened_after_turn_sequence: openedAfterSequence,
+    ...(current.last_turn_id ? { opened_after_turn_id: current.last_turn_id } : {}),
+    last_turn_sequence: Math.max(openedAfterSequence, requestedSequence),
     ...(session.transcript_id ? { transcript_id: session.transcript_id } : {}),
     ...(session.transcript_path ? { transcript_path: session.transcript_path } : {}),
     ...(session.provider ? { provider: session.provider } : {}),
@@ -441,19 +447,40 @@ export function openActivation(registry, session = {}, explicitActivationId = ''
     active_activation_id: activationId,
     activation_epoch: epoch,
     activation_started_at: session.activation_started_at || session.started_at || '',
-    last_turn_sequence: requestedSequence,
+    last_turn_sequence: Math.max(openedAfterSequence, requestedSequence),
     activations,
   };
   return next;
 }
 
 export function advanceActivationTurn(registry, turn = {}) {
-  const next = cloneRegistry(registry);
+  let next = cloneRegistry(registry);
   const sessionId = turn.session_id || turn.canonical_session_id || '';
-  const current = next.sessions[sessionId];
+  let current = next.sessions[sessionId];
   if (!current) return next;
 
-  const activeId = current.active_activation_id || '';
+  const turnId = String(turn.turn_id || '');
+  const knownTurn = Boolean(turnId && (
+    current.last_turn_id === turnId
+    || current.last_prompt_turn_id === turnId
+    || Object.prototype.hasOwnProperty.call(current.turn_sequences || {}, turnId)
+  ));
+  if (knownTurn) return next;
+
+  let activeId = current.active_activation_id || '';
+  if ((!activeId || current.activations?.[activeId]?.status !== 'active') && turn.recovery_activation_id) {
+    next = openActivation(next, {
+      session_id: sessionId,
+      activation_id: turn.recovery_activation_id,
+      activation_started_at: turn.recovery_started_at || turn.started_at || '',
+      turn_sequence: turn.turn_sequence ?? current.last_turn_sequence,
+      transcript_id: turn.transcript_id || current.transcript_id,
+      transcript_path: turn.transcript_path || current.transcript_path,
+      provider: turn.provider || current.provider,
+    });
+    current = next.sessions[sessionId];
+    activeId = current.active_activation_id || '';
+  }
   if (turn.activation_id && activeId && turn.activation_id !== activeId) return next;
   const previous = nonNegativeSequence(current.last_turn_sequence, 0);
   const explicit = nonNegativeSequence(turn.turn_sequence ?? turn.last_turn_sequence);
@@ -466,9 +493,18 @@ export function advanceActivationTurn(registry, turn = {}) {
         nonNegativeSequence(activations[activeId].last_turn_sequence, 0),
         sequence,
       ),
+      ...(turnId ? { last_prompt_turn_id: turnId } : {}),
     };
   }
-  next.sessions[sessionId] = { ...current, last_turn_sequence: sequence, activations };
+  next.sessions[sessionId] = {
+    ...current,
+    last_turn_sequence: sequence,
+    ...(turnId ? {
+      last_prompt_turn_id: turnId,
+      turn_sequences: { ...(current.turn_sequences || {}), [turnId]: sequence },
+    } : {}),
+    activations,
+  };
   return next;
 }
 
@@ -478,23 +514,22 @@ export function resolveStopActivation(registry, stop = {}) {
   if (!entry) return '';
   if (stop.activation_id) return String(stop.activation_id);
 
+  const activeId = entry.active_activation_id || '';
+  const active = entry.activations?.[activeId];
+  if (!activeId || active?.status !== 'active') return '';
   const transcriptId = String(stop.transcript_id || '');
   const transcriptPath = String(stop.transcript_path || '');
   if (!transcriptId && !transcriptPath) return '';
-  const matches = Object.entries(entry.activations || {}).filter(([, activation]) => {
-    if (!activation) return false;
-    if (transcriptId && activation.transcript_id && activation.transcript_id !== transcriptId) return false;
-    const paths = [
-      ...(Array.isArray(activation.transcript_paths) ? activation.transcript_paths : []),
-      activation.transcript_path,
-    ].filter(Boolean);
-    if (transcriptPath && paths.length && !paths.some((path) => transcriptsMatch(path, transcriptPath))) return false;
-    return Boolean(
-      (transcriptId && activation.transcript_id === transcriptId)
-      || (transcriptPath && paths.some((path) => transcriptsMatch(path, transcriptPath))),
-    );
-  });
-  return matches.length === 1 ? matches[0][0] : '';
+  if (transcriptId && active.transcript_id && active.transcript_id !== transcriptId) return '';
+  const paths = [
+    ...(Array.isArray(active.transcript_paths) ? active.transcript_paths : []),
+    active.transcript_path,
+  ].filter(Boolean);
+  if (transcriptPath && paths.length && !paths.some((path) => transcriptsMatch(path, transcriptPath))) return '';
+  return (
+    (transcriptId && active.transcript_id === transcriptId)
+    || (transcriptPath && paths.some((path) => transcriptsMatch(path, transcriptPath)))
+  ) ? activeId : '';
 }
 
 function stopResult(registry, stopDisposition, canPromoteMemory = false) {
@@ -531,21 +566,31 @@ export function applyStopActivation(registry, stop = {}) {
   const stopSequence = nonNegativeSequence(stop.turn_sequence ?? stop.last_turn_sequence);
   const lastSequence = nonNegativeSequence(current.last_turn_sequence, 0);
   if (stopSequence === null) return stopResult(next, 'ambiguous');
+  const active = current.activations?.[activeId] || {};
+  const openedAfterSequence = nonNegativeSequence(active.opened_after_turn_sequence, 0);
+  if (stopSequence <= openedAfterSequence && active.epoch > 1) {
+    return stopResult(next, 'superseded');
+  }
+  const stopTurnId = String(stop.turn_id || '');
+  if (stopTurnId && active.last_stop_turn_id === stopTurnId) {
+    return stopResult(next, 'duplicate');
+  }
   if (stopSequence < lastSequence) return stopResult(next, 'stale_turn');
 
   const activations = { ...(current.activations || {}) };
   activations[activeId] = {
     ...(activations[activeId] || { activation_id: activeId, epoch: current.activation_epoch }),
-    status: 'done',
-    ended_at: stop.ended_at || '',
+    status: 'active',
     last_turn_sequence: stopSequence,
+    last_stop_turn_sequence: stopSequence,
+    ...(stopTurnId ? { last_stop_turn_id: stopTurnId } : {}),
   };
   next.sessions[sessionId] = {
     ...current,
-    status: 'done',
-    ended_at: stop.ended_at || current.ended_at || '',
-    active_activation_id: '',
-    last_turn_sequence: stopSequence,
+    status: 'active',
+    active_activation_id: activeId,
+    last_turn_sequence: Math.max(lastSequence, stopSequence),
+    ...(stopTurnId ? { last_turn_id: stopTurnId } : {}),
     activations,
   };
   return stopResult(next, 'applied', true);
@@ -584,7 +629,7 @@ export function upsertSessionRegistry(vaultBase, sessionId, patch) {
           activation_id: clean.activation_id,
           activation_started_at: clean.activation_started_at,
           started_at: clean.activation_started_at || clean.started_at,
-          last_turn_sequence: clean.last_turn_sequence,
+          last_turn_sequence: patch.last_turn_sequence,
           transcript_id: clean.transcript_id || current.transcript_id,
           transcript_path: clean.transcript_path || current.transcript_path,
           provider: clean.provider || current.provider,
@@ -597,7 +642,13 @@ export function upsertSessionRegistry(vaultBase, sessionId, patch) {
         {
           session_id: sessionId,
           activation_id: causalCurrent.active_activation_id || '',
+          recovery_activation_id: patch.recovery_activation_id || '',
+          recovery_started_at: patch.recovery_started_at || '',
+          turn_id: patch.turn_id || '',
           turn_sequence: patch.turn_sequence,
+          transcript_id: clean.transcript_id || causalCurrent.transcript_id,
+          transcript_path: clean.transcript_path || causalCurrent.transcript_path,
+          provider: clean.provider || causalCurrent.provider,
         },
       ).sessions[sessionId];
     }

--- a/hooks/session-ensure.mjs
+++ b/hooks/session-ensure.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { randomUUID } from 'crypto';
 import { existsSync, renameSync, statSync, writeFileSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import {
@@ -41,6 +42,16 @@ function turnSequenceFromInput(input = {}) {
   const value = input.turn_sequence ?? input.turnSequence;
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function causalTurnPatch(input, now) {
+  return {
+    advance_turn_sequence: true,
+    turn_sequence: turnSequenceFromInput(input),
+    turn_id: input.turn_id || input.turnId || '',
+    recovery_activation_id: randomUUID(),
+    recovery_started_at: formatLocalIso(now),
+  };
 }
 
 function buildSessionContent({ relPath, now, summary = 'session', sessionId = '', reason = 'Sessão criada automaticamente pelo hook UserPromptSubmit.' }) {
@@ -268,8 +279,7 @@ function activateExistingSession({ vaultBase, relPath, startedAt, sessionId, inp
     transcript_path: identity.transcriptPath,
     transcript_id: identity.transcriptId,
     provider: identity.provider,
-    advance_turn_sequence: true,
-    turn_sequence: turnSequenceFromInput(input),
+    ...causalTurnPatch(input, now),
   });
   return true;
 }
@@ -296,8 +306,7 @@ function createSession({ vaultBase, sessionId, input, now, identity }) {
     transcript_path: identity.transcriptPath,
     transcript_id: identity.transcriptId,
     provider: identity.provider,
-    advance_turn_sequence: true,
-    turn_sequence: turnSequenceFromInput(input),
+    ...causalTurnPatch(input, now),
   });
   return { relPath, startedAt };
 }
@@ -348,8 +357,7 @@ function main() {
           transcript_path: identity.transcriptPath,
           transcript_id: identity.transcriptId,
           provider: identity.provider,
-          advance_turn_sequence: true,
-          turn_sequence: turnSequenceFromInput(input),
+          ...causalTurnPatch(input, now),
         });
         writeHookOutput({});
         return;
@@ -393,8 +401,7 @@ function main() {
         transcript_path: identity.transcriptPath,
         transcript_id: identity.transcriptId,
         provider: identity.provider,
-        advance_turn_sequence: true,
-        turn_sequence: turnSequenceFromInput(input),
+        ...causalTurnPatch(input, now),
       });
       writeHookOutput({});
       return;

--- a/hooks/session-memory-lifecycle.mjs
+++ b/hooks/session-memory-lifecycle.mjs
@@ -1,0 +1,330 @@
+// Durable SessionStop memory publication split into three explicit phases:
+// registry-guarded outbox staging -> independent projection -> registry CAS outcome.
+// Keeping the MEMORY lock out of the registry critical section avoids lock inversion,
+// while the immutable outbox is the durable hand-off between both locks.
+import { buildSessionMemoryEvents } from './memory-handoff.mjs';
+import { detectMemoryMode } from './memory-mode.mjs';
+import { sanitizeMemoryText } from './memory-schema.mjs';
+import { enqueueMemoryEvent, projectMemoryOutbox } from './memory-store.mjs';
+import { mutateSessionRegistry } from './obsidian-common.mjs';
+
+const DEFAULT_OBSERVED_AT = '1970-01-01T00:00:00.000Z';
+
+const DEFAULT_DEPS = Object.freeze({
+  buildSessionMemoryEvents,
+  detectMemoryMode,
+  enqueueMemoryEvent,
+  mutateSessionRegistry,
+  projectMemoryOutbox,
+  sanitizeMemoryText,
+});
+
+function dependencies(overrides = {}) {
+  return { ...DEFAULT_DEPS, ...(overrides || {}) };
+}
+
+function nonNegativeInteger(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function normalizeContext(context = {}) {
+  const handoff = context.handoff && typeof context.handoff === 'object'
+    ? context.handoff
+    : context;
+  const identity = handoff.identity || context.identity || {};
+  const activation = handoff.activation || context.activation || {};
+  const turn = handoff.turn || context.turn || {};
+  const sessionId = String(
+    context.sessionId
+    || context.canonicalSessionId
+    || identity.canonicalConversationId
+    || '',
+  );
+  const activationId = String(context.activationId || activation.id || '');
+  const activationEpoch = nonNegativeInteger(
+    context.activationEpoch ?? activation.epoch,
+    0,
+  );
+  const turnId = String(context.turnId || turn.id || '');
+  const turnSequence = nonNegativeInteger(context.turnSequence ?? turn.sequence, 0);
+  const observedAt = String(context.observedAt || handoff.observedAt || DEFAULT_OBSERVED_AT);
+  const disposition = String(
+    context.disposition
+    || context.stopDisposition
+    || 'applied',
+  );
+
+  return {
+    sessionId,
+    activationId,
+    activationEpoch,
+    turnId,
+    turnSequence,
+    observedAt,
+    disposition,
+    handoff: {
+      ...handoff,
+      identity: { ...identity, canonicalConversationId: sessionId },
+      activation: { ...activation, id: activationId, epoch: activationEpoch },
+      turn: { ...turn, id: turnId, sequence: turnSequence },
+      observedAt,
+    },
+  };
+}
+
+function attemptIdentity(context, memoryMode) {
+  return {
+    v: 1,
+    memory_mode: memoryMode,
+    canonical_session_id: context.sessionId,
+    activation_id: context.activationId,
+    activation_epoch: context.activationEpoch,
+    turn_id: context.turnId,
+    turn_sequence: context.turnSequence,
+    observed_at: context.observedAt,
+  };
+}
+
+function sameAttempt(left, right) {
+  if (!left || !right) return false;
+  return String(left.canonical_session_id || '') === String(right.canonical_session_id || '')
+    && String(left.activation_id || '') === String(right.activation_id || '')
+    && nonNegativeInteger(left.activation_epoch, -1) === nonNegativeInteger(right.activation_epoch, -1)
+    && String(left.turn_id || '') === String(right.turn_id || '')
+    && nonNegativeInteger(left.turn_sequence, -1) === nonNegativeInteger(right.turn_sequence, -1);
+}
+
+function skippedAttempt(context, memoryMode, disposition) {
+  return {
+    ...attemptIdentity(context, memoryMode),
+    disposition,
+    state: 'skipped',
+    event_ids: [],
+    checkpoint: null,
+  };
+}
+
+function causalDisposition(entry, context) {
+  if (!entry || !context.sessionId || !context.activationId || !context.turnId) return 'ambiguous';
+  if (['ambiguous', 'stale_turn', 'superseded'].includes(context.disposition)) {
+    return context.disposition;
+  }
+
+  const activeId = String(entry.active_activation_id || '');
+  const active = entry.activations?.[activeId];
+  if (!activeId || activeId !== context.activationId || active?.status !== 'active') {
+    return 'superseded';
+  }
+  if (nonNegativeInteger(active.epoch, -1) !== context.activationEpoch) return 'superseded';
+
+  const openedAfter = nonNegativeInteger(active.opened_after_turn_sequence, 0);
+  if (context.activationEpoch > 1 && context.turnSequence <= openedAfter) return 'superseded';
+
+  const lastStopSequence = nonNegativeInteger(
+    active.last_stop_turn_sequence,
+    nonNegativeInteger(entry.last_turn_sequence, 0),
+  );
+  const lastStopTurnId = String(active.last_stop_turn_id || entry.last_turn_id || '');
+  if (lastStopSequence > context.turnSequence) return 'stale_turn';
+  if (lastStopTurnId && lastStopTurnId !== context.turnId) return 'stale_turn';
+  return 'applied';
+}
+
+function retryAttempt(previous) {
+  if (previous.state === 'projected' || previous.state === 'duplicate') {
+    return { ...previous, disposition: 'duplicate', state: 'duplicate', retry: true };
+  }
+  if (previous.state === 'enqueued' || previous.state === 'degraded') {
+    return { ...previous, state: 'enqueued', retry: true };
+  }
+  return null;
+}
+
+function canPersistAmbiguousSkip(entry, candidate) {
+  if (candidate.disposition !== 'ambiguous') return false;
+  const entryEpoch = nonNegativeInteger(entry.activation_epoch, -1);
+  if (entryEpoch > candidate.activation_epoch) return false;
+  if (entryEpoch === candidate.activation_epoch
+      && nonNegativeInteger(entry.last_turn_sequence, -1) > candidate.turn_sequence) {
+    return false;
+  }
+
+  const previous = entry.last_memory_attempt;
+  if (!previous) return true;
+  const previousEpoch = nonNegativeInteger(previous.activation_epoch, -1);
+  if (previousEpoch !== candidate.activation_epoch) return previousEpoch < candidate.activation_epoch;
+  const previousTurn = nonNegativeInteger(previous.turn_sequence, -1);
+  if (previousTurn !== candidate.turn_sequence) return previousTurn < candidate.turn_sequence;
+  return sameAttempt(previous, candidate) && previous.state === 'skipped';
+}
+
+/**
+ * Revalidate the Stop under SESSION_REGISTRY.lock, durably enqueue every event, and only
+ * then acknowledge `last_memory_attempt.state = enqueued` in the same registry mutation.
+ */
+export function stageStopMemoryAttempt(vaultBase, rawContext, overrides = {}) {
+  const deps = dependencies(overrides);
+  const context = normalizeContext(rawContext);
+  const mode = deps.detectMemoryMode(vaultBase).mode;
+  if (mode === 'legacy') return skippedAttempt(context, 'legacy', 'legacy');
+
+  const identity = attemptIdentity(context, 'v2');
+  let staged = null;
+  deps.mutateSessionRegistry(vaultBase, (registry) => {
+    const entry = registry.sessions?.[context.sessionId];
+    const disposition = causalDisposition(entry, context);
+    if (disposition !== 'applied') {
+      staged = skippedAttempt(context, 'v2', disposition);
+      if (entry && canPersistAmbiguousSkip(entry, staged)) {
+        entry.last_memory_attempt = staged;
+        entry.memory_status = 'skipped';
+        if (context.activationId) entry.memory_activation_id = context.activationId;
+      }
+      return staged;
+    }
+
+    const previous = entry.last_memory_attempt;
+    if (sameAttempt(previous, identity)) {
+      const retry = retryAttempt(previous);
+      if (retry) {
+        staged = retry;
+        return staged;
+      }
+    }
+
+    const events = deps.buildSessionMemoryEvents(context.handoff);
+    if (!Array.isArray(events) || events.length === 0) {
+      throw new TypeError('Session memory staging requires at least one event.');
+    }
+    for (const event of events) deps.enqueueMemoryEvent(vaultBase, event);
+
+    staged = {
+      ...identity,
+      disposition: 'applied',
+      state: 'enqueued',
+      event_ids: events.map((event) => String(event.event_id || '')),
+      checkpoint: null,
+    };
+    entry.last_memory_attempt = staged;
+    entry.memory_status = 'enqueued';
+    entry.memory_activation_id = context.activationId;
+    return staged;
+  });
+
+  return staged || skippedAttempt(context, 'v2', 'ambiguous');
+}
+
+function outcome(attempt, state, extra = {}) {
+  const eventIds = Array.isArray(attempt?.event_ids) ? [...attempt.event_ids] : [];
+  return {
+    ...attempt,
+    ...extra,
+    state,
+    status: state,
+    event_ids: eventIds,
+    eventIds,
+    eventCount: eventIds.length,
+  };
+}
+
+/** Project outside the registry lock. The outbox remains the recovery authority on failure. */
+export function projectStopMemoryAttempt(vaultBase, attempt, overrides = {}) {
+  const deps = dependencies(overrides);
+  if (attempt?.memory_mode === 'legacy') {
+    return { ...outcome(attempt, 'skipped'), status: 'legacy' };
+  }
+  if (attempt?.state === 'duplicate') return outcome(attempt, 'duplicate');
+  if (attempt?.state === 'skipped') return outcome(attempt, 'skipped');
+
+  try {
+    const projection = deps.projectMemoryOutbox(vaultBase, overrides.projectOptions || {});
+    if (projection?.status === 'busy') {
+      return outcome(attempt, 'degraded', {
+        error: 'memory projector busy; outbox preserved for replay',
+        checkpoint: null,
+      });
+    }
+    return outcome(attempt, 'projected', {
+      checkpoint: {
+        revision: projection.revision,
+        event_cursor: projection.eventCursor,
+        state_hash: projection.stateHash,
+      },
+    });
+  } catch (error) {
+    return outcome(attempt, 'degraded', {
+      error: deps.sanitizeMemoryText(error?.message || String(error)),
+      checkpoint: null,
+    });
+  }
+}
+
+function activeContextMatches(entry, attempt) {
+  const activeId = String(entry?.active_activation_id || '');
+  const active = entry?.activations?.[activeId];
+  return activeId === String(attempt.activation_id || '')
+    && active?.status === 'active'
+    && nonNegativeInteger(active.epoch, -1) === nonNegativeInteger(attempt.activation_epoch, -1);
+}
+
+function storedAttempt(outcomeValue) {
+  const stored = {
+    v: 1,
+    memory_mode: 'v2',
+    canonical_session_id: String(outcomeValue.canonical_session_id || ''),
+    activation_id: String(outcomeValue.activation_id || ''),
+    activation_epoch: nonNegativeInteger(outcomeValue.activation_epoch, 0),
+    turn_id: String(outcomeValue.turn_id || ''),
+    turn_sequence: nonNegativeInteger(outcomeValue.turn_sequence, 0),
+    disposition: String(outcomeValue.disposition || 'applied'),
+    state: outcomeValue.state,
+    event_ids: Array.isArray(outcomeValue.event_ids) ? [...outcomeValue.event_ids] : [],
+    observed_at: String(outcomeValue.observed_at || DEFAULT_OBSERVED_AT),
+  };
+  if (outcomeValue.state === 'projected' && outcomeValue.checkpoint) {
+    stored.checkpoint = { ...outcomeValue.checkpoint };
+  }
+  if (outcomeValue.state === 'degraded' && outcomeValue.error) {
+    stored.error = String(outcomeValue.error);
+  }
+  return stored;
+}
+
+/** Persist a final outcome only while the exact staged activation/epoch/turn still owns it. */
+export function recordStopMemoryOutcome(vaultBase, attempt, outcomeValue, overrides = {}) {
+  if (attempt?.memory_mode === 'legacy' || outcomeValue?.status === 'legacy') {
+    return { ...outcomeValue, persisted: false, reason: 'legacy' };
+  }
+  if (outcomeValue?.state === 'duplicate' || outcomeValue?.state === 'skipped') {
+    return { ...outcomeValue, persisted: false, reason: outcomeValue.state };
+  }
+  if (!sameAttempt(attempt, outcomeValue)) {
+    return { ...outcomeValue, persisted: false, reason: 'stale-causal-context' };
+  }
+  if (!['projected', 'degraded'].includes(outcomeValue?.state)) {
+    return { ...outcomeValue, persisted: false, reason: 'non-final-outcome' };
+  }
+
+  const deps = dependencies(overrides);
+  let result = { ...outcomeValue, persisted: false, reason: 'stale-causal-context' };
+  deps.mutateSessionRegistry(vaultBase, (registry) => {
+    const entry = registry.sessions?.[attempt.canonical_session_id];
+    if (!entry || !activeContextMatches(entry, attempt)) return result;
+    if (!sameAttempt(entry.last_memory_attempt, attempt)) return result;
+
+    entry.last_memory_attempt = storedAttempt(outcomeValue);
+    entry.memory_status = outcomeValue.state;
+    entry.memory_activation_id = attempt.activation_id;
+    if (outcomeValue.state === 'projected') {
+      entry.memory_checkpoint = { ...outcomeValue.checkpoint };
+    } else {
+      // This branch is reachable only after the exact attempt CAS above. A stale outcome
+      // cannot clear a checkpoint owned by a newer activation/turn.
+      delete entry.memory_checkpoint;
+    }
+    result = { ...outcomeValue, persisted: true, reason: 'recorded' };
+    return result;
+  });
+  return result;
+}

--- a/hooks/session-stop.mjs
+++ b/hooks/session-stop.mjs
@@ -17,6 +17,11 @@ import { enqueueMemoryEvent, projectMemoryOutbox } from './memory-store.mjs';
 import { detectMemoryMode } from './memory-mode.mjs';
 import { sanitizeMemoryText } from './memory-schema.mjs';
 import {
+  projectStopMemoryAttempt,
+  recordStopMemoryOutcome,
+  stageStopMemoryAttempt,
+} from './session-memory-lifecycle.mjs';
+import {
   ensureDir,
   findActiveSessionByTranscript,
   formatDate,
@@ -525,6 +530,26 @@ export function parseTranscript(transcriptPath) {
     if (looksLikeClaudeEvent(event)) return parseClaudeTranscript(transcriptPath);
   }
   return parseCodexTranscript(transcriptPath);
+}
+
+export function resolveTurnIdentity(transcript, requestedTurnId = '') {
+  const turns = Array.isArray(transcript?.turns) ? transcript.turns : [];
+  const requested = String(requestedTurnId || '');
+  let index = requested
+    ? turns.findIndex((turn) => String(turn?.turnId || '') === requested)
+    : -1;
+  if (requested && index < 0) return null;
+  if (index < 0 && transcript?.latestTurnId) {
+    index = turns.findIndex((turn) => String(turn?.turnId || '') === String(transcript.latestTurnId));
+  }
+  if (index < 0) index = turns.length - 1;
+  const turn = turns[index];
+  if (!turn?.turnId) return null;
+  return {
+    id: String(turn.turnId),
+    order: index + 1,
+    observedAt: String(turn.timestamp || ''),
+  };
 }
 
 function compactText(text, max = 600) {
@@ -1095,7 +1120,18 @@ function pingObsidianVault(apiKey) {
   } catch {}
 }
 
-function main() {
+export function shouldAbortStopAfterStaging(causalStop, memoryAttempt) {
+  const rejectedByV2Revalidation = memoryAttempt?.memory_mode === 'v2'
+    && memoryAttempt?.state === 'skipped';
+  if (rejectedByV2Revalidation) return true;
+  return Boolean(
+    causalStop
+    && !causalStop.canPromoteMemory
+    && memoryAttempt?.state !== 'enqueued'
+  );
+}
+
+export function main({ stageMemory = stageStopMemoryAttempt } = {}) {
   const input = readHookInput();
   if (input.stop_hook_active) {
     writeHookOutput({});
@@ -1132,15 +1168,34 @@ function main() {
     return;
   }
 
-  const tx = parseTranscript(input.transcript_path || input.transcriptPath);
-  const turnId = input.turn_id || tx.latestTurnId || String(Date.now());
+  const tx = parseTranscript(identity.transcriptPath || input.transcript_path || input.transcriptPath);
+  const requestedTurnId = String(input.turn_id || input.turnId || '');
   const sessionId = identity.canonicalConversationId;
   const finalizing = shouldFinalizeSession();
+  const turnIdentity = resolveTurnIdentity(tx, requestedTurnId);
+  if (!turnIdentity) {
+    if (finalizing) {
+      const activeId = String(entry.active_activation_id || '');
+      const active = entry.activations?.[activeId] || {};
+      stageMemory(vaultBase, {
+        sessionId,
+        activationId: activeId,
+        activationEpoch: Number(active.epoch || entry.activation_epoch || 0),
+        turnId: requestedTurnId || 'unresolved-turn',
+        turnSequence: Number(entry.last_turn_sequence || 0),
+        disposition: 'ambiguous',
+        observedAt: new Date(0).toISOString(),
+      });
+    }
+    const message = 'wendkeep: Stop ambiguous; o turno solicitado não foi provado pelo transcript.';
+    process.stderr.write(`[wendkeep] ${message}\n`);
+    writeHookOutput({ systemMessage: message });
+    return;
+  }
+  const turnId = turnIdentity.id;
   const now = finalizing ? new Date() : null;
   const endedAt = finalizing ? formatLocalIso(now) : '';
-  const stopTurnSequence = Number.isSafeInteger(Number(input.turn_sequence))
-    ? Number(input.turn_sequence)
-    : Number(entry.last_turn_sequence || 0);
+  const stopTurnSequence = turnIdentity.order;
   const causalStop = finalizing
     ? mutateSessionRegistry(vaultBase, (registry) => {
       const activationId = resolveStopActivation(registry, {
@@ -1152,6 +1207,7 @@ function main() {
       const cas = applyStopActivation(registry, {
         session_id: sessionId,
         activation_id: activationId,
+        turn_id: turnId,
         turn_sequence: stopTurnSequence,
         ended_at: endedAt,
       });
@@ -1176,8 +1232,44 @@ function main() {
       };
     })
     : null;
-  if (causalStop && !causalStop.canPromoteMemory) {
-    const message = `wendkeep: Stop ${causalStop.stopDisposition}; uma activation mais nova foi preservada e a memória não foi promovida.`;
+  let memoryHandoff = null;
+  let memoryAttempt = null;
+  if (finalizing) {
+    let projectId = '';
+    try {
+      projectId = JSON.parse(readFileSync(join(vaultBase, '.brain', 'PROJECT.json'), 'utf8')).projectId || '';
+    } catch { /* the staging validator exposes an observable failure below */ }
+    const finalSummary = sessionFinalSummary(tx);
+    const memoryEvidence = collectLifecycleEvidence(vaultBase, {
+      changeSlug: entry.change_slug,
+      summary: finalSummary,
+      noteRel: sessionRel,
+    });
+    memoryHandoff = {
+      projectId,
+      identity,
+      activation: {
+        id: causalStop?.activationId || '',
+        epoch: Number(causalStop?.activation?.epoch || entry.activation_epoch || 0),
+      },
+      turn: { id: turnId, sequence: stopTurnSequence },
+      noteRel: sessionRel,
+      observedAt: turnIdentity.observedAt || new Date(0).toISOString(),
+      summary: finalSummary,
+      evidence: memoryEvidence,
+    };
+    memoryAttempt = stageMemory(vaultBase, {
+      handoff: memoryHandoff,
+      disposition: causalStop?.stopDisposition || 'ambiguous',
+    });
+  }
+  if (shouldAbortStopAfterStaging(causalStop, memoryAttempt)) {
+    const disposition = memoryAttempt?.disposition || causalStop?.stopDisposition || 'ambiguous';
+    if (disposition === 'duplicate' && memoryAttempt?.state === 'duplicate') {
+      writeHookOutput({});
+      return;
+    }
+    const message = `wendkeep: Stop ${disposition}; uma activation mais nova foi preservada e a memória não foi promovida.`;
     process.stderr.write(`[wendkeep] ${message}\n`);
     writeHookOutput({ systemMessage: message });
     return;
@@ -1252,40 +1344,24 @@ function main() {
     last_logged_turn_id: turnId,
   });
 
-  let projectId = '';
-  try {
-    projectId = JSON.parse(readFileSync(join(vaultBase, '.brain', 'PROJECT.json'), 'utf8')).projectId || '';
-  } catch { /* store validator reports a degraded handoff below */ }
-  const finalSummary = sessionFinalSummary(tx);
-  const memoryEvidence = collectLifecycleEvidence(vaultBase, {
-    changeSlug: entry.change_slug,
-    summary: finalSummary,
-    noteRel: sessionRel,
-  });
-  const memoryResult = commitSessionMemory(vaultBase, {
-    projectId,
-    identity,
-    activation: {
-      id: causalStop.activationId,
-      epoch: Number(causalStop.activation?.epoch || entry.activation_epoch || 0),
-    },
-    turn: { id: turnId, sequence: stopTurnSequence },
-    noteRel: sessionRel,
-    observedAt: new Date().toISOString(),
-    summary: finalSummary,
-    evidence: memoryEvidence,
-  });
-  mutateSessionRegistry(vaultBase, (registry) => {
-    const current = registry.sessions[sessionId];
-    if (!current) return null;
-    registry.sessions[sessionId] = {
-      ...current,
-      memory_status: memoryResult.status,
-      memory_activation_id: causalStop.activationId,
-      ...(memoryResult.checkpoint ? { memory_checkpoint: memoryResult.checkpoint } : {}),
-    };
-    return null;
-  });
+  const memoryResult = projectStopMemoryAttempt(vaultBase, memoryAttempt);
+  if (memoryResult.status === 'legacy') {
+    mutateSessionRegistry(vaultBase, (registry) => {
+      const current = registry.sessions[sessionId];
+      const active = current?.activations?.[current.active_activation_id || ''];
+      if (!current
+        || current.active_activation_id !== memoryAttempt.activation_id
+        || Number(active?.epoch || 0) !== Number(memoryAttempt.activation_epoch || 0)) return null;
+      registry.sessions[sessionId] = {
+        ...current,
+        memory_status: 'legacy',
+        memory_activation_id: memoryAttempt.activation_id,
+      };
+      return null;
+    });
+  } else {
+    recordStopMemoryOutcome(vaultBase, memoryAttempt, memoryResult);
+  }
 
   // Reconstrói índice (camada fria) + digest (camada quente) ao finalizar. Nunca derruba o Stop.
   try {

--- a/hooks/vault-health.mjs
+++ b/hooks/vault-health.mjs
@@ -121,27 +121,117 @@ function readJsonLines(path, label) {
 
 function inspectOutbox(vaultBase, projectId) {
   const dir = join(vaultBase, '.brain', 'memory-outbox');
-  if (!existsSync(dir)) return { count: 0, errors: [] };
+  if (!existsSync(dir)) return { count: 0, errors: [], eventIds: new Set() };
   const files = readdirSync(dir).filter((name) => name.endsWith('.json')).sort();
   const errors = [];
+  const eventIds = new Set();
   for (const name of files) {
     const path = join(dir, name);
     try {
       const event = JSON.parse(readFileSync(path, 'utf8'));
       const validation = validateMemoryEvent(event, projectId ? { projectId } : {});
       if (!validation.ok) errors.push(`${name}: ${validation.errors.join(' ')}`);
+      else eventIds.add(event.event_id);
     } catch (error) {
       errors.push(`${name}: JSON inválido: ${error.message}`);
     }
   }
-  return { count: files.length, errors };
+  return { count: files.length, errors, eventIds };
+}
+
+function checkpointMatchesLedgerPrefix(checkpoint, eventIds, ledgerEvents) {
+  if (!checkpoint || typeof checkpoint !== 'object') return false;
+  if (!Number.isInteger(checkpoint.revision) || checkpoint.revision < 0) return false;
+  if (typeof checkpoint.event_cursor !== 'string' || !checkpoint.event_cursor) return false;
+  if (typeof checkpoint.state_hash !== 'string' || !checkpoint.state_hash) return false;
+
+  const cursorIndex = ledgerEvents.findIndex((event) => event?.event_id === checkpoint.event_cursor);
+  if (cursorIndex < 0) return false;
+  const prefix = ledgerEvents.slice(0, cursorIndex + 1);
+  const prefixIds = new Set(prefix.map((event) => event.event_id));
+  if (eventIds.some((eventId) => !prefixIds.has(eventId))) return false;
+
+  try {
+    const replay = reduceMemoryEvents(prefix);
+    return checkpoint.revision === replay.revision
+      && checkpoint.event_cursor === replay.eventCursor
+      && checkpoint.state_hash === replay.stateHash;
+  } catch {
+    return false;
+  }
+}
+
+function checkMemoryAttempts(registry, { ledgerEvents = [], outboxEventIds = new Set() } = {}) {
+  const failures = [];
+  const warnings = [];
+  const ledgerEventIds = new Set(ledgerEvents.map((event) => event?.event_id).filter(Boolean));
+  const attempts = Object.values(registry?.sessions || {})
+    .map((entry) => entry?.last_memory_attempt)
+    .filter((attempt) => attempt && typeof attempt === 'object' && attempt.memory_mode === 'v2');
+
+  for (const attempt of attempts) {
+    const state = String(attempt.state || '');
+    const disposition = String(attempt.disposition || '');
+    const eventIds = Array.isArray(attempt.event_ids)
+      ? [...new Set(attempt.event_ids.filter((eventId) => typeof eventId === 'string' && eventId))]
+      : [];
+
+    if (state === 'skipped' && disposition === 'ambiguous') {
+      failures.push(`Lifecycle de memória v2 ambíguo: Stop pulou a publicação sem identidade causal suficiente. Inspecione com: ${MEMORY_STATUS_COMMAND}.`);
+      continue;
+    }
+
+    if (state === 'skipped' && ['stale_turn', 'superseded'].includes(disposition)) {
+      if (eventIds.length) {
+        failures.push(`Stop stale/superseded emitiu event_ids apesar da rejeição causal. Inspecione com: ${MEMORY_STATUS_COMMAND}.`);
+      } else {
+        warnings.push('Stop stale/superseded foi descartado sem publicar memória.');
+      }
+      continue;
+    }
+
+    if (disposition !== 'applied') {
+      if (state === 'skipped') warnings.push('Attempt de memória v2 foi descartado sem publicação.');
+      else failures.push(`Attempt de memória v2 possui disposition não reconhecida para o estado informado. Inspecione com: ${MEMORY_STATUS_COMMAND}.`);
+      continue;
+    }
+
+    if (!eventIds.length) {
+      failures.push(`Attempt v2 aplicado não declarou event_ids; publicação perdida. Inspecione com: ${MEMORY_STATUS_COMMAND}.`);
+      continue;
+    }
+
+    if (state === 'enqueued' || state === 'degraded') {
+      const missing = eventIds.filter((eventId) => !ledgerEventIds.has(eventId) && !outboxEventIds.has(eventId));
+      if (missing.length) {
+        failures.push(`Attempt v2 perdeu ${missing.length} evento(s): ausentes do ledger e da outbox. Inspecione com: ${MEMORY_STATUS_COMMAND}.`);
+      } else {
+        warnings.push(`Attempt de memória v2 ${state} permanece recuperável: ${eventIds.length} evento(s) durável(is) no ledger e/ou outbox.`);
+      }
+      continue;
+    }
+
+    if (state === 'projected') {
+      const outsideLedger = eventIds.filter((eventId) => !ledgerEventIds.has(eventId));
+      if (outsideLedger.length) {
+        failures.push(`Attempt projetado perdeu ${outsideLedger.length} evento(s) no ledger. Inspecione com: ${MEMORY_STATUS_COMMAND}.`);
+      } else if (!checkpointMatchesLedgerPrefix(attempt.checkpoint, eventIds, ledgerEvents)) {
+        failures.push(`Checkpoint do attempt projetado diverge do prefixo rederivado do ledger. Inspecione com: ${MEMORY_STATUS_COMMAND}.`);
+      }
+      continue;
+    }
+
+    failures.push(`Attempt de memória v2 possui state inválido. Inspecione com: ${MEMORY_STATUS_COMMAND}.`);
+  }
+
+  return { failures, warnings };
 }
 
 /**
  * Read-only consistency check for the local memory-v2 bundle. It intentionally
  * does not acquire MEMORY.lock or invoke the projector/repair paths.
  */
-export function checkMemoryBundle(vaultBase) {
+export function checkMemoryBundle(vaultBase, { registry } = {}) {
   const brain = join(vaultBase, '.brain');
   const mode = detectMemoryMode(vaultBase);
   if (mode.mode === 'legacy') {
@@ -206,6 +296,13 @@ export function checkMemoryBundle(vaultBase) {
       failures.push(`Projeção SHARED stale/lag (${divergences.join('; ')}). Inspecione com: ${MEMORY_STATUS_COMMAND}.`);
     }
   }
+
+  const lifecycle = checkMemoryAttempts(registry || readSessionRegistry(vaultBase), {
+    ledgerEvents: bundle.ledger?.events || [],
+    outboxEventIds: outbox.eventIds,
+  });
+  failures.push(...lifecycle.failures);
+  warnings.push(...lifecycle.warnings);
 
   const unresolved = candidates.items.filter((item) => !['resolved', 'rejected', 'superseded'].includes(item?.status));
   const activeConflicts = unresolved.filter((item) => item?.reason === 'conflict');
@@ -332,7 +429,7 @@ export function runVaultHealth({ vaultBase, session = '' }) {
   ];
   let memory = { status: 'legacy', metrics: {} };
   if (memoryMarkers.some((path) => existsSync(path))) {
-    memory = checkMemoryBundle(vaultBase);
+    memory = checkMemoryBundle(vaultBase, { registry });
     failures.push(...memory.failures.map((item) => `Memória: ${item}`));
     warnings.push(...memory.warnings.map((item) => `Memória: ${item}`));
   } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.58.2",
+  "version": "0.58.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.58.2",
+      "version": "0.58.3",
       "license": "MIT",
       "bin": {
         "wendkeep": "bin/wendkeep.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.58.2",
+  "version": "0.58.3",
   "description": "A persistent-memory harness for AI coding agents on your Obsidian vault: turn-by-turn session capture plus a native, zero-dependency spec→change→verify→archive loop (sensor-gated, independent verdict, mutation discrimination). Local-first, agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "bin": {

--- a/src/taxonomy.mjs
+++ b/src/taxonomy.mjs
@@ -37,6 +37,7 @@ export const HOOK_FILES = [
   'memory-schema.mjs',
   'memory-store.mjs',
   'memory-handoff.mjs',
+  'session-memory-lifecycle.mjs',
   'change-core.mjs',
   'spec-core.mjs',
   'sensors-core.mjs',

--- a/tests/fixtures/synthetic-memory-lifecycle.mjs
+++ b/tests/fixtures/synthetic-memory-lifecycle.mjs
@@ -1,0 +1,258 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { renderSharedMemory } from '../../hooks/memory-schema.mjs';
+
+const artificialInstant = (offset = 0) => new Date(offset).toISOString();
+const artificialCommit = 'a'.repeat(40);
+
+export const SYNTHETIC_MEMORY = Object.freeze({
+  projectId: 'wk-fixture-example-project',
+  vaultName: '.wk-fixture-example-vault',
+  sessionId: 'wk-fixture-example-session',
+  conversationId: 'wk-fixture-example-conversation',
+  activationOne: 'wk-fixture-example-activation-one',
+  activationTwo: 'wk-fixture-example-activation-two',
+  turnOne: 'wk-fixture-example-turn-one',
+  changeSlug: 'wk-fixture-example-change',
+  nextActionId: 'wk-fixture-example-follow-up',
+  noteRel: '03-Sessões/wk-fixture-example-session.md',
+  transcriptName: 'wk-fixture-example-transcript.jsonl',
+  observedAt: artificialInstant(),
+  artificialCommit,
+  userMessage: '[wk-fixture] artificial user request for lifecycle verification.',
+  agentMessage: '[wk-fixture] artificial agent response for lifecycle verification.',
+});
+
+export const SYNTHETIC_SUMMARY_FACTS = Object.freeze([
+  '[wk-fixture] archived change evidence is artificial.',
+  '[wk-fixture] verification coverage is artificial and green.',
+  `[wk-fixture] local commit ${artificialCommit}, sem push.`,
+  `[wk-fixture] A próxima change será ${SYNTHETIC_MEMORY.nextActionId}.`,
+]);
+
+export const SYNTHETIC_SUMMARY = SYNTHETIC_SUMMARY_FACTS.join(' ');
+
+export const SYNTHETIC_MEMORY_FACTS = Object.freeze([
+  SYNTHETIC_MEMORY.changeSlug,
+  'ADR-0001',
+  'wk-fixture-example-sensor-alpha',
+  SYNTHETIC_MEMORY.artificialCommit,
+  SYNTHETIC_MEMORY.nextActionId,
+  '[wk-fixture] archived change evidence is artificial.',
+  'wk-fixture-example-session.md',
+]);
+
+export function syntheticWindowsHomePath() {
+  const slash = '\\';
+  return ['C:', slash, 'Users', slash, 'wk-fixture-example-user', slash, SYNTHETIC_MEMORY.transcriptName].join('');
+}
+
+export function makeSyntheticHandoff({ summary = SYNTHETIC_SUMMARY, evidence = {} } = {}) {
+  return {
+    projectId: SYNTHETIC_MEMORY.projectId,
+    identity: {
+      canonicalConversationId: SYNTHETIC_MEMORY.conversationId,
+      provider: 'codex',
+    },
+    activation: { id: SYNTHETIC_MEMORY.activationOne, epoch: 1 },
+    turn: { id: SYNTHETIC_MEMORY.turnOne, sequence: 1 },
+    noteRel: SYNTHETIC_MEMORY.noteRel,
+    observedAt: SYNTHETIC_MEMORY.observedAt,
+    summary,
+    evidence,
+  };
+}
+
+function seedMemoryFiles(vault) {
+  const brain = join(vault, '.brain');
+  mkdirSync(brain, { recursive: true });
+  writeFileSync(join(brain, 'CORE.md'), '# WK Fixture Core\n\n[WK fixture] immutable artificial baseline.\n');
+  writeFileSync(join(brain, 'SHARED_MEMORY.md'), renderSharedMemory());
+  writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), '');
+  writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), '');
+  return brain;
+}
+
+export function seedSyntheticMemoryVault() {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-fixture-example-memory-'));
+  seedMemoryFiles(vault);
+  return vault;
+}
+
+export function seedSyntheticLifecycleEvidence(vault) {
+  const archived = join(vault, '08-Mudanças', '_arquivo', SYNTHETIC_MEMORY.changeSlug);
+  const decisions = join(vault, '04-Decisões');
+  mkdirSync(archived, { recursive: true });
+  mkdirSync(decisions, { recursive: true });
+
+  writeFileSync(join(archived, 'verdict.json'), JSON.stringify({
+    ok: true,
+    coverage: Array.from({ length: 3 }, (_, index) => ({
+      req: `WK-FIXTURE-${index + 1}`,
+      covered: true,
+    })),
+  }));
+  writeFileSync(join(archived, 'evidencia.json'), JSON.stringify([
+    { id: 'wk-fixture-example-sensor-alpha', status: 'green' },
+    { id: 'wk-fixture-example-sensor-beta', status: 'green' },
+    { id: 'wk-fixture-example-sensor-gamma', status: 'green' },
+  ]));
+  writeFileSync(
+    join(decisions, `ADR-0001-${SYNTHETIC_MEMORY.changeSlug}.md`),
+    '# WK Fixture ADR\n\n[WK fixture] artificial lifecycle decision.\n',
+  );
+}
+
+function syntheticSessionNote() {
+  return `---
+type: session
+session_id: ${SYNTHETIC_MEMORY.sessionId}
+provider: codex
+status: active
+ended_at:
+---
+
+# [wk-fixture] Artificial session
+
+## Objetivo da sessão
+
+> [wk-fixture] Exercise the lifecycle without consumer data.
+
+## Iterações
+
+## Decisões geradas nesta sessão
+
+Nenhuma decisão registrada ainda.
+
+## Bugs gerados nesta sessão
+
+Nenhum bug registrado ainda.
+
+## Aprendizados gerados nesta sessão
+
+Nenhum aprendizado registrado ainda.
+
+## Pendências
+
+- [ ] [wk-fixture] Review the artificial lifecycle result.
+
+## Encerramento
+
+[wk-fixture] Session is still active.
+`;
+}
+
+function transcriptEvents(project) {
+  return [
+    {
+      type: 'session_meta',
+      timestamp: artificialInstant(),
+      payload: {
+        id: SYNTHETIC_MEMORY.sessionId,
+        cwd: project,
+        model: 'gpt-5.6-sol',
+        model_provider: 'openai',
+      },
+    },
+    {
+      type: 'event_msg',
+      timestamp: artificialInstant(1_000),
+      payload: { type: 'task_started', turn_id: SYNTHETIC_MEMORY.turnOne },
+    },
+    {
+      type: 'event_msg',
+      timestamp: artificialInstant(2_000),
+      payload: {
+        type: 'user_message',
+        turn_id: SYNTHETIC_MEMORY.turnOne,
+        message: SYNTHETIC_MEMORY.userMessage,
+      },
+    },
+    {
+      type: 'event_msg',
+      timestamp: artificialInstant(3_000),
+      payload: {
+        type: 'agent_message',
+        turn_id: SYNTHETIC_MEMORY.turnOne,
+        message: SYNTHETIC_SUMMARY,
+      },
+    },
+  ];
+}
+
+export function seedSyntheticHybridLifecycle({ withSeededSession = true } = {}) {
+  const project = mkdtempSync(join(tmpdir(), 'wk-fixture-example-project-'));
+  const vault = join(project, SYNTHETIC_MEMORY.vaultName);
+  const brain = seedMemoryFiles(vault);
+  const sessionPath = join(vault, ...SYNTHETIC_MEMORY.noteRel.split('/'));
+  const transcript = join(project, SYNTHETIC_MEMORY.transcriptName);
+
+  mkdirSync(dirname(sessionPath), { recursive: true });
+  seedSyntheticLifecycleEvidence(vault);
+
+  writeFileSync(join(project, '.wendkeep.json'), JSON.stringify({
+    schemaVersion: 1,
+    projectId: SYNTHETIC_MEMORY.projectId,
+    vault: SYNTHETIC_MEMORY.vaultName,
+  }));
+  writeFileSync(join(brain, 'PROJECT.json'), JSON.stringify({
+    schemaVersion: 1,
+    projectId: SYNTHETIC_MEMORY.projectId,
+  }));
+  if (withSeededSession) writeFileSync(sessionPath, syntheticSessionNote());
+
+  const events = transcriptEvents(project);
+  writeFileSync(transcript, `${events.map((event) => JSON.stringify(event)).join('\n')}\n`);
+
+  if (withSeededSession) {
+    writeFileSync(join(brain, 'SESSION_REGISTRY.json'), JSON.stringify({
+      version: 1,
+      sessions: {
+        [SYNTHETIC_MEMORY.sessionId]: {
+          session_file: SYNTHETIC_MEMORY.noteRel,
+          status: 'active',
+          provider: 'codex',
+          transcript_path: transcript,
+          transcript_id: SYNTHETIC_MEMORY.sessionId,
+          change_slug: SYNTHETIC_MEMORY.changeSlug,
+          activation_id: SYNTHETIC_MEMORY.activationOne,
+          active_activation_id: SYNTHETIC_MEMORY.activationOne,
+          activation_epoch: 1,
+          last_turn_sequence: 0,
+          activations: {
+            [SYNTHETIC_MEMORY.activationOne]: {
+              activation_id: SYNTHETIC_MEMORY.activationOne,
+              epoch: 1,
+              status: 'active',
+              last_turn_sequence: 0,
+              transcript_id: SYNTHETIC_MEMORY.sessionId,
+              transcript_path: transcript,
+              provider: 'codex',
+            },
+          },
+        },
+      },
+    }));
+  }
+
+  return {
+    project,
+    vault,
+    brain,
+    sessionPath,
+    transcript,
+  };
+}
+
+export function cleanSyntheticHookEnv(vault) {
+  const env = {
+    ...process.env,
+    OBSIDIAN_VAULT_PATH: vault,
+    CLAUDECODE: '',
+    CLAUDE_CODE_SESSION_ID: '',
+  };
+  delete env.CODEX_THREAD_ID;
+  return env;
+}

--- a/tests/memory-activation.test.mjs
+++ b/tests/memory-activation.test.mjs
@@ -42,13 +42,14 @@ function runHook(script, vault, input) {
   });
 }
 
-test('[req:MEM-HYB-4] [req:HOOK-MEM-1] late stop cannot close or promote over a newer activation', () => {
+test('[req:MEM-HYB-4] [req:MEM-STOP-4] late stop cannot close or promote over a newer activation', () => {
   const first = openActivation(emptyRegistry(), session('s1', 'act-1', 4));
   const second = openActivation(first, session('s1', 'act-2', 0));
 
   const result = applyStopActivation(second, {
     session_id: 's1',
     activation_id: 'act-1',
+    turn_id: 'turn-4',
     turn_sequence: 4,
     ended_at: '2026-07-26T03:30:00Z',
   });
@@ -61,14 +62,14 @@ test('[req:MEM-HYB-4] [req:HOOK-MEM-1] late stop cannot close or promote over a 
   assert.equal(result.canPromoteMemory, false);
 });
 
-test('[req:MEM-HYB-4] current activation rejects a stop older than its last observed turn', () => {
+test('[req:MEM-HYB-4] [req:MEM-STOP-4] current activation rejects a stop older than its last observed turn', () => {
   const opened = openActivation(emptyRegistry(), session('s1', 'act-1', 3));
   const advanced = advanceActivationTurn(opened, {
     session_id: 's1', activation_id: 'act-1', turn_sequence: 7,
   });
 
   const result = applyStopActivation(advanced, {
-    session_id: 's1', activation_id: 'act-1', turn_sequence: 6,
+    session_id: 's1', activation_id: 'act-1', turn_id: 'turn-6', turn_sequence: 6,
   });
 
   assert.equal(result.sessions.s1.active_activation_id, 'act-1');
@@ -77,23 +78,88 @@ test('[req:MEM-HYB-4] current activation rejects a stop older than its last obse
   assert.equal(result.canPromoteMemory, false);
 });
 
-test('[req:HOOK-MEM-1] matching activation and non-older turn closes exactly that activation', () => {
+test('[req:MEM-STOP-2] non-consecutive native prompt replay is a causal no-op', () => {
+  const opened = openActivation(emptyRegistry(), session('s1', 'act-1'));
+  const first = advanceActivationTurn(opened, {
+    session_id: 's1', turn_id: 'turn-a',
+  });
+  const second = advanceActivationTurn(first, {
+    session_id: 's1', turn_id: 'turn-b',
+  });
+  const replay = advanceActivationTurn(second, {
+    session_id: 's1', turn_id: 'turn-a',
+  });
+
+  assert.equal(replay.sessions.s1.last_turn_sequence, 2);
+  assert.equal(replay.sessions.s1.last_prompt_turn_id, 'turn-b');
+  assert.deepEqual(replay.sessions.s1.turn_sequences, { 'turn-a': 1, 'turn-b': 2 });
+  assert.equal(replay.sessions.s1.activations['act-1'].last_turn_sequence, 2);
+  assert.equal(replay.sessions.s1.activations['act-1'].last_prompt_turn_id, 'turn-b');
+
+  const stop = applyStopActivation(replay, {
+    session_id: 's1', activation_id: 'act-1', turn_id: 'turn-b', turn_sequence: 2,
+  });
+  assert.equal(stop.stopDisposition, 'applied');
+  assert.equal(stop.canPromoteMemory, true);
+});
+
+test('[req:MEM-STOP-2] pre-patch registry deduplicates its last native turn before recovery', () => {
+  const prePatch = openActivation(emptyRegistry(), {
+    ...session('s1', 'legacy-act', 1), transcript_id: 'rollout-1', transcript_path: 'one.jsonl',
+  });
+  const legacyEntry = prePatch.sessions.s1;
+  legacyEntry.last_turn_id = 'turn-a';
+  legacyEntry.last_turn_sequence = 1;
+  legacyEntry.active_activation_id = '';
+  legacyEntry.activations['legacy-act'].status = 'done';
+  delete legacyEntry.last_prompt_turn_id;
+  delete legacyEntry.turn_sequences;
+
+  const replay = advanceActivationTurn(prePatch, {
+    session_id: 's1',
+    turn_id: 'turn-a',
+    recovery_activation_id: 'must-not-open',
+    transcript_id: 'rollout-1',
+    transcript_path: 'one.jsonl',
+  });
+  assert.equal(replay.sessions.s1.last_turn_sequence, 1);
+  assert.equal(replay.sessions.s1.active_activation_id, '');
+  assert.equal(replay.sessions.s1.activations['must-not-open'], undefined);
+
+  const nextTurn = advanceActivationTurn(replay, {
+    session_id: 's1',
+    turn_id: 'turn-b',
+    recovery_activation_id: 'recovery-act',
+    transcript_id: 'rollout-1',
+    transcript_path: 'one.jsonl',
+  });
+  assert.equal(nextTurn.sessions.s1.last_turn_sequence, 2);
+  assert.equal(nextTurn.sessions.s1.active_activation_id, 'recovery-act');
+  const stop = applyStopActivation(nextTurn, {
+    session_id: 's1', activation_id: 'recovery-act', turn_id: 'turn-b', turn_sequence: 2,
+  });
+  assert.equal(stop.stopDisposition, 'applied');
+});
+
+test('[req:HOOK-MEM-1] [req:MEM-STOP-2] matching turn is acknowledged without closing its SessionStart epoch', () => {
   const opened = openActivation(emptyRegistry(), session('s1', 'act-1', 3));
   const result = applyStopActivation(opened, {
     session_id: 's1',
     activation_id: 'act-1',
+    turn_id: 'turn-4',
     turn_sequence: 4,
     ended_at: '2026-07-26T03:30:00Z',
   });
 
-  assert.equal(result.sessions.s1.active_activation_id, '');
-  assert.equal(result.sessions.s1.activations['act-1'].status, 'done');
+  assert.equal(result.sessions.s1.active_activation_id, 'act-1');
+  assert.equal(result.sessions.s1.activations['act-1'].status, 'active');
   assert.equal(result.sessions.s1.activations['act-1'].last_turn_sequence, 4);
+  assert.equal(result.sessions.s1.activations['act-1'].last_stop_turn_id, 'turn-4');
   assert.equal(result.stopDisposition, 'applied');
   assert.equal(result.canPromoteMemory, true);
 });
 
-test('[req:HOOK-MEM-1] Stop resolves only the activation proven by its transcript identity', () => {
+test('[req:HOOK-MEM-1] [req:MEM-STOP-4] implicit Stop resolves only the active transcript-compatible activation', () => {
   const first = openActivation(emptyRegistry(), {
     ...session('s1', 'act-1', 4), transcript_id: 'rollout-1', transcript_path: 'one.jsonl',
   });
@@ -103,7 +169,10 @@ test('[req:HOOK-MEM-1] Stop resolves only the activation proven by its transcrip
 
   assert.equal(resolveStopActivation(second, {
     session_id: 's1', transcript_id: 'rollout-1', transcript_path: 'one.jsonl',
-  }), 'act-1');
+  }), '');
+  assert.equal(resolveStopActivation(second, {
+    session_id: 's1', transcript_id: 'rollout-2', transcript_path: 'two.jsonl',
+  }), 'act-2');
   assert.equal(resolveStopActivation(second, {
     session_id: 's1', transcript_id: 'unknown', transcript_path: 'unknown.jsonl',
   }), '');
@@ -113,7 +182,75 @@ test('[req:HOOK-MEM-1] Stop resolves only the activation proven by its transcrip
   });
   assert.equal(resolveStopActivation(ambiguous, {
     session_id: 's1', transcript_id: 'rollout-1', transcript_path: 'one.jsonl',
-  }), '');
+  }), 'act-2');
+});
+
+test('[req:MEM-STOP-3] repeated Stop for the same native turn is an explicit duplicate', () => {
+  const opened = openActivation(emptyRegistry(), {
+    ...session('s1', 'act-1', 2), transcript_id: 'rollout-1', transcript_path: 'one.jsonl',
+  });
+  const first = applyStopActivation(opened, {
+    session_id: 's1', activation_id: 'act-1', turn_id: 'turn-2', turn_sequence: 2,
+  });
+  const duplicate = applyStopActivation(first, {
+    session_id: 's1', activation_id: 'act-1', turn_id: 'turn-2', turn_sequence: 2,
+  });
+
+  assert.equal(first.stopDisposition, 'applied');
+  assert.equal(duplicate.stopDisposition, 'duplicate');
+  assert.equal(duplicate.canPromoteMemory, false);
+  assert.equal(duplicate.sessions.s1.active_activation_id, 'act-1');
+});
+
+test('[req:MEM-STOP-2] recovery activation opens exactly once when a prompt finds a closed legacy epoch', () => {
+  const legacy = openActivation(emptyRegistry(), {
+    ...session('s1', 'legacy-act', 1), transcript_id: 'rollout-1', transcript_path: 'one.jsonl',
+  });
+  legacy.sessions.s1.activations['legacy-act'].status = 'done';
+  legacy.sessions.s1.active_activation_id = '';
+  legacy.sessions.s1.last_turn_id = 'turn-1';
+
+  const recovered = advanceActivationTurn(legacy, {
+    session_id: 's1',
+    turn_id: 'turn-2',
+    turn_sequence: 2,
+    recovery_activation_id: 'recovery-act-1',
+    transcript_id: 'rollout-1',
+    transcript_path: 'one.jsonl',
+  });
+  const duplicatePrompt = advanceActivationTurn(recovered, {
+    session_id: 's1',
+    turn_id: 'turn-2',
+    turn_sequence: 2,
+    recovery_activation_id: 'recovery-act-2',
+    transcript_id: 'rollout-1',
+    transcript_path: 'one.jsonl',
+  });
+
+  assert.equal(recovered.sessions.s1.active_activation_id, 'recovery-act-1');
+  assert.equal(duplicatePrompt.sessions.s1.active_activation_id, 'recovery-act-1');
+  assert.equal(duplicatePrompt.sessions.s1.activation_epoch, 2);
+  assert.equal(duplicatePrompt.sessions.s1.activations['recovery-act-2'], undefined);
+});
+
+test('[req:MEM-STOP-4] Stop from before the active epoch floor is superseded without an external activation id', () => {
+  const first = openActivation(emptyRegistry(), {
+    ...session('s1', 'act-1', 4), transcript_id: 'rollout-1', transcript_path: 'one.jsonl',
+  });
+  first.sessions.s1.last_turn_id = 'turn-4';
+  const second = openActivation(first, {
+    ...session('s1', 'act-2', 5), transcript_id: 'rollout-1', transcript_path: 'one.jsonl',
+  });
+  const activeId = resolveStopActivation(second, {
+    session_id: 's1', transcript_id: 'rollout-1', transcript_path: 'one.jsonl',
+  });
+  const late = applyStopActivation(second, {
+    session_id: 's1', activation_id: activeId, turn_id: 'turn-4', turn_sequence: 4,
+  });
+
+  assert.equal(activeId, 'act-2');
+  assert.equal(late.stopDisposition, 'superseded');
+  assert.equal(late.sessions.s1.active_activation_id, 'act-2');
 });
 
 test('[req:MEM-HYB-4] registry v2 without activation fields remains readable', () => {
@@ -183,7 +320,7 @@ test('[req:HOOK-MEM-1] SessionStart opens epochs and UserPromptSubmit only advan
     const entry = registry.sessions[sessionId];
     assert.equal(entry.activation_epoch, 2);
     assert.equal(entry.active_activation_id, 'act-2');
-    assert.equal(entry.last_turn_sequence, 0);
+    assert.equal(entry.last_turn_sequence, 3);
     assert.equal(entry.activations['act-1'].last_turn_sequence, 3);
     assert.equal(entry.activations['act-1'].status, 'superseded');
     assert.equal(entry.activations['act-2'].status, 'active');

--- a/tests/memory-handoff.test.mjs
+++ b/tests/memory-handoff.test.mjs
@@ -1,91 +1,99 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 
 import { buildSessionMemoryEvents, collectLifecycleEvidence } from '../hooks/memory-handoff.mjs';
+import {
+  SYNTHETIC_MEMORY,
+  SYNTHETIC_SUMMARY,
+  makeSyntheticHandoff,
+  seedSyntheticLifecycleEvidence,
+  seedSyntheticMemoryVault,
+  syntheticWindowsHomePath,
+} from './fixtures/synthetic-memory-lifecycle.mjs';
 
-const context = {
-  projectId: 'vendiva',
-  identity: { canonicalConversationId: 'session-1', provider: 'codex' },
-  activation: { id: 'act-7', epoch: 7 },
-  turn: { id: 'turn-final', sequence: 42 },
-  noteRel: '02-Sessões/2026/07-JUL/DIA 25/22-22-files-mentioned-by-the-user.md',
-  observedAt: '2026-07-26T03:20:47Z',
-};
-
-test('[req:MEM-HYB-1] the final handoff is always preserved as reported with source provenance', () => {
-  const events = buildSessionMemoryEvents({
-    ...context,
-    summary: 'Concluído; PASSWORD=hunter2. Commit local; nenhum push. C:\\Users\\Example\\rollout.jsonl',
-    evidence: {},
-  });
+test('[req:MEM-STOP-7] synthetic handoff redacts an artificial local path', () => {
+  const handoff = makeSyntheticHandoff({ summary: syntheticWindowsHomePath() });
+  const events = buildSessionMemoryEvents(handoff);
 
   assert.equal(events.length, 1);
   assert.equal(events[0].memory_key, 'handoff.latest');
   assert.equal(events[0].authority, 'reported');
-  assert.equal(events[0].canonical_session_id, 'session-1');
-  assert.equal(events[0].activation_id, 'act-7');
-  assert.equal(events[0].turn_sequence, 42);
-  assert.deepEqual(events[0].evidence, [context.noteRel]);
-  assert.doesNotMatch(JSON.stringify(events[0]), /hunter2|C:\\\\Users|rollout\.jsonl/);
+  assert.equal(events[0].canonical_session_id, SYNTHETIC_MEMORY.conversationId);
+  assert.equal(events[0].activation_id, SYNTHETIC_MEMORY.activationOne);
+  assert.equal(events[0].turn_sequence, 1);
+  assert.deepEqual(events[0].evidence, [SYNTHETIC_MEMORY.noteRel]);
+  assert.match(events[0].value, /\[REDACTED_LOCAL_PATH\]/);
+  assert.doesNotMatch(JSON.stringify(events[0]), /[A-Za-z]:\\Users\\/i);
 });
 
-test('[req:MEM-HYB-1] lifecycle facts become separate verified events only with local evidence', () => {
-  const events = buildSessionMemoryEvents({
-    ...context,
-    summary: 'ADR-0107 arquivada; verdict 7/7; próxima change: interface de revisão.',
-    evidence: {
-      change: { slug: 'campanhas-importacao', status: 'archived', adr: 'ADR-0107' },
-      verdict: { ok: true, covered: 7, total: 7, path: 'verdict.json' },
-      sensors: ['backend-unit', 'contracts-openapi', 'campaign-import-backend'],
-      git: { commit: '9fbbbb1bdad630cd4145ea4a916ef8f240ed603f', pushed: false },
-      nextAction: { id: 'campaign-review-ui', summary: 'Criar interface de revisão' },
+test('[req:MEM-STOP-7] synthetic lifecycle evidence creates causal memory events', () => {
+  const evidence = {
+    change: {
+      slug: SYNTHETIC_MEMORY.changeSlug,
+      status: 'archived',
+      adr: 'ADR-0001',
+      path: `04-Decisões/ADR-0001-${SYNTHETIC_MEMORY.changeSlug}.md`,
     },
-  });
-
+    verdict: {
+      ok: true,
+      covered: 3,
+      total: 3,
+      path: `08-Mudanças/_arquivo/${SYNTHETIC_MEMORY.changeSlug}/verdict.json`,
+    },
+    sensors: [
+      'wk-fixture-example-sensor-alpha',
+      'wk-fixture-example-sensor-beta',
+      'wk-fixture-example-sensor-gamma',
+    ],
+    git: {
+      commit: SYNTHETIC_MEMORY.artificialCommit,
+      pushed: false,
+      verified: false,
+      path: SYNTHETIC_MEMORY.noteRel,
+    },
+    nextAction: {
+      id: SYNTHETIC_MEMORY.nextActionId,
+      summary: SYNTHETIC_MEMORY.nextActionId,
+    },
+  };
+  const events = buildSessionMemoryEvents(makeSyntheticHandoff({ evidence }));
   const byKey = new Map(events.map((event) => [event.memory_key, event]));
-  assert.equal(byKey.get('change.campanhas-importacao.status').value.status, 'archived');
-  assert.equal(byKey.get('change.campanhas-importacao.status').authority, 'verified');
-  assert.deepEqual(byKey.get('quality.latest-verdict').value, { ok: true, covered: 7, total: 7 });
+
+  assert.equal(byKey.get(`change.${SYNTHETIC_MEMORY.changeSlug}.status`).value.status, 'archived');
+  assert.equal(byKey.get(`change.${SYNTHETIC_MEMORY.changeSlug}.status`).authority, 'verified');
+  assert.deepEqual(byKey.get('quality.latest-verdict').value, { ok: true, covered: 3, total: 3 });
   assert.equal(byKey.get('git.local-head').value.pushed, false);
-  assert.equal(byKey.get('next.campaign-review-ui').value, 'Criar interface de revisão');
-  assert.ok(events.filter((event) => event.authority === 'verified').every((event) => event.evidence.length > 0));
+  assert.equal(byKey.get(`next.${SYNTHETIC_MEMORY.nextActionId}`).value, SYNTHETIC_MEMORY.nextActionId);
+  assert.ok(events
+    .filter((event) => event.authority === 'verified')
+    .every((event) => event.evidence.length > 0));
 });
 
-test('[req:MEM-HYB-1] archived change evidence is resolved from the vault, not trusted from prose alone', () => {
-  const vault = mkdtempSync(join(tmpdir(), 'wk-handoff-evidence-'));
-  const archived = join(vault, '08-Mudanças', '_arquivo', '2026-07-25-campanhas-importacao');
-  const decisions = join(vault, '04-Decisões', '2026', '07-JUL');
-  mkdirSync(archived, { recursive: true });
-  mkdirSync(decisions, { recursive: true });
-  writeFileSync(join(archived, 'verdict.json'), JSON.stringify({
-    ok: true,
-    coverage: Array.from({ length: 7 }, (_, index) => ({ req: `R-${index + 1}`, covered: true })),
-  }));
-  writeFileSync(join(archived, 'evidencia.json'), JSON.stringify([
-    { id: 'backend-unit', status: 'green' },
-    { id: 'contracts-openapi', status: 'green' },
-    { id: 'campaign-import-backend', status: 'green' },
-  ]));
-  writeFileSync(join(decisions, 'ADR-0107-campanhas-importacao.md'), '# ADR-0107');
+test('[req:MEM-STOP-7] synthetic archived artifacts are collected as lifecycle evidence', () => {
+  const vault = seedSyntheticMemoryVault();
+  seedSyntheticLifecycleEvidence(vault);
 
   const evidence = collectLifecycleEvidence(vault, {
-    changeSlug: 'campanhas-importacao',
-    summary: 'Concluído. A próxima change será a interface de revisão.',
-    noteRel: context.noteRel,
+    changeSlug: SYNTHETIC_MEMORY.changeSlug,
+    summary: SYNTHETIC_SUMMARY,
+    noteRel: SYNTHETIC_MEMORY.noteRel,
   });
 
   assert.deepEqual(evidence.change, {
-    slug: 'campanhas-importacao',
+    slug: SYNTHETIC_MEMORY.changeSlug,
     status: 'archived',
-    adr: 'ADR-0107',
-    path: '04-Decisões/2026/07-JUL/ADR-0107-campanhas-importacao.md',
+    adr: 'ADR-0001',
+    path: `04-Decisões/ADR-0001-${SYNTHETIC_MEMORY.changeSlug}.md`,
   });
   assert.equal(evidence.verdict.ok, true);
-  assert.equal(evidence.verdict.covered, 7);
-  assert.equal(evidence.verdict.total, 7);
-  assert.deepEqual(evidence.sensors, ['backend-unit', 'campaign-import-backend', 'contracts-openapi']);
-  assert.equal(evidence.nextAction.summary, 'interface de revisão');
+  assert.equal(evidence.verdict.covered, 3);
+  assert.equal(evidence.verdict.total, 3);
+  assert.deepEqual(evidence.sensors, [
+    'wk-fixture-example-sensor-alpha',
+    'wk-fixture-example-sensor-beta',
+    'wk-fixture-example-sensor-gamma',
+  ]);
+  assert.equal(evidence.git.commit, SYNTHETIC_MEMORY.artificialCommit);
+  assert.equal(evidence.git.pushed, false);
+  assert.equal(evidence.nextAction.summary, SYNTHETIC_MEMORY.nextActionId);
 });

--- a/tests/memory-hybrid-e2e.test.mjs
+++ b/tests/memory-hybrid-e2e.test.mjs
@@ -1,264 +1,227 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { renderSharedMemory } from '../hooks/memory-schema.mjs';
+
+import {
+  SYNTHETIC_MEMORY,
+  SYNTHETIC_MEMORY_FACTS,
+  cleanSyntheticHookEnv,
+  seedSyntheticHybridLifecycle,
+} from './fixtures/synthetic-memory-lifecycle.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const STOP = join(ROOT, 'hooks', 'session-stop.mjs');
 const START = join(ROOT, 'hooks', 'session-start.mjs');
 const INJECT = join(ROOT, 'hooks', 'brain-inject.mjs');
-const SID = '019f9cea-b7c1-79d0-9ac5-931e56192b52';
-const SUMMARY = [
-  'Concluído. Halley finalizou com verdict ok:true, cobrindo 7/7 requisitos.',
-  'Change arquivada como ADR-0107. Sensores backend-unit, contracts-openapi e campaign-import-backend verdes.',
-  'E2E confirmou worker, OCR, MinIO privado e materialização 1|1|1|1.',
-  'Commit local em main: 9fbbbb1bdad630cd4145ea4a916ef8f240ed603f. Nenhum push realizado.',
-  'A próxima change será a interface de revisão.',
-].join(' ');
 
-const NOTE = `---
-type: session
-session_id: "${SID}"
-provider: codex
-status: active
-ended_at:
----
-
-# 22:22 - files mentioned by the user
-
-## Iterações
-
-## Decisões geradas nesta sessão
-
-Nenhuma decisão registrada ainda.
-
-## Bugs gerados nesta sessão
-
-Nenhum bug registrado ainda.
-
-## Aprendizados gerados nesta sessão
-
-Nenhum aprendizado registrado ainda.
-
-## Pendências
-
-Nenhuma.
-`;
-
-function seed({ withSeededSession = true } = {}) {
-  const project = mkdtempSync(join(tmpdir(), 'wk-memory-e2e-project-'));
-  const vault = join(project, '.Vendiva-vault');
-  const brain = join(vault, '.brain');
-  const sessionRel = '02-Sessões/2026/07-JUL/DIA 25/22-22-files-mentioned-by-the-user.md';
-  const sessionPath = join(vault, ...sessionRel.split('/'));
-  const transcript = join(project, `rollout-${SID}.jsonl`);
-  const archived = join(vault, '08-Mudanças', '_arquivo', '2026-07-25-campanhas-importacao');
-  const decisions = join(vault, '04-Decisões', '2026', '07-JUL');
-  mkdirSync(brain, { recursive: true });
-  mkdirSync(dirname(sessionPath), { recursive: true });
-  mkdirSync(archived, { recursive: true });
-  mkdirSync(decisions, { recursive: true });
-
-  writeFileSync(join(project, '.wendkeep.json'), JSON.stringify({ schemaVersion: 1, projectId: 'vendiva', vault: '.Vendiva-vault' }));
-  writeFileSync(join(brain, 'PROJECT.json'), JSON.stringify({ schemaVersion: 1, projectId: 'vendiva' }));
-  writeFileSync(join(brain, 'CORE.md'), [
-    '# CORE', '', '## Preferências do Usuário', '- responder em pt-BR', '',
-    '## Padrões Ativos', '- memória local e auditável', '', '## Pendências Abertas', '- consultar SHARED diretamente', '',
-  ].join('\n'));
-  if (withSeededSession) writeFileSync(sessionPath, NOTE);
-  writeFileSync(join(archived, 'verdict.json'), JSON.stringify({
-    ok: true,
-    coverage: Array.from({ length: 7 }, (_, index) => ({ req: `REQ-${index + 1}`, covered: true })),
-  }));
-  writeFileSync(join(archived, 'evidencia.json'), JSON.stringify([
-    { id: 'backend-unit', status: 'green' },
-    { id: 'contracts-openapi', status: 'green' },
-    { id: 'campaign-import-backend', status: 'green' },
-  ]));
-  writeFileSync(join(decisions, 'ADR-0107-campanhas-importacao.md'), '# ADR-0107 — campanhas-importacao\n');
-
-  const events = [
-    { type: 'session_meta', timestamp: '2026-07-25T22:22:00.000Z', payload: { id: SID, cwd: project, model: 'gpt-5.6-sol', model_provider: 'openai' } },
-    { type: 'event_msg', timestamp: '2026-07-26T03:20:40.000Z', payload: { type: 'task_started', turn_id: 'turn-final' } },
-    { type: 'event_msg', timestamp: '2026-07-26T03:20:41.000Z', payload: { type: 'user_message', turn_id: 'turn-final', message: 'Finalize e registre o handoff.' } },
-    { type: 'event_msg', timestamp: '2026-07-26T03:20:47.000Z', payload: { type: 'agent_message', turn_id: 'turn-final', message: SUMMARY } },
-  ];
-  writeFileSync(transcript, `${events.map((event) => JSON.stringify(event)).join('\n')}\n`);
-  writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), '');
-  writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), '');
-  writeFileSync(join(brain, 'SHARED_MEMORY.md'), renderSharedMemory());
-  if (withSeededSession) {
-    writeFileSync(join(brain, 'SESSION_REGISTRY.json'), JSON.stringify({
-      version: 2,
-      sessions: {
-        [SID]: {
-          session_file: sessionRel,
-          status: 'active',
-          provider: 'codex',
-          transcript_path: transcript,
-          transcript_id: SID,
-          change_slug: 'campanhas-importacao',
-          activation_id: 'activation-1',
-          active_activation_id: 'activation-1',
-          activation_epoch: 1,
-          last_turn_sequence: 1,
-          activations: {
-            'activation-1': {
-              activation_id: 'activation-1', epoch: 1, status: 'active', last_turn_sequence: 1,
-              transcript_id: SID, transcript_path: transcript, provider: 'codex',
-            },
-          },
-        },
-      },
-    }));
-  }
-  return { project, vault, brain, sessionPath, transcript };
+function stopInput(project, transcript, activationId = SYNTHETIC_MEMORY.activationOne) {
+  return {
+    hook_event_name: 'Stop',
+    cwd: project,
+    session_id: SYNTHETIC_MEMORY.sessionId,
+    transcript_path: transcript,
+    turn_id: SYNTHETIC_MEMORY.turnOne,
+    turn_sequence: 1,
+    activation_id: activationId,
+  };
 }
 
-function cleanEnv(vault) {
-  const env = { ...process.env, OBSIDIAN_VAULT_PATH: vault, CLAUDECODE: '', CLAUDE_CODE_SESSION_ID: '' };
-  delete env.CODEX_THREAD_ID;
-  return env;
+function runHook(script, { project, vault, input }) {
+  return spawnSync(process.execPath, [script], {
+    cwd: project,
+    env: cleanSyntheticHookEnv(vault),
+    encoding: 'utf8',
+    input: JSON.stringify(input),
+  });
 }
 
-test('[req:MEM-HYB-1] [req:MEM-HYB-2] [req:MEM-HYB-3] Vendiva-like Stop becomes direct memory in the next SessionStart', () => {
-  const { project, vault, brain, sessionPath, transcript } = seed();
+function escapeRegExp(value) {
+  return value.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&');
+}
+
+test('[req:MEM-STOP-7] synthetic Stop projects lifecycle memory and remains idempotent', () => {
+  const { project, vault, brain, sessionPath, transcript } = seedSyntheticHybridLifecycle();
   const corePath = join(brain, 'CORE.md');
   const coreBeforeStop = readFileSync(corePath);
-  const stop = spawnSync(process.execPath, [STOP], {
-    cwd: project,
-    env: cleanEnv(vault),
-    encoding: 'utf8',
-    input: JSON.stringify({
-      hook_event_name: 'Stop', cwd: project, session_id: SID, transcript_path: transcript,
-      turn_id: 'turn-final', turn_sequence: 1, activation_id: 'activation-1',
-    }),
+  const stop = runHook(STOP, {
+    project,
+    vault,
+    input: stopInput(project, transcript),
   });
 
   assert.equal(stop.status, 0, stop.stderr);
   assert.doesNotThrow(() => JSON.parse(stop.stdout || '{}'));
   const stopOutput = JSON.parse(stop.stdout || '{}');
-  assert.equal(stopOutput.systemMessage, undefined, `${stop.stderr}\n${stop.stdout}`);
+  assert.equal(stopOutput.systemMessage, undefined, '[wk-fixture] successful Stop stays silent');
   assert.match(readFileSync(sessionPath, 'utf8'), /status: done/);
-  const registry = JSON.parse(readFileSync(join(brain, 'SESSION_REGISTRY.json'), 'utf8'));
-  assert.equal(registry.sessions[SID].memory_status, 'projected');
-  assert.equal(registry.sessions[SID].memory_checkpoint.revision >= 5, true);
-  assert.deepEqual(readFileSync(corePath), coreBeforeStop, 'Stop alterou bytes do CORE curado');
+
+  const registryPath = join(brain, 'SESSION_REGISTRY.json');
+  const registry = JSON.parse(readFileSync(registryPath, 'utf8'));
+  assert.equal(registry.sessions[SYNTHETIC_MEMORY.sessionId].memory_status, 'projected');
+  assert.equal(
+    registry.sessions[SYNTHETIC_MEMORY.sessionId].memory_checkpoint.revision >= 5,
+    true,
+  );
+  assert.deepEqual(
+    readFileSync(corePath),
+    coreBeforeStop,
+    '[wk-fixture] runtime projection must not curate CORE',
+  );
 
   const shared = readFileSync(join(brain, 'SHARED_MEMORY.md'), 'utf8');
-  for (const fact of ['ADR-0107', '7/7', 'backend-unit', 'MinIO privado', '9fbbbb1bdad630cd4145ea4a916ef8f240ed603f', 'Nenhum push', 'interface de revisão']) {
-    assert.match(shared, new RegExp(fact.replace(/[|]/g, '\\|'), 'i'), `SHARED perdeu: ${fact}`);
+  for (const fact of SYNTHETIC_MEMORY_FACTS) {
+    assert.match(
+      shared,
+      new RegExp(escapeRegExp(fact), 'i'),
+      '[wk-fixture] projected fact is present in shared memory',
+    );
   }
 
   const noteMtime = statSync(sessionPath).mtimeMs;
-  const ledgerBefore = readFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), 'utf8');
-  const repeated = spawnSync(process.execPath, [STOP], {
-    cwd: project,
-    env: cleanEnv(vault),
-    encoding: 'utf8',
-    input: JSON.stringify({
-      hook_event_name: 'Stop', cwd: project, session_id: SID, transcript_path: transcript,
-      turn_id: 'turn-final', turn_sequence: 1, activation_id: 'activation-1',
-    }),
+  const ledgerPath = join(brain, 'MEMORY_EVENTS.jsonl');
+  const ledgerBefore = readFileSync(ledgerPath);
+  const repeated = runHook(STOP, {
+    project,
+    vault,
+    input: stopInput(project, transcript),
   });
-  assert.equal(repeated.status, 0);
-  assert.equal(statSync(sessionPath).mtimeMs, noteMtime, 'Stop repetido não reescreve a nota');
-  assert.equal(readFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), 'utf8'), ledgerBefore, 'Stop repetido não reapenda memória');
 
-  const start = spawnSync(process.execPath, [INJECT], {
-    cwd: project,
-    env: cleanEnv(vault),
-    encoding: 'utf8',
-    input: JSON.stringify({ hook_event_name: 'SessionStart', source: 'startup', cwd: project, session_id: 'next-session' }),
+  assert.equal(repeated.status, 0, repeated.stderr);
+  assert.equal(
+    statSync(sessionPath).mtimeMs,
+    noteMtime,
+    '[wk-fixture] repeated Stop must not rewrite the note',
+  );
+  assert.equal(
+    readFileSync(ledgerPath, 'utf8'),
+    ledgerBefore.toString('utf8'),
+    '[wk-fixture] repeated Stop must not duplicate ledger events',
+  );
+
+  const inject = runHook(INJECT, {
+    project,
+    vault,
+    input: {
+      hook_event_name: 'UserPromptSubmit',
+      source: 'startup',
+      cwd: project,
+      session_id: 'wk-fixture-example-injected-session',
+    },
   });
-  assert.equal(start.status, 0, start.stderr);
-  assert.deepEqual(readFileSync(corePath), coreBeforeStop, 'SessionStart seguinte alterou bytes do CORE curado');
-  const context = JSON.parse(start.stdout).hookSpecificOutput.additionalContext;
+  assert.equal(inject.status, 0, inject.stderr);
+  assert.deepEqual(
+    readFileSync(corePath),
+    coreBeforeStop,
+    '[wk-fixture] injection must not mutate CORE',
+  );
+  const context = JSON.parse(inject.stdout).hookSpecificOutput.additionalContext;
   assert.match(context, /<brain_memory version="2"/);
-  for (const fact of ['ADR-0107', '7/7', 'backend-unit', 'MinIO privado', '9fbbbb1bdad630cd4145ea4a916ef8f240ed603f', 'Nenhum push', 'interface de revisão']) {
-    assert.match(context, new RegExp(fact.replace(/[|]/g, '\\|'), 'i'), `SessionStart perdeu: ${fact}`);
+  for (const fact of SYNTHETIC_MEMORY_FACTS) {
+    assert.match(
+      context,
+      new RegExp(escapeRegExp(fact), 'i'),
+      '[wk-fixture] injected context contains projected memory',
+    );
   }
 });
 
-test('[req:MEM-HYB-7] [req:HOOK-MEM-1] real Stop stays exit-0/JSON and records degraded checkpoint when projector lock is busy', () => {
-  const { project, vault, brain, transcript } = seed();
+test('[req:MEM-STOP-7] synthetic busy projector preserves active session and durable outbox', () => {
+  const { project, vault, brain, transcript } = seedSyntheticHybridLifecycle();
   mkdirSync(join(brain, 'MEMORY.lock'));
-  const stop = spawnSync(process.execPath, [STOP], {
-    cwd: project,
-    env: cleanEnv(vault),
-    encoding: 'utf8',
-    input: JSON.stringify({
-      hook_event_name: 'Stop', cwd: project, session_id: SID, transcript_path: transcript,
-      turn_id: 'turn-final', turn_sequence: 1, activation_id: 'activation-1',
-    }),
+  const stop = runHook(STOP, {
+    project,
+    vault,
+    input: stopInput(project, transcript),
   });
 
   assert.equal(stop.status, 0, stop.stderr);
   const output = JSON.parse(stop.stdout || '{}');
   assert.match(output.systemMessage, /memória compartilhada degradada|outbox/i);
   const registry = JSON.parse(readFileSync(join(brain, 'SESSION_REGISTRY.json'), 'utf8'));
-  assert.equal(registry.sessions[SID].status, 'done');
-  assert.equal(registry.sessions[SID].memory_status, 'degraded');
-  assert.equal(registry.sessions[SID].memory_checkpoint, undefined);
+  assert.equal(registry.sessions[SYNTHETIC_MEMORY.sessionId].status, 'active');
+  assert.equal(registry.sessions[SYNTHETIC_MEMORY.sessionId].memory_status, 'degraded');
+  assert.equal(registry.sessions[SYNTHETIC_MEMORY.sessionId].memory_checkpoint, undefined);
   assert.ok(readdirSync(join(brain, 'memory-outbox')).some((name) => name.endsWith('.json')));
 });
 
-test('[req:HOOK-MEM-1] real late Stop N cannot rewrite activation N+1 note, registry, ledger or checkpoint', () => {
-  const { project, vault, brain, transcript } = seed({ withSeededSession: false });
-  const startN = spawnSync(process.execPath, [START], {
-    cwd: project,
-    env: cleanEnv(vault),
-    encoding: 'utf8',
-    input: JSON.stringify({
-      hook_event_name: 'SessionStart', cwd: project, session_id: SID, transcript_path: transcript,
-      activation_id: 'activation-1', source: 'startup',
-    }),
+test('[req:MEM-STOP-7] synthetic late Stop cannot overwrite a newer activation', () => {
+  const { project, vault, brain, transcript } = seedSyntheticHybridLifecycle({
+    withSeededSession: false,
   });
-  assert.equal(startN.status, 0, startN.stderr);
-  assert.doesNotThrow(() => JSON.parse(startN.stdout || '{}'));
+  const startOne = runHook(START, {
+    project,
+    vault,
+    input: {
+      hook_event_name: 'SessionStart',
+      cwd: project,
+      session_id: SYNTHETIC_MEMORY.sessionId,
+      transcript_path: transcript,
+      activation_id: SYNTHETIC_MEMORY.activationOne,
+      source: 'startup',
+    },
+  });
+  assert.equal(startOne.status, 0, startOne.stderr);
+  assert.doesNotThrow(() => JSON.parse(startOne.stdout || '{}'));
 
   const registryPath = join(brain, 'SESSION_REGISTRY.json');
-  const registryN = JSON.parse(readFileSync(registryPath, 'utf8'));
-  assert.equal(registryN.sessions[SID].active_activation_id, 'activation-1');
-  assert.equal(registryN.sessions[SID].activations['activation-1'].epoch, 1);
+  const registryOne = JSON.parse(readFileSync(registryPath, 'utf8'));
+  assert.equal(
+    registryOne.sessions[SYNTHETIC_MEMORY.sessionId].active_activation_id,
+    SYNTHETIC_MEMORY.activationOne,
+  );
+  assert.equal(
+    registryOne.sessions[SYNTHETIC_MEMORY.sessionId]
+      .activations[SYNTHETIC_MEMORY.activationOne].epoch,
+    1,
+  );
 
-  const startNPlusOne = spawnSync(process.execPath, [START], {
-    cwd: project,
-    env: cleanEnv(vault),
-    encoding: 'utf8',
-    input: JSON.stringify({
-      hook_event_name: 'SessionStart', cwd: project, session_id: SID, transcript_path: transcript,
-      activation_id: 'activation-2', source: 'compact',
-    }),
+  const startTwo = runHook(START, {
+    project,
+    vault,
+    input: {
+      hook_event_name: 'SessionStart',
+      cwd: project,
+      session_id: SYNTHETIC_MEMORY.sessionId,
+      transcript_path: transcript,
+      activation_id: SYNTHETIC_MEMORY.activationTwo,
+      source: 'startup',
+    },
   });
-  assert.equal(startNPlusOne.status, 0, startNPlusOne.stderr);
-  assert.doesNotThrow(() => JSON.parse(startNPlusOne.stdout || '{}'));
+  assert.equal(startTwo.status, 0, startTwo.stderr);
+  assert.doesNotThrow(() => JSON.parse(startTwo.stdout || '{}'));
 
   const ledgerPath = join(brain, 'MEMORY_EVENTS.jsonl');
-  const registryNPlusOne = JSON.parse(readFileSync(registryPath, 'utf8'));
-  assert.equal(registryNPlusOne.sessions[SID].active_activation_id, 'activation-2');
-  assert.equal(registryNPlusOne.sessions[SID].activations['activation-2'].epoch, 2);
-  const sessionPath = join(vault, ...registryNPlusOne.sessions[SID].session_file.split('/'));
-
+  const registryTwo = JSON.parse(readFileSync(registryPath, 'utf8'));
+  assert.equal(
+    registryTwo.sessions[SYNTHETIC_MEMORY.sessionId].active_activation_id,
+    SYNTHETIC_MEMORY.activationTwo,
+  );
+  assert.equal(
+    registryTwo.sessions[SYNTHETIC_MEMORY.sessionId]
+      .activations[SYNTHETIC_MEMORY.activationTwo].epoch,
+    2,
+  );
+  const sessionPath = join(
+    vault,
+    ...registryTwo.sessions[SYNTHETIC_MEMORY.sessionId].session_file.split('/'),
+  );
   const before = {
     note: readFileSync(sessionPath),
     registry: readFileSync(registryPath),
     ledger: readFileSync(ledgerPath),
-    checkpoint: Buffer.from(JSON.stringify(registryNPlusOne.sessions[SID].memory_checkpoint ?? null)),
+    checkpoint: Buffer.from(JSON.stringify(
+      registryTwo.sessions[SYNTHETIC_MEMORY.sessionId].memory_checkpoint ?? null,
+    )),
   };
+
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
-  const late = spawnSync(process.execPath, [STOP], {
-    cwd: project,
-    env: cleanEnv(vault),
-    encoding: 'utf8',
-    input: JSON.stringify({
-      hook_event_name: 'Stop', cwd: project, session_id: SID, transcript_path: transcript,
-      turn_id: 'turn-final', turn_sequence: 1, activation_id: 'activation-1',
-    }),
+  const late = runHook(STOP, {
+    project,
+    vault,
+    input: stopInput(project, transcript, SYNTHETIC_MEMORY.activationOne),
   });
 
   assert.equal(late.status, 0, late.stderr);
@@ -268,8 +231,10 @@ test('[req:HOOK-MEM-1] real late Stop N cannot rewrite activation N+1 note, regi
   assert.deepEqual(readFileSync(ledgerPath), before.ledger);
   const registryAfterLateStop = JSON.parse(readFileSync(registryPath, 'utf8'));
   assert.deepEqual(
-    Buffer.from(JSON.stringify(registryAfterLateStop.sessions[SID].memory_checkpoint ?? null)),
+    Buffer.from(JSON.stringify(
+      registryAfterLateStop.sessions[SYNTHETIC_MEMORY.sessionId].memory_checkpoint ?? null,
+    )),
     before.checkpoint,
-    'Stop N não pode alterar o checkpoint de N+1',
+    '[wk-fixture] stale Stop must preserve the newer checkpoint',
   );
 });

--- a/tests/privacy-hygiene.test.mjs
+++ b/tests/privacy-hygiene.test.mjs
@@ -1,0 +1,208 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const FIXTURE_SOURCES = new Set([
+  'tests/memory-handoff.test.mjs',
+  'tests/memory-hybrid-e2e.test.mjs',
+  'tests/session-stop-memory.test.mjs',
+  'tests/fixtures/synthetic-memory-lifecycle.mjs',
+]);
+
+const SENSITIVE_FIELDS = new Set([
+  'NOTE',
+  'SID',
+  'SUMMARY',
+  'canonicalConversationId',
+  'context',
+  'contexto',
+  'message',
+  'noteRel',
+  'objective',
+  'pedido',
+  'projectId',
+  'project_id',
+  'sessionId',
+  'sessionRel',
+  'session_id',
+  'summary',
+  'title',
+  'transcriptId',
+  'transcript_id',
+  'vault',
+  'vaultName',
+]);
+
+const SAFE_RELATIVE_SEGMENTS = new Set([
+  '.brain',
+  '03-Sessões',
+  '03-Sessions',
+]);
+
+function decodeLiteral(raw, quote) {
+  if (quote === '"') {
+    try { return JSON.parse(`${quote}${raw}${quote}`); } catch { return raw; }
+  }
+  return raw
+    .replaceAll('\\\\', '\\')
+    .replaceAll(`\\${quote}`, quote)
+    .replaceAll('\\n', '\n')
+    .replaceAll('\\r', '\r')
+    .replaceAll('\\t', '\t');
+}
+
+function literalsOnLine(line) {
+  const literals = [];
+  const pattern = /(["'`])((?:\\.|(?!\1).)*)\1/g;
+  for (const match of line.matchAll(pattern)) {
+    literals.push({
+      column: match.index ?? 0,
+      raw: match[0],
+      value: decodeLiteral(match[2], match[1]),
+    });
+  }
+  return literals;
+}
+
+function allowedFixtureValue(value) {
+  if (!value) return true;
+  if (/^\[wk-fixture\]/.test(value)) return true;
+  if (/^\.?wk-fixture-[a-z0-9-]+(?:\.[a-z0-9]+)?$/i.test(value)) return true;
+
+  const segments = value.split(/[\\/]/).filter(Boolean);
+  return segments.length > 0 && segments.every((segment) => (
+    SAFE_RELATIVE_SEGMENTS.has(segment)
+    || /^\.?wk-fixture-[a-z0-9-]+(?:\.[a-z0-9]+)?$/i.test(segment)
+  ));
+}
+
+function sensitiveFieldBefore(line, column) {
+  const prefix = line.slice(0, column);
+  const match = prefix.match(/(?:^|[,{;]\s*|\bconst\s+)["']?([A-Za-z_][A-Za-z0-9_]*)["']?\s*[:=]\s*$/);
+  return match && SENSITIVE_FIELDS.has(match[1]) ? match[1] : '';
+}
+
+function structuralCategories(value) {
+  const categories = [];
+  if (/^[A-Za-z]:[\\/]/.test(value)
+    || /^\/(?:Users|home)\//.test(value)
+    || /^\\\\[^\\/]+[\\/][^\\/]+/.test(value)) {
+    categories.push('absolute-local-path');
+  }
+  if (/\b[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\b/i.test(value)
+    || /\b[0-9a-f]{24,}\b/i.test(value)
+    || /\b[A-Za-z0-9_-]{32,}\b/.test(value)) {
+    if (!allowedFixtureValue(value)) categories.push('opaque-identifier');
+  }
+  return categories;
+}
+
+function categoriesForLiteral(value, field) {
+  const categories = structuralCategories(value);
+  if (field && !allowedFixtureValue(value)) categories.push('unapproved-fixture-value');
+  return categories;
+}
+
+function unescapedBackticks(line) {
+  let found = 0;
+  for (let index = 0; index < line.length; index += 1) {
+    if (line[index] !== '`') continue;
+    let slashes = 0;
+    for (let cursor = index - 1; cursor >= 0 && line[cursor] === '\\'; cursor -= 1) slashes += 1;
+    if (slashes % 2 === 0) found += 1;
+  }
+  return found;
+}
+
+export function inspectFixtureSource(relativePath, source) {
+  const findings = new Set();
+  const lines = String(source).replaceAll('\r\n', '\n').split('\n');
+  let insideTemplate = false;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (insideTemplate) {
+      for (const category of structuralCategories(line)) {
+        findings.add(`${relativePath}:${index + 1}:${category}`);
+      }
+    }
+    for (const literal of literalsOnLine(line)) {
+      const field = sensitiveFieldBefore(line, literal.column);
+      for (const category of categoriesForLiteral(literal.value, field)) {
+        findings.add(`${relativePath}:${index + 1}:${category}`);
+      }
+    }
+    if (unescapedBackticks(line) % 2 === 1) insideTemplate = !insideTemplate;
+  }
+  return [...findings].sort();
+}
+
+function repositoryFixtureSources() {
+  const listed = spawnSync('git', ['ls-files', '--cached', '--others', '--exclude-standard', '-z'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+  assert.equal(listed.status, 0, listed.stderr);
+  return listed.stdout.split('\0').filter((relativePath) => FIXTURE_SOURCES.has(relativePath));
+}
+
+function runtimeSamples() {
+  const slash = '\\';
+  return {
+    homePath: ['C:', slash, 'Users', slash, 'consumer-placeholder', slash, 'repo'].join(''),
+    uncPath: [slash, slash, 'server', slash, 'share', slash, 'repo'].join(''),
+    opaqueId: ['11111111', '2222', '3333', '4444', '555555555555'].join('-'),
+    consumerLabel: ['consumer', 'placeholder'].join('-'),
+  };
+}
+
+test('[req:MEM-STOP-7] privacy scanner rejects local paths and unapproved identifiers', () => {
+  const sample = runtimeSamples();
+  const source = [
+    `const home = ${JSON.stringify(sample.homePath)};`,
+    `const network = ${JSON.stringify(sample.uncPath)};`,
+    `const SID = ${JSON.stringify(sample.opaqueId)};`,
+    `const projectId = ${JSON.stringify(sample.consumerLabel)};`,
+    'const note = `',
+    sample.homePath,
+    '`;',
+  ].join('\n');
+
+  assert.deepEqual(inspectFixtureSource('virtual.test.mjs', source), [
+    'virtual.test.mjs:1:absolute-local-path',
+    'virtual.test.mjs:2:absolute-local-path',
+    'virtual.test.mjs:3:opaque-identifier',
+    'virtual.test.mjs:3:unapproved-fixture-value',
+    'virtual.test.mjs:4:unapproved-fixture-value',
+    'virtual.test.mjs:6:absolute-local-path',
+  ]);
+});
+
+test('[req:MEM-STOP-7] privacy scanner accepts only the synthetic fixture namespace', () => {
+  const source = [
+    "const projectId = 'wk-fixture-example-project';",
+    "const sessionRel = '03-Sessões/wk-fixture-example-session.md';",
+    "const summary = '[wk-fixture] artificial lifecycle summary';",
+  ].join('\n');
+
+  assert.deepEqual(inspectFixtureSource('virtual.test.mjs', source), []);
+});
+
+test('[req:MEM-STOP-7] privacy diagnostics never disclose rejected values', () => {
+  const sample = runtimeSamples();
+  const source = `const projectId = ${JSON.stringify(sample.consumerLabel)};`;
+  const report = inspectFixtureSource('virtual.test.mjs', source).join('\n');
+
+  assert.equal(report, 'virtual.test.mjs:1:unapproved-fixture-value');
+  assert.equal(report.includes(sample.consumerLabel), false);
+});
+
+test('[req:MEM-STOP-7] versioned memory lifecycle fixtures contain only synthetic data', () => {
+  const findings = repositoryFixtureSources().flatMap((relativePath) => (
+    inspectFixtureSource(relativePath, readFileSync(join(ROOT, relativePath), 'utf8'))
+  ));
+  if (findings.length) throw new Error(findings.join('\n'));
+});

--- a/tests/readme-packaging.test.mjs
+++ b/tests/readme-packaging.test.mjs
@@ -93,7 +93,9 @@ test('npm pack: o tarball leva o inglês e o repositório volta ao português', 
 
     const pkg = join(outDir, 'package');
     const packedManifest = JSON.parse(readFileSync(join(pkg, 'package.json'), 'utf8'));
-    assert.equal(packedManifest.version, '0.58.2', 'DOC-5: o tarball deve declarar exatamente a release 0.58.2');
+    const sourceManifest = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+    assert.equal(packedManifest.version, sourceManifest.version,
+      `DOC-5: o tarball deve declarar exatamente a release ${sourceManifest.version}`);
     assert.ok(isEn(readFileSync(join(pkg, 'README.md'), 'utf8')),
       'o README.md DO TARBALL é o inglês — é o que a página do npm renderiza');
     assert.ok(existsSync(join(pkg, 'README.en.md')), 'e o inglês também viaja pelo nome próprio');

--- a/tests/session-memory-lifecycle.test.mjs
+++ b/tests/session-memory-lifecycle.test.mjs
@@ -1,0 +1,381 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { buildSessionMemoryEvents } from '../hooks/memory-handoff.mjs';
+import { renderSharedMemory } from '../hooks/memory-schema.mjs';
+import { readMemoryLedger } from '../hooks/memory-store.mjs';
+import {
+  projectStopMemoryAttempt,
+  recordStopMemoryOutcome,
+  stageStopMemoryAttempt,
+} from '../hooks/session-memory-lifecycle.mjs';
+
+const SESSION_ID = 'example-session-1';
+const ACTIVATION_ID = 'example-activation-1';
+const TURN_ID = 'example-turn-1';
+
+function registryEntry({
+  activationId = ACTIVATION_ID,
+  epoch = 1,
+  turnId = TURN_ID,
+  turnSequence = 1,
+} = {}) {
+  return {
+    status: 'active',
+    active_activation_id: activationId,
+    activation_id: activationId,
+    activation_epoch: epoch,
+    last_turn_id: turnId,
+    last_turn_sequence: turnSequence,
+    activations: {
+      [activationId]: {
+        activation_id: activationId,
+        epoch,
+        status: 'active',
+        last_turn_sequence: turnSequence,
+        last_stop_turn_id: turnId,
+        last_stop_turn_sequence: turnSequence,
+      },
+    },
+  };
+}
+
+function context({
+  activationId = ACTIVATION_ID,
+  epoch = 1,
+  turnId = TURN_ID,
+  turnSequence = 1,
+  observedAt = '2026-01-01T00:00:01.000Z',
+  summary = 'example handoff one',
+  evidence = {},
+} = {}) {
+  return {
+    sessionId: SESSION_ID,
+    disposition: 'applied',
+    projectId: 'example-project',
+    identity: { canonicalConversationId: SESSION_ID, provider: 'codex' },
+    activation: { id: activationId, epoch },
+    turn: { id: turnId, sequence: turnSequence },
+    noteRel: 'example-sessions/example-session.md',
+    observedAt,
+    summary,
+    evidence,
+  };
+}
+
+function fixture({ legacy = false } = {}) {
+  const vault = mkdtempSync(join(tmpdir(), 'example-memory-lifecycle-'));
+  const brain = join(vault, '.brain');
+  mkdirSync(brain, { recursive: true });
+  writeFileSync(join(brain, 'PROJECT.json'), `${JSON.stringify({
+    schemaVersion: 2,
+    projectId: 'example-project',
+  })}\n`);
+  writeFileSync(join(brain, 'SHARED_MEMORY.md'), legacy
+    ? '# Example legacy memory\n\n- example legacy fact\n'
+    : renderSharedMemory());
+  writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), '');
+  writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), '');
+  writeFileSync(join(brain, 'SESSION_REGISTRY.json'), `${JSON.stringify({
+    version: 2,
+    sessions: { [SESSION_ID]: registryEntry() },
+  }, null, 2)}\n`);
+  return { vault, brain, registryPath: join(brain, 'SESSION_REGISTRY.json') };
+}
+
+function readRegistry(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function writeRegistry(path, registry) {
+  writeFileSync(path, `${JSON.stringify(registry, null, 2)}\n`);
+}
+
+test('[req:MEM-STOP-5] [sensor:session-memory-lifecycle] outbox is durable before the registry acknowledges enqueued', () => {
+  const calls = [];
+  let durable = false;
+  const registry = { version: 2, sessions: { [SESSION_ID]: registryEntry() } };
+  const fakeEvent = { event_id: 'example-event-1' };
+
+  const attempt = stageStopMemoryAttempt('example-vault', context(), {
+    detectMemoryMode: () => ({ mode: 'v2', reason: 'example-v2' }),
+    buildSessionMemoryEvents: () => [fakeEvent],
+    enqueueMemoryEvent: (_vault, event) => {
+      calls.push(`enqueue:${event.event_id}`);
+      durable = true;
+      return { status: 'enqueued', eventId: event.event_id };
+    },
+    mutateSessionRegistry: (_vault, mutator) => {
+      const result = mutator(registry);
+      assert.equal(durable, true, 'registry cannot acknowledge an event before its durable enqueue');
+      calls.push(`persist:${registry.sessions[SESSION_ID].last_memory_attempt.state}`);
+      return result;
+    },
+  });
+
+  assert.deepEqual(calls, ['enqueue:example-event-1', 'persist:enqueued']);
+  assert.equal(attempt.state, 'enqueued');
+  assert.deepEqual(registry.sessions[SESSION_ID].last_memory_attempt.event_ids, ['example-event-1']);
+});
+
+test('[req:MEM-STOP-3] [req:MEM-STOP-5] [sensor:session-memory-lifecycle] retry reuses the frozen attempt when clock and evidence change', () => {
+  const { vault, brain, registryPath } = fixture();
+  let builds = 0;
+  const deps = {
+    buildSessionMemoryEvents: (handoff) => {
+      builds += 1;
+      return buildSessionMemoryEvents(handoff);
+    },
+  };
+
+  try {
+    const first = stageStopMemoryAttempt(vault, context(), deps);
+    const outboxPath = join(brain, 'memory-outbox', `${first.event_ids[0]}.json`);
+    const frozenPayload = readFileSync(outboxPath);
+    const degraded = projectStopMemoryAttempt(vault, first, {
+      projectMemoryOutbox: () => { throw new Error('example projector failure'); },
+    });
+    recordStopMemoryOutcome(vault, first, degraded);
+
+    const retry = stageStopMemoryAttempt(vault, context({
+      observedAt: '2026-01-01T00:09:59.000Z',
+      summary: 'example handoff changed after staging',
+      evidence: { nextAction: { id: 'example-next', summary: 'example next changed' } },
+    }), deps);
+
+    assert.equal(builds, 1, 'retry must not rebuild a payload that is already frozen in the outbox');
+    assert.deepEqual(retry.event_ids, first.event_ids);
+    assert.deepEqual(readFileSync(outboxPath), frozenPayload);
+    assert.equal(readRegistry(registryPath).sessions[SESSION_ID].last_memory_attempt.state, 'degraded');
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-STOP-3] [req:MEM-STOP-5] [sensor:session-memory-lifecycle] degraded busy attempt replays exactly once', () => {
+  const { vault, brain, registryPath } = fixture();
+  try {
+    const staged = stageStopMemoryAttempt(vault, context());
+    const busy = projectStopMemoryAttempt(vault, staged, {
+      projectMemoryOutbox: () => ({ status: 'busy', pending: staged.event_ids.length }),
+    });
+    const recordedBusy = recordStopMemoryOutcome(vault, staged, busy);
+
+    assert.equal(recordedBusy.persisted, true);
+    assert.equal(readRegistry(registryPath).sessions[SESSION_ID].last_memory_attempt.state, 'degraded');
+    assert.ok(existsSync(join(brain, 'memory-outbox', `${staged.event_ids[0]}.json`)));
+
+    const retry = stageStopMemoryAttempt(vault, context({
+      observedAt: '2026-01-01T00:01:00.000Z',
+      summary: 'example retry must not replace the frozen handoff',
+    }));
+    const projected = projectStopMemoryAttempt(vault, retry);
+    const recorded = recordStopMemoryOutcome(vault, retry, projected);
+    const registry = readRegistry(registryPath);
+
+    assert.equal(recorded.persisted, true);
+    assert.equal(projected.state, 'projected');
+    assert.deepEqual(retry.event_ids, staged.event_ids);
+    assert.deepEqual(readMemoryLedger(vault).events.map((event) => event.event_id), staged.event_ids);
+    assert.equal(registry.sessions[SESSION_ID].memory_status, 'projected');
+    assert.equal(registry.sessions[SESSION_ID].memory_checkpoint.revision, 1);
+    assert.equal(readdirSync(join(brain, 'memory-outbox')).length, 0);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-STOP-3] [sensor:session-memory-lifecycle] projected turn becomes a byte-stable duplicate', () => {
+  const { vault, brain, registryPath } = fixture();
+  try {
+    const staged = stageStopMemoryAttempt(vault, context());
+    const projected = projectStopMemoryAttempt(vault, staged);
+    recordStopMemoryOutcome(vault, staged, projected);
+    const ledgerBefore = readFileSync(join(brain, 'MEMORY_EVENTS.jsonl'));
+    const sharedBefore = readFileSync(join(brain, 'SHARED_MEMORY.md'));
+    const registryBefore = readFileSync(registryPath);
+
+    const duplicate = stageStopMemoryAttempt(vault, context({
+      observedAt: '2026-01-01T23:59:59.000Z',
+      summary: 'example duplicate with different transient inputs',
+    }));
+    const duplicateOutcome = projectStopMemoryAttempt(vault, duplicate, {
+      projectMemoryOutbox: () => { throw new Error('duplicate must not invoke the projector'); },
+    });
+    const recorded = recordStopMemoryOutcome(vault, duplicate, duplicateOutcome);
+
+    assert.equal(duplicate.state, 'duplicate');
+    assert.deepEqual(duplicate.event_ids, staged.event_ids);
+    assert.equal(recorded.persisted, false);
+    assert.deepEqual(readFileSync(join(brain, 'MEMORY_EVENTS.jsonl')), ledgerBefore);
+    assert.deepEqual(readFileSync(join(brain, 'SHARED_MEMORY.md')), sharedBefore);
+    assert.deepEqual(readFileSync(registryPath), registryBefore);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-STOP-4] [sensor:session-memory-lifecycle] stale outcome cannot overwrite a newer activation checkpoint', () => {
+  const { vault, registryPath } = fixture();
+  try {
+    const staged = stageStopMemoryAttempt(vault, context());
+    const projected = projectStopMemoryAttempt(vault, staged);
+    const registry = readRegistry(registryPath);
+    const newerCheckpoint = {
+      revision: 99,
+      event_cursor: 'example-newer-cursor',
+      state_hash: 'a'.repeat(64),
+    };
+    registry.sessions[SESSION_ID] = {
+      ...registry.sessions[SESSION_ID],
+      ...registryEntry({
+        activationId: 'example-activation-2',
+        epoch: 2,
+        turnId: 'example-turn-2',
+        turnSequence: 2,
+      }),
+      memory_status: 'projected',
+      memory_activation_id: 'example-activation-2',
+      memory_checkpoint: newerCheckpoint,
+      last_memory_attempt: {
+        v: 1,
+        memory_mode: 'v2',
+        canonical_session_id: SESSION_ID,
+        activation_id: 'example-activation-2',
+        activation_epoch: 2,
+        turn_id: 'example-turn-2',
+        turn_sequence: 2,
+        disposition: 'applied',
+        state: 'projected',
+        event_ids: ['example-newer-event'],
+        observed_at: '2026-01-01T00:00:02.000Z',
+        checkpoint: newerCheckpoint,
+      },
+    };
+    writeRegistry(registryPath, registry);
+    const registryBefore = readFileSync(registryPath);
+
+    const recorded = recordStopMemoryOutcome(vault, staged, projected);
+
+    assert.equal(recorded.persisted, false);
+    assert.equal(recorded.reason, 'stale-causal-context');
+    assert.deepEqual(readFileSync(registryPath), registryBefore);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-STOP-5] [req:MEM-STOP-6] [sensor:session-memory-lifecycle] ambiguous v2 skip is persisted for diagnostics', () => {
+  const { vault, brain, registryPath } = fixture();
+  try {
+    const registry = readRegistry(registryPath);
+    registry.sessions[SESSION_ID].active_activation_id = '';
+    registry.sessions[SESSION_ID].activations[ACTIVATION_ID].status = 'done';
+    registry.sessions[SESSION_ID].memory_status = 'legacy';
+    writeRegistry(registryPath, registry);
+
+    const skipped = stageStopMemoryAttempt(vault, {
+      ...context(),
+      disposition: 'ambiguous',
+    });
+    const recorded = readRegistry(registryPath).sessions[SESSION_ID];
+
+    assert.equal(skipped.state, 'skipped');
+    assert.equal(skipped.disposition, 'ambiguous');
+    assert.equal(recorded.last_memory_attempt.memory_mode, 'v2');
+    assert.equal(recorded.last_memory_attempt.state, 'skipped');
+    assert.equal(recorded.last_memory_attempt.disposition, 'ambiguous');
+    assert.equal(recorded.memory_status, 'skipped', 'a v2 Stop cannot leave the flat view as legacy');
+    assert.equal(existsSync(join(brain, 'memory-outbox')), false);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-STOP-4] [req:MEM-STOP-6] [sensor:session-memory-lifecycle] older ambiguous skip preserves a newer attempt', () => {
+  const { vault, registryPath } = fixture();
+  try {
+    const registry = readRegistry(registryPath);
+    const newerCheckpoint = {
+      revision: 2,
+      event_cursor: 'example-newer-cursor',
+      state_hash: 'b'.repeat(64),
+    };
+    registry.sessions[SESSION_ID] = {
+      ...registry.sessions[SESSION_ID],
+      ...registryEntry({
+        activationId: 'example-activation-2',
+        epoch: 2,
+        turnId: 'example-turn-2',
+        turnSequence: 2,
+      }),
+      memory_status: 'projected',
+      memory_activation_id: 'example-activation-2',
+      memory_checkpoint: newerCheckpoint,
+      last_memory_attempt: {
+        v: 1,
+        memory_mode: 'v2',
+        canonical_session_id: SESSION_ID,
+        activation_id: 'example-activation-2',
+        activation_epoch: 2,
+        turn_id: 'example-turn-2',
+        turn_sequence: 2,
+        disposition: 'applied',
+        state: 'projected',
+        event_ids: ['example-newer-event'],
+        observed_at: '2026-01-01T00:00:02.000Z',
+        checkpoint: newerCheckpoint,
+      },
+    };
+    writeRegistry(registryPath, registry);
+    const registryBefore = readFileSync(registryPath);
+
+    const skipped = stageStopMemoryAttempt(vault, {
+      ...context(),
+      disposition: 'ambiguous',
+    });
+
+    assert.equal(skipped.state, 'skipped');
+    assert.equal(skipped.disposition, 'ambiguous');
+    assert.deepEqual(readFileSync(registryPath), registryBefore);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-STOP-5] [sensor:session-memory-lifecycle] legacy mode is inert across all phases', () => {
+  const { vault, registryPath } = fixture({ legacy: true });
+  try {
+    const registryBefore = readFileSync(registryPath);
+    const inert = stageStopMemoryAttempt(vault, context(), {
+      buildSessionMemoryEvents: () => { throw new Error('legacy cannot build events'); },
+      enqueueMemoryEvent: () => { throw new Error('legacy cannot enqueue events'); },
+      mutateSessionRegistry: () => { throw new Error('legacy cannot mutate registry'); },
+    });
+    const outcome = projectStopMemoryAttempt(vault, inert, {
+      projectMemoryOutbox: () => { throw new Error('legacy cannot project'); },
+    });
+    const recorded = recordStopMemoryOutcome(vault, inert, outcome, {
+      mutateSessionRegistry: () => { throw new Error('legacy cannot record'); },
+    });
+
+    assert.equal(inert.memory_mode, 'legacy');
+    assert.equal(inert.state, 'skipped');
+    assert.equal(outcome.status, 'legacy');
+    assert.equal(recorded.persisted, false);
+    assert.deepEqual(readFileSync(registryPath), registryBefore);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});

--- a/tests/session-stop-memory.test.mjs
+++ b/tests/session-stop-memory.test.mjs
@@ -1,63 +1,58 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { commitSessionMemory } from '../hooks/session-stop.mjs';
-import { renderSharedMemory } from '../hooks/memory-schema.mjs';
+import {
+  SYNTHETIC_MEMORY,
+  makeSyntheticHandoff,
+  seedSyntheticMemoryVault,
+} from './fixtures/synthetic-memory-lifecycle.mjs';
 
-function fixture() {
-  const vault = mkdtempSync(join(tmpdir(), 'wk-stop-memory-'));
-  mkdirSync(join(vault, '.brain'), { recursive: true });
-  writeFileSync(join(vault, '.brain', 'PROJECT.json'), `${JSON.stringify({ schemaVersion: 2, projectId: 'vendiva' })}\n`);
-  writeFileSync(join(vault, '.brain', 'SHARED_MEMORY.md'), renderSharedMemory());
-  writeFileSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl'), '');
-  writeFileSync(join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl'), '');
-  return vault;
-}
-
-const handoff = {
-  projectId: 'vendiva',
-  identity: { canonicalConversationId: 'session-1', provider: 'codex' },
-  activation: { id: 'activation-1', epoch: 1 },
-  turn: { id: 'turn-9', sequence: 9 },
-  noteRel: '02-Sessões/2026/07-JUL/DIA 25/22-22-session.md',
-  observedAt: '2026-07-26T03:20:47Z',
-  summary: 'Concluído. Próxima change será a interface de revisão.',
-  evidence: {},
-};
-
-test('[req:MEM-HYB-1] [req:HOOK-MEM-1] finalized handoff reaches ledger and SHARED with a checkpoint', () => {
-  const vault = fixture();
-  const result = commitSessionMemory(vault, handoff);
+test('[req:MEM-STOP-7] synthetic session memory commits through the projector', () => {
+  const vault = seedSyntheticMemoryVault();
+  const result = commitSessionMemory(vault, makeSyntheticHandoff());
 
   assert.equal(result.status, 'projected');
   assert.equal(result.eventCount, 1);
   assert.equal(result.checkpoint.revision, 1);
   assert.match(result.checkpoint.state_hash, /^[a-f0-9]{64}$/);
-  assert.match(readFileSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl'), 'utf8'), /handoff\.latest/);
-  assert.match(readFileSync(join(vault, '.brain', 'SHARED_MEMORY.md'), 'utf8'), /interface de revisão/);
+  assert.match(
+    readFileSync(join(vault, '.brain', 'SHARED_MEMORY.md'), 'utf8'),
+    new RegExp(SYNTHETIC_MEMORY.nextActionId),
+  );
+  assert.match(
+    readFileSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl'), 'utf8'),
+    /handoff\.latest/,
+  );
 });
 
-test('[req:MEM-HYB-7] projector failure is degraded and preserves the outbox for replay', () => {
-  const vault = fixture();
-  const result = commitSessionMemory(vault, handoff, { projectOptions: { faultAt: 'after-ledger' } });
+test('[req:MEM-STOP-7] synthetic projector failure preserves replayable outbox data', () => {
+  const vault = seedSyntheticMemoryVault();
+  const result = commitSessionMemory(vault, makeSyntheticHandoff(), {
+    projectOptions: { faultAt: 'after-ledger' },
+  });
 
   assert.equal(result.status, 'degraded');
-  assert.match(result.error, /after-ledger/);
-  assert.ok(existsSync(join(vault, '.brain', 'memory-outbox', `${result.eventIds[0]}.json`)));
+  assert.match(result.error, /Injected memory-store fault/);
+  assert.ok(existsSync(join(
+    vault,
+    '.brain',
+    'memory-outbox',
+    `${result.eventIds[0]}.json`,
+  )));
 });
 
-test('[req:MEM-HYB-1] [req:MEM-HYB-9] legacy mode makes SessionStop memory publication inert', () => {
-  const vault = fixture();
+test('[req:MEM-STOP-7] synthetic legacy memory remains untouched without v2 evidence', () => {
+  const vault = seedSyntheticMemoryVault();
   const sharedPath = join(vault, '.brain', 'SHARED_MEMORY.md');
   const ledgerPath = join(vault, '.brain', 'MEMORY_EVENTS.jsonl');
   const candidatesPath = join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl');
-  const legacy = '# SHARED legado\n\n## Próximo\n- curar antes de migrar\n';
+  const legacy = '# Legacy WK Fixture Memory\n\n- [wk-fixture] artificial legacy fact.\n';
   writeFileSync(sharedPath, legacy);
 
-  const result = commitSessionMemory(vault, handoff);
+  const result = commitSessionMemory(vault, makeSyntheticHandoff());
 
   assert.equal(result.status, 'legacy');
   assert.equal(result.eventCount, 0);
@@ -69,15 +64,20 @@ test('[req:MEM-HYB-1] [req:MEM-HYB-9] legacy mode makes SessionStop memory publi
   assert.equal(existsSync(join(vault, '.brain', 'memory-outbox')), false);
 });
 
-test('[req:MEM-HYB-1] [req:MEM-HYB-7] unreadable v2 state degrades SessionStop and preserves an outbox', () => {
-  const vault = fixture();
+test('[req:MEM-STOP-7] synthetic unreadable shared memory degrades without losing outbox data', () => {
+  const vault = seedSyntheticMemoryVault();
   const sharedPath = join(vault, '.brain', 'SHARED_MEMORY.md');
   rmSync(sharedPath);
   mkdirSync(sharedPath);
 
-  const result = commitSessionMemory(vault, handoff);
+  const result = commitSessionMemory(vault, makeSyntheticHandoff());
 
   assert.equal(result.status, 'degraded');
   assert.notEqual(result.error, undefined);
-  assert.ok(existsSync(join(vault, '.brain', 'memory-outbox', `${result.eventIds[0]}.json`)));
+  assert.ok(existsSync(join(
+    vault,
+    '.brain',
+    'memory-outbox',
+    `${result.eventIds[0]}.json`,
+  )));
 });

--- a/tests/session-stop-migration-lifecycle.test.mjs
+++ b/tests/session-stop-migration-lifecycle.test.mjs
@@ -1,0 +1,431 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  appendFileSync,
+  cpSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { parseSharedMemory } from '../hooks/memory-schema.mjs';
+import {
+  parseTranscript,
+  resolveTurnIdentity,
+  shouldAbortStopAfterStaging,
+} from '../hooks/session-stop.mjs';
+import { migrateMemory } from '../src/memory.mjs';
+import { renderCoreSkeleton } from '../src/validate-core.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const SESSION_ID = 'synthetic-session-issue-20';
+const TRANSCRIPT_ID = 'synthetic-rollout-issue-20';
+
+function cleanEnv(vault) {
+  const env = { ...process.env, OBSIDIAN_VAULT_PATH: vault };
+  delete env.CLAUDECODE;
+  delete env.CLAUDE_CODE_SESSION_ID;
+  delete env.CLAUDE_PROJECT_DIR;
+  delete env.CODEX_THREAD_ID;
+  delete env.OBSIDIAN_NO_AUTO_FINALIZE;
+  return env;
+}
+
+function runHook(script, project, vault, input) {
+  return spawnSync(process.execPath, [script], {
+    cwd: project,
+    env: cleanEnv(vault),
+    input: JSON.stringify({ cwd: project, obsidian_vault_path: vault, ...input }),
+    encoding: 'utf8',
+  });
+}
+
+function writeEvent(transcript, event) {
+  appendFileSync(transcript, `${JSON.stringify(event)}\n`);
+}
+
+function writeTurn(transcript, turnId, userMessage, assistantMessage) {
+  writeEvent(transcript, {
+    type: 'turn_context',
+    payload: { turn_id: turnId },
+  });
+  writeEvent(transcript, {
+    type: 'event_msg',
+    payload: { type: 'user_message', message: userMessage },
+  });
+  writeEvent(transcript, {
+    type: 'event_msg',
+    payload: { type: 'agent_message', message: assistantMessage },
+  });
+}
+
+function seedLegacyFixture() {
+  const project = mkdtempSync(join(tmpdir(), 'wk-session-memory-lifecycle-'));
+  const vault = join(project, '.Synthetic-vault');
+  const brain = join(vault, '.brain');
+  const transcript = join(project, 'synthetic-rollout.jsonl');
+  mkdirSync(brain, { recursive: true });
+  writeFileSync(join(brain, 'PROJECT.json'), `${JSON.stringify({
+    schemaVersion: 1,
+    projectId: 'synthetic-memory-project',
+  })}\n`);
+  writeFileSync(join(brain, 'CORE.md'), renderCoreSkeleton());
+  writeFileSync(
+    join(brain, 'SHARED_MEMORY.md'),
+    '# Shared legacy\n\n## Current state\n- Synthetic legacy state.\n',
+  );
+  writeFileSync(transcript, `${JSON.stringify({
+    type: 'session_meta',
+    payload: {
+      id: TRANSCRIPT_ID,
+      session_id: SESSION_ID,
+      model_provider: 'openai',
+      cwd: project,
+    },
+  })}\n`);
+  return { project, vault, brain, transcript };
+}
+
+function assertHookSucceeded(result, label) {
+  assert.equal(result.status, 0, `${label} failed:\n${result.stderr}`);
+  assert.doesNotThrow(() => JSON.parse(result.stdout || '{}'), `${label} returned invalid JSON`);
+}
+
+function readRegistry(brain) {
+  return JSON.parse(readFileSync(join(brain, 'SESSION_REGISTRY.json'), 'utf8'));
+}
+
+function readLedger(brain) {
+  return readFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), 'utf8')
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function runMigrationLifecycle(runtimeRoot = ROOT) {
+  const START = join(runtimeRoot, 'hooks', 'session-start.mjs');
+  const ENSURE = join(runtimeRoot, 'hooks', 'session-ensure.mjs');
+  const STOP = join(runtimeRoot, 'hooks', 'session-stop.mjs');
+  const { project, vault, brain, transcript } = seedLegacyFixture();
+  try {
+    const start = runHook(START, project, vault, {
+      hook_event_name: 'SessionStart',
+      session_id: SESSION_ID,
+      transcript_path: transcript,
+      source: 'startup',
+    });
+    assertHookSucceeded(start, 'SessionStart');
+
+    writeTurn(
+      transcript,
+      'synthetic-turn-1',
+      'Start the synthetic lifecycle.',
+      'Synthetic legacy turn completed.',
+    );
+    const firstPrompt = runHook(ENSURE, project, vault, {
+      hook_event_name: 'UserPromptSubmit',
+      session_id: SESSION_ID,
+      transcript_path: transcript,
+      turn_id: 'synthetic-turn-1',
+      prompt: 'Start the synthetic lifecycle.',
+    });
+    assertHookSucceeded(firstPrompt, 'first UserPromptSubmit');
+
+    const legacyStop = runHook(STOP, project, vault, {
+      hook_event_name: 'Stop',
+      session_id: SESSION_ID,
+      transcript_path: transcript,
+      turn_id: 'synthetic-turn-1',
+    });
+    assertHookSucceeded(legacyStop, 'legacy Stop');
+    assert.equal(readRegistry(brain).sessions[SESSION_ID].memory_status, 'legacy');
+
+    // Reproduces the durable registry shape left by the pre-fix lifecycle. The
+    // fixture remains synthetic; the following hooks and migration are real.
+    const legacyRegistry = readRegistry(brain);
+    const legacyEntry = legacyRegistry.sessions[SESSION_ID];
+    const legacyActivationId = legacyEntry.active_activation_id;
+    legacyEntry.status = 'done';
+    legacyEntry.active_activation_id = '';
+    legacyEntry.activations[legacyActivationId].status = 'done';
+    writeFileSync(join(brain, 'SESSION_REGISTRY.json'), `${JSON.stringify(legacyRegistry, null, 2)}\n`);
+
+    const migration = migrateMemory(vault, { apply: true });
+    assert.equal(migration.status, 'migrated');
+    assert.equal(parseSharedMemory(readFileSync(join(brain, 'SHARED_MEMORY.md'), 'utf8')).metadata.revision, 0);
+
+    writeTurn(
+      transcript,
+      'synthetic-turn-2',
+      'Continue after the synthetic migration.',
+      'Synthetic v2 handoff completed. Next action: review the fixture.',
+    );
+    const ensure = runHook(ENSURE, project, vault, {
+      hook_event_name: 'UserPromptSubmit',
+      session_id: SESSION_ID,
+      transcript_path: transcript,
+      turn_id: 'synthetic-turn-2',
+      prompt: 'Continue after the synthetic migration.',
+    });
+    assertHookSucceeded(ensure, 'UserPromptSubmit');
+
+    const v2Stop = runHook(STOP, project, vault, {
+      hook_event_name: 'Stop',
+      session_id: SESSION_ID,
+      transcript_path: transcript,
+      turn_id: 'synthetic-turn-2',
+    });
+    assertHookSucceeded(v2Stop, 'v2 Stop');
+
+    const duplicateStop = runHook(STOP, project, vault, {
+      hook_event_name: 'Stop',
+      session_id: SESSION_ID,
+      transcript_path: transcript,
+      turn_id: 'synthetic-turn-2',
+    });
+    assertHookSucceeded(duplicateStop, 'duplicate v2 Stop');
+
+    const registry = readRegistry(brain);
+    const shared = parseSharedMemory(readFileSync(join(brain, 'SHARED_MEMORY.md'), 'utf8'));
+    const ledger = readLedger(brain);
+    const handoffs = ledger.filter((event) => event.memory_key === 'handoff.latest');
+    const diagnostic = JSON.stringify({
+      ledger_events: ledger.length,
+      shared_revision: shared.metadata.revision,
+      memory_status: registry.sessions[SESSION_ID].memory_status,
+      has_checkpoint: Boolean(registry.sessions[SESSION_ID].memory_checkpoint),
+      stop_output: JSON.parse(v2Stop.stdout || '{}'),
+    });
+
+    assert.equal(handoffs.length, 1, `first eligible v2 Stop did not publish exactly once: ${diagnostic}`);
+    assert.equal(shared.metadata.revision, 1, diagnostic);
+    assert.equal(registry.sessions[SESSION_ID].memory_status, 'projected', diagnostic);
+    assert.deepEqual(registry.sessions[SESSION_ID].memory_checkpoint, {
+      revision: 1,
+      event_cursor: handoffs[0].event_id,
+      state_hash: shared.metadata.state_hash,
+    });
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+}
+
+// [sensor:session-memory-lifecycle]
+test('[req:MEM-STOP-1] [req:MEM-STOP-2] [req:MEM-STOP-7] first real Stop after legacy-to-v2 migration publishes exactly once', () => {
+  runMigrationLifecycle();
+});
+
+test('[req:MEM-STOP-1] [req:MEM-STOP-7] removing lifecycle staging makes the full-process oracle fail', () => {
+  const mutantRoot = mkdtempSync(join(tmpdir(), 'wk-session-memory-mutant-'));
+
+  try {
+    cpSync(join(ROOT, 'hooks'), join(mutantRoot, 'hooks'), { recursive: true });
+    cpSync(join(ROOT, 'src'), join(mutantRoot, 'src'), { recursive: true });
+
+    assert.doesNotThrow(() => runMigrationLifecycle(mutantRoot));
+
+    const lifecyclePath = join(mutantRoot, 'hooks', 'session-memory-lifecycle.mjs');
+    const source = readFileSync(lifecyclePath, 'utf8');
+    const marker = 'for (const event of events) deps.enqueueMemoryEvent(vaultBase, event);';
+    const replacement = 'for (const event of events) void event;';
+    assert.ok(source.includes(marker), 'mutation marker must track the production staging call');
+    writeFileSync(lifecyclePath, source.replace(marker, replacement));
+
+    assert.throws(
+      () => runMigrationLifecycle(mutantRoot),
+      /first eligible v2 Stop did not publish exactly once/,
+    );
+  } finally {
+    rmSync(mutantRoot, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-STOP-2] native Codex and Claude transcripts derive causal turn order without hook-only fields', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'wk-provider-turn-order-'));
+  try {
+    const codexPath = join(dir, 'synthetic-codex.jsonl');
+    const codexEvents = [
+      { type: 'session_meta', payload: { id: 'wk-fixture-rollout', session_id: 'wk-fixture-session' } },
+      { type: 'turn_context', payload: { turn_id: 'wk-fixture-codex-turn-1' } },
+      { type: 'event_msg', payload: { type: 'user_message', message: 'Synthetic first prompt.' } },
+      { type: 'event_msg', payload: { type: 'agent_message', message: 'Synthetic first answer.' } },
+      { type: 'turn_context', payload: { turn_id: 'wk-fixture-codex-turn-2' } },
+      { type: 'event_msg', payload: { type: 'user_message', message: 'Synthetic second prompt.' } },
+      { type: 'event_msg', payload: { type: 'agent_message', message: 'Synthetic second answer.' } },
+    ];
+    writeFileSync(codexPath, `${codexEvents.map((event) => JSON.stringify(event)).join('\n')}\n`);
+    const codex = parseTranscript(codexPath);
+    assert.deepEqual(resolveTurnIdentity(codex, 'wk-fixture-codex-turn-1'), {
+      id: 'wk-fixture-codex-turn-1', order: 1, observedAt: '',
+    });
+    assert.equal(resolveTurnIdentity(codex, 'wk-fixture-missing-turn'), null);
+
+    const claudePath = join(dir, 'synthetic-claude.jsonl');
+    const claudeEvents = [
+      {
+        type: 'user', uuid: 'wk-fixture-claude-turn-1', timestamp: '2026-01-01T00:00:01.000Z',
+        sessionId: 'wk-fixture-session', message: { role: 'user', content: 'Synthetic first prompt.' },
+      },
+      {
+        type: 'assistant', uuid: 'wk-fixture-claude-answer-1', timestamp: '2026-01-01T00:00:02.000Z',
+        sessionId: 'wk-fixture-session', message: { role: 'assistant', content: [{ type: 'text', text: 'Synthetic first answer.' }] },
+      },
+      {
+        type: 'user', uuid: 'wk-fixture-claude-turn-2', timestamp: '2026-01-01T00:00:03.000Z',
+        sessionId: 'wk-fixture-session', message: { role: 'user', content: 'Synthetic second prompt.' },
+      },
+      {
+        type: 'assistant', uuid: 'wk-fixture-claude-answer-2', timestamp: '2026-01-01T00:00:04.000Z',
+        sessionId: 'wk-fixture-session', message: { role: 'assistant', content: [{ type: 'text', text: 'Synthetic second answer.' }] },
+      },
+    ];
+    writeFileSync(claudePath, `${claudeEvents.map((event) => JSON.stringify(event)).join('\n')}\n`);
+    const claude = parseTranscript(claudePath);
+    assert.deepEqual(resolveTurnIdentity(claude), {
+      id: 'wk-fixture-claude-turn-2', order: 2, observedAt: '2026-01-01T00:00:03.000Z',
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-STOP-6] unverifiable v2 Stop is durably observable as ambiguous', () => {
+  const { project, vault, brain, transcript } = seedLegacyFixture();
+  try {
+    assert.equal(migrateMemory(vault, { apply: true }).status, 'migrated');
+    const start = runHook(join(ROOT, 'hooks', 'session-start.mjs'), project, vault, {
+      hook_event_name: 'SessionStart',
+      session_id: SESSION_ID,
+      transcript_path: transcript,
+      source: 'startup',
+    });
+    assertHookSucceeded(start, 'SessionStart before ambiguous Stop');
+
+    const stop = runHook(join(ROOT, 'hooks', 'session-stop.mjs'), project, vault, {
+      hook_event_name: 'Stop',
+      session_id: SESSION_ID,
+      transcript_path: transcript,
+      turn_id: 'wk-fixture-turn-not-in-transcript',
+    });
+    assertHookSucceeded(stop, 'ambiguous Stop');
+    assert.match(JSON.parse(stop.stdout).systemMessage, /Stop ambiguous/);
+
+    const attempt = readRegistry(brain).sessions[SESSION_ID].last_memory_attempt;
+    assert.equal(attempt.memory_mode, 'v2');
+    assert.equal(attempt.disposition, 'ambiguous');
+    assert.equal(attempt.state, 'skipped');
+    assert.deepEqual(attempt.event_ids, []);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-STOP-4] v2 staging revalidation aborts an older Stop before finalization', () => {
+  const stopAcceptedBeforeConcurrentStart = {
+    stopDisposition: 'applied',
+    canPromoteMemory: true,
+  };
+  const supersededAtStaging = {
+    memory_mode: 'v2',
+    state: 'skipped',
+    disposition: 'superseded',
+  };
+
+  assert.equal(shouldAbortStopAfterStaging(
+    stopAcceptedBeforeConcurrentStart,
+    supersededAtStaging,
+  ), true);
+  assert.equal(shouldAbortStopAfterStaging(stopAcceptedBeforeConcurrentStart, {
+    memory_mode: 'v2', state: 'enqueued', disposition: 'applied',
+  }), false);
+  assert.equal(shouldAbortStopAfterStaging(stopAcceptedBeforeConcurrentStart, {
+    memory_mode: 'legacy', state: 'skipped', disposition: 'legacy',
+  }), false);
+});
+
+test('[req:MEM-STOP-4] concurrent activation between Stop CAS and staging preserves note and control', () => {
+  const { project, vault, brain, transcript } = seedLegacyFixture();
+  try {
+    assert.equal(migrateMemory(vault, { apply: true }).status, 'migrated');
+    const start = runHook(join(ROOT, 'hooks', 'session-start.mjs'), project, vault, {
+      hook_event_name: 'SessionStart',
+      session_id: SESSION_ID,
+      transcript_path: transcript,
+      source: 'startup',
+    });
+    assertHookSucceeded(start, 'SessionStart before concurrent Stop');
+    writeTurn(
+      transcript,
+      'wk-fixture-concurrent-turn-1',
+      'Start the concurrency fixture.',
+      'Synthetic concurrent turn completed.',
+    );
+    const ensure = runHook(join(ROOT, 'hooks', 'session-ensure.mjs'), project, vault, {
+      hook_event_name: 'UserPromptSubmit',
+      session_id: SESSION_ID,
+      transcript_path: transcript,
+      turn_id: 'wk-fixture-concurrent-turn-1',
+      prompt: 'Start the concurrency fixture.',
+    });
+    assertHookSucceeded(ensure, 'UserPromptSubmit before concurrent Stop');
+
+    const before = readRegistry(brain).sessions[SESSION_ID];
+    const notePath = join(vault, before.session_file);
+    const controlPath = join(brain, 'CURRENT_SESSION.md');
+    const noteBefore = readFileSync(notePath);
+    const controlBefore = readFileSync(controlPath);
+    const runner = join(project, 'synthetic-concurrent-stop-runner.mjs');
+    const stopModule = pathToFileURL(join(ROOT, 'hooks', 'session-stop.mjs')).href;
+    const lifecycleModule = pathToFileURL(join(ROOT, 'hooks', 'session-memory-lifecycle.mjs')).href;
+    const commonModule = pathToFileURL(join(ROOT, 'hooks', 'obsidian-common.mjs')).href;
+    writeFileSync(runner, `
+import { main } from ${JSON.stringify(stopModule)};
+import { stageStopMemoryAttempt } from ${JSON.stringify(lifecycleModule)};
+import { mutateSessionRegistry, openActivation } from ${JSON.stringify(commonModule)};
+main({
+  stageMemory(vaultBase, context) {
+    mutateSessionRegistry(vaultBase, (registry) => {
+      const next = openActivation(registry, {
+        session_id: ${JSON.stringify(SESSION_ID)},
+        activation_id: 'wk-fixture-concurrent-activation-2',
+        activation_started_at: '2026-01-01T00:00:02.000Z',
+        turn_sequence: context.handoff.turn.sequence,
+        transcript_id: ${JSON.stringify(TRANSCRIPT_ID)},
+        transcript_path: ${JSON.stringify(transcript)},
+        provider: 'codex',
+      });
+      registry.version = next.version;
+      registry.sessions = next.sessions;
+      return null;
+    });
+    return stageStopMemoryAttempt(vaultBase, context);
+  },
+});
+`);
+
+    const stop = runHook(runner, project, vault, {
+      hook_event_name: 'Stop',
+      session_id: SESSION_ID,
+      transcript_path: transcript,
+      turn_id: 'wk-fixture-concurrent-turn-1',
+    });
+    assertHookSucceeded(stop, 'concurrent Stop');
+    assert.match(JSON.parse(stop.stdout).systemMessage, /Stop superseded/);
+    assert.deepEqual(readFileSync(notePath), noteBefore);
+    assert.deepEqual(readFileSync(controlPath), controlBefore);
+    const after = readRegistry(brain).sessions[SESSION_ID];
+    assert.equal(after.active_activation_id, 'wk-fixture-concurrent-activation-2');
+    assert.equal(after.activations['wk-fixture-concurrent-activation-2'].status, 'active');
+    assert.equal(parseSharedMemory(readFileSync(join(brain, 'SHARED_MEMORY.md'), 'utf8')).metadata.revision, 0);
+    assert.deepEqual(readLedger(brain), []);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+});

--- a/tests/vault-health-memory.test.mjs
+++ b/tests/vault-health-memory.test.mjs
@@ -43,7 +43,10 @@ function createBundle(events = [event()]) {
   const reduced = reduceMemoryEvents(events);
   writeFileSync(join(brain, 'PROJECT.json'), `${JSON.stringify({ schemaVersion: 1, projectId: PROJECT_ID })}\n`);
   writeFileSync(join(brain, 'CORE.md'), renderCoreSkeleton());
-  writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), events.map((item) => JSON.stringify(item)).join('\n') + '\n');
+  writeFileSync(
+    join(brain, 'MEMORY_EVENTS.jsonl'),
+    events.length ? `${events.map((item) => JSON.stringify(item)).join('\n')}\n` : '',
+  );
   writeFileSync(join(brain, 'SHARED_MEMORY.md'), renderSharedMemory({
     revision: reduced.revision,
     eventCursor: reduced.eventCursor,
@@ -71,6 +74,44 @@ function byteSnapshot(vault) {
   return entries;
 }
 
+function writeLastMemoryAttempt(vault, attempt, sessionId = 'example-session-health') {
+  writeFileSync(join(vault, '.brain', 'SESSION_REGISTRY.json'), `${JSON.stringify({
+    version: 2,
+    sessions: {
+      [sessionId]: {
+        status: 'done',
+        session_file: '02-Sessions/example-session.md',
+        last_memory_attempt: attempt,
+      },
+    },
+  })}\n`);
+}
+
+function memoryAttempt(overrides = {}) {
+  return {
+    v: 1,
+    memory_mode: 'v2',
+    activation_id: 'example-activation-health',
+    activation_epoch: 1,
+    turn_id: 'example-turn-health',
+    turn_sequence: 1,
+    disposition: 'applied',
+    state: 'enqueued',
+    event_ids: ['mem-health-1'],
+    observed_at: '2000-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function checkpointFor(events) {
+  const reduced = reduceMemoryEvents(events);
+  return {
+    revision: reduced.revision,
+    event_cursor: reduced.eventCursor,
+    state_hash: reduced.stateHash,
+  };
+}
+
 test('[req:DIAG-8] doctor names a healthy bundle and reports schema/revision/cursor/hash', () => {
   const vault = createBundle();
   try {
@@ -86,6 +127,177 @@ test('[req:DIAG-8] doctor names a healthy bundle and reports schema/revision/cur
     assert.match(result.metrics.stateHash, /^[a-f0-9]{64}$/);
     assert.equal(result.metrics.ledgerEvents, 1);
     assert.deepEqual(byteSnapshot(vault), before, 'doctor must be byte-for-byte read-only');
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-STOP-6] [sensor:memory-health] valid revision 0 stays healthy with no attempt or a legacy attempt', () => {
+  const vault = createBundle([]);
+  try {
+    const absent = checkMemoryBundle(vault);
+    assert.equal(absent.ok, true, absent.failures.join('; '));
+    assert.equal(absent.status, 'healthy');
+
+    writeLastMemoryAttempt(vault, memoryAttempt({
+      memory_mode: 'legacy',
+      state: 'skipped',
+      event_ids: [],
+    }));
+    const legacy = checkMemoryBundle(vault);
+    assert.equal(legacy.ok, true, legacy.failures.join('; '));
+    assert.equal(legacy.status, 'healthy');
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-STOP-6] [sensor:memory-health] ambiguous v2 skip is blocking', () => {
+  const vault = createBundle([]);
+  try {
+    writeLastMemoryAttempt(vault, memoryAttempt({
+      disposition: 'ambiguous',
+      state: 'skipped',
+      event_ids: [],
+    }));
+    const result = checkMemoryBundle(vault);
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 'blocked');
+    assert.match(result.failures.join('\n'), /amb[ií]gu|lifecycle/i);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-STOP-5] [req:MEM-STOP-6] [sensor:memory-health] degraded attempt split across ledger and valid outbox is recoverable', () => {
+  const projected = event('mem-example-projected', {
+    memory_key: 'example.projected', value: 'synthetic projected state',
+  });
+  const pending = event('mem-example-pending', {
+    memory_key: 'example.pending', value: 'synthetic pending state', turn_sequence: 2,
+  });
+  const vault = createBundle([projected]);
+  try {
+    const outbox = join(vault, '.brain', 'memory-outbox');
+    mkdirSync(outbox);
+    writeFileSync(join(outbox, `${pending.event_id}.json`), `${JSON.stringify(pending)}\n`);
+    writeLastMemoryAttempt(vault, memoryAttempt({
+      state: 'degraded',
+      event_ids: [projected.event_id, pending.event_id],
+      error: 'example-private-payload-must-not-be-rendered',
+    }));
+
+    const result = checkMemoryBundle(vault);
+    assert.equal(result.ok, true, result.failures.join('; '));
+    assert.equal(result.status, 'warning');
+    assert.match(result.warnings.join('\n'), /recuper|attempt/i);
+    assert.doesNotMatch(JSON.stringify(result), /example-private-payload-must-not-be-rendered/);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-STOP-6] [sensor:memory-health] applied v2 attempt with no event ids is blocking', () => {
+  const vault = createBundle([]);
+  try {
+    writeLastMemoryAttempt(vault, memoryAttempt({ event_ids: [] }));
+    const result = checkMemoryBundle(vault);
+    assert.equal(result.ok, false);
+    assert.match(result.failures.join('\n'), /event_ids|publica[cç][aã]o perdida/i);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-STOP-6] [sensor:memory-health] attempt event absent from both ledger and outbox is blocking', () => {
+  const vault = createBundle([]);
+  try {
+    writeLastMemoryAttempt(vault, memoryAttempt({ event_ids: ['mem-example-missing'] }));
+    const result = checkMemoryBundle(vault);
+    assert.equal(result.ok, false);
+    assert.match(result.failures.join('\n'), /ausente|ledger.*outbox|publica[cç][aã]o perdida/i);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-STOP-6] [sensor:memory-health] projected checkpoint remains valid when the current projection is newer', () => {
+  const attemptEvent = event('mem-example-prefix', {
+    memory_key: 'example.prefix', value: 'synthetic prefix state',
+  });
+  const concurrentCursor = event('mem-example-concurrent-cursor', {
+    memory_key: 'example.concurrent', value: 'synthetic concurrent state', turn_sequence: 2,
+  });
+  const later = event('mem-example-later', {
+    memory_key: 'example.later', value: 'synthetic later state', turn_sequence: 3,
+  });
+  const vault = createBundle([attemptEvent, concurrentCursor, later]);
+  try {
+    writeLastMemoryAttempt(vault, memoryAttempt({
+      state: 'projected',
+      event_ids: [attemptEvent.event_id],
+      checkpoint: checkpointFor([attemptEvent, concurrentCursor]),
+    }));
+    const result = checkMemoryBundle(vault);
+    assert.equal(result.ok, true, result.failures.join('; '));
+    assert.equal(result.status, 'healthy');
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-STOP-5] [req:MEM-STOP-6] [sensor:memory-health] projected attempt requires its events in the ledger, not only the outbox', () => {
+  const pending = event('mem-example-projected-outbox-only', {
+    memory_key: 'example.outbox-only', value: 'synthetic outbox-only state',
+  });
+  const vault = createBundle([]);
+  try {
+    const outbox = join(vault, '.brain', 'memory-outbox');
+    mkdirSync(outbox);
+    writeFileSync(join(outbox, `${pending.event_id}.json`), `${JSON.stringify(pending)}\n`);
+    writeLastMemoryAttempt(vault, memoryAttempt({
+      state: 'projected',
+      event_ids: [pending.event_id],
+      checkpoint: checkpointFor([pending]),
+    }));
+
+    const result = checkMemoryBundle(vault);
+    assert.equal(result.ok, false);
+    assert.match(result.failures.join('\n'), /projetado.*ledger|ledger.*projetado/i);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-STOP-6] [sensor:memory-health] projected checkpoint mismatch is blocking', () => {
+  const first = event('mem-example-checkpoint', {
+    memory_key: 'example.checkpoint', value: 'synthetic checkpoint state',
+  });
+  const vault = createBundle([first]);
+  try {
+    writeLastMemoryAttempt(vault, memoryAttempt({
+      state: 'projected',
+      event_ids: [first.event_id],
+      checkpoint: { ...checkpointFor([first]), state_hash: '0'.repeat(64) },
+    }));
+    const result = checkMemoryBundle(vault);
+    assert.equal(result.ok, false);
+    assert.match(result.failures.join('\n'), /checkpoint|proje[cç][aã]o/i);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-STOP-6] [sensor:memory-health] stale or superseded skip is non-blocking without emitted events', () => {
+  const vault = createBundle([]);
+  try {
+    writeLastMemoryAttempt(vault, memoryAttempt({
+      disposition: 'superseded',
+      state: 'skipped',
+      event_ids: [],
+    }));
+    const result = checkMemoryBundle(vault);
+    assert.equal(result.ok, true, result.failures.join('; '));
+    assert.doesNotMatch(result.failures.join('\n'), /publica[cç][aã]o perdida|ausente|checkpoint/i);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-STOP-5] [req:MEM-STOP-6] [sensor:memory-health] rejected stale attempt with emitted ids is blocking', () => {
+  const emitted = event('mem-example-causal-leak', {
+    memory_key: 'example.causal-leak', value: 'synthetic rejected state',
+  });
+  const vault = createBundle([emitted]);
+  try {
+    writeLastMemoryAttempt(vault, memoryAttempt({
+      disposition: 'stale_turn',
+      state: 'skipped',
+      event_ids: [emitted.event_id],
+    }));
+    const result = checkMemoryBundle(vault);
+    assert.equal(result.ok, false);
+    assert.match(result.failures.join('\n'), /stale|superseded|causal/i);
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
 

--- a/wendkeep.sensors.json
+++ b/wendkeep.sensors.json
@@ -40,6 +40,14 @@
       "severity": "critical",
       "type": "command",
       "command": "node --test tests/docs-bilingual.test.mjs tests/readme-packaging.test.mjs"
+    },
+    {
+      "id": "session-memory-lifecycle",
+      "name": "Session memory lifecycle",
+      "description": "Exercises the full legacy-to-v2 SessionStop lifecycle, causal retries and memory diagnostics",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test tests/session-stop-migration-lifecycle.test.mjs tests/memory-activation.test.mjs tests/session-memory-lifecycle.test.mjs tests/vault-health-memory.test.mjs"
     }
   ]
 }


### PR DESCRIPTION
## Resumo
- corrige o primeiro SessionStop elegível após a migração legacy para memória v2
- mantém activation como epoch multi-Stop, recupera uma activation ausente uma única vez e usa identidade nativa de turno/transcript
- grava outbox antes do acknowledgement, projeta fora do lock e protege retries, duplicatas e outcomes stale/superseded por CAS causal
- torna retornos ambíguos e falhas de projeção observáveis no registry e no doctor
- adiciona documentação PT-BR/EN, fixtures exclusivamente sintéticas e gate de privacidade

## TDD e evidências
- regressão de lifecycle completo com migração real, SessionStart, UserPromptSubmit e Stop
- oracle mutante falha quando a publicação é removida
- regressões para replay A-B-A, registry pré-patch, duplicate/stale Stop e activation concorrente entre CAS e staging
- suíte focada: 87/87
- suíte completa: 680/680
- wendkeep verify e verify --deep: 5/5 sensores verdes
- verificação independente: ok true, MEM-STOP-1..7 cobertos e 59/59 testes adicionais
- change arquivada sem force como ADR-0051

## Release
- package.json, package-lock.json e CHANGELOG preparados em 0.58.3
- nenhuma tag, GitHub Release ou publicação npm foi criada por esta PR

## Privacidade
- fixtures e reproduções persistíveis usam somente namespace sintético
- o scanner cobre arquivos rastreados e novos e divulga apenas arquivo, linha e categoria

Fixes #20