### PR TITLE
feat: extract MCP configuration kernel (0.65.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.65.0] — 2026-07-29
+
+### Added
+
+- **O workspace privado MCP passa a ter um kernel canônico de configuração.**
+  `packages/mcp/src/config.mjs` concentra a entrada do MCPVault, a seleção de servidores por
+  descritores e o merge imutável de `.mcp.json`, sem efeitos no import.
+- **O tarball instalado prova a composição MCP fora do checkout.** O teste executa `init` em um
+  consumidor temporário, confirma a preservação de configuração existente e rejeita exports
+  públicos prematuros como `wendkeep/mcp` e `@wendkeep/mcp`.
+
+### Changed
+
+- **Taxonomia e instalador agora delegam ao kernel MCP.** `src/taxonomy.mjs` fornece descritores
+  como dados e preserva a identidade dos exports históricos; `src/init.mjs` mantém a orquestração
+  do filesystem e o comportamento de reconciliação, inclusive `.mcp.json.new` para JSON inválido.
+- **A publicação continua unificada e compatível.** Não há servidor MCP nativo, subpath público ou
+  pacote npm separado nesta fase; comandos, flags, transporte MCPVault e arquivos existentes
+  preservam o comportamento anterior.
+
 ## [0.64.0] — 2026-07-28
 
 ### Added

--- a/README.en.md
+++ b/README.en.md
@@ -16,13 +16,21 @@
 **Persistent memory for AI coding agents, built on your Obsidian vault.** Every Claude Code **and Codex** session is captured turn by turn into local Markdown — `init` wires both (Codex asks you to approve its hooks once; `import` backfills past sessions either way) — with token/cost tracking and automatically extracted decisions, bugs, and learnings. That always-on plane is **Keep Core**. On top of it, **Wend Runtime** provides a native, zero-dependency lifecycle (spec → change → TDD → sensor-gated archive), selected through the `OFF`, `FLOW`, `GUIDE`, `GOVERN`, and `ASSURE` Operating Profiles. 100% local, open-core.
 
 The runtime is being separated into six physical boundaries — `cli`, `harness`, `vault`, `mcp`,
-`integrations`, and `pi` — without fragmenting installation. The private `cli`, `harness`, and
-`vault` workspaces now canonically own the executable runtime, Operating Profiles/the sensor
-engine, and safe binding/the Shared Project Memory v2 kernel, respectively. The root package
-exposes Harness and Vault through `wendkeep/harness` and `wendkeep/vault`; CLI remains public only
-through the `wendkeep`/`wk` binaries. Historical imports keep working through compatibility
-facades and no session data needs migration;
+`integrations`, and `pi` — without fragmenting installation. The private `cli`, `harness`,
+`vault`, and `mcp` workspaces now canonically own the executable runtime, Operating Profiles/the
+sensor engine, safe binding/the Shared Project Memory v2 kernel, and the MCP configuration kernel,
+respectively. The root package exposes Harness and Vault through `wendkeep/harness` and
+`wendkeep/vault`; CLI and MCP remain private surfaces, reached only through the binaries and the
+configuration effects of `init`. Historical imports keep working through compatibility facades
+and no session data needs migration;
 see the [modular architecture](docs/en/architecture.md).
+
+In the **0.65 MCP Configuration Kernel** phase, `packages/mcp/src/config.mjs` becomes the
+canonical authority for the MCPVault entry, catalog-described server selection, and `.mcp.json`
+merging. `src/taxonomy.mjs` supplies descriptors while `src/init.mjs` retains only filesystem
+orchestration. Existing keys and servers remain preserved; invalid JSON stays byte-for-byte intact
+and the reconciled proposal is written to `.mcp.json.new`. The workspace remains private, with no
+public `wendkeep/mcp` subpath or separate npm package.
 
 In the **0.64 CLI Runtime** phase, `packages/cli/src/index.mjs` owns help, version reporting, Vault
 selection, error presentation, and lazy dispatch. `bin/wendkeep.mjs` is reduced to the shebang and

--- a/README.md
+++ b/README.md
@@ -16,13 +16,21 @@
 **Memória persistente para agentes de código, construída sobre o seu cofre Obsidian.** Cada sessão do Claude Code e do Codex é capturada turno a turno em Markdown local — o `init` wira os hooks dos dois agentes (no Codex, valendo depois que você aprovar o prompt de confiança dele); o `import` recupera as sessões passadas — com rastreio de tokens/custo, decisões, bugs e aprendizados extraídos automaticamente. Esse plano sempre ativo é o **Keep Core**. Sobre ele, o **Wend Runtime** oferece um ciclo nativo e sem dependências (spec → change → TDD → archive com gate por sensor), selecionável pelos Perfis de Operação `OFF`, `FLOW`, `GUIDE`, `GOVERN` e `ASSURE`. 100% local, open‑core.
 
 O runtime está sendo separado em seis fronteiras físicas — `cli`, `harness`, `vault`, `mcp`,
-`integrations` e `pi` — sem fragmentar a instalação. Os workspaces privados `cli`, `harness` e
-`vault` agora são donos canônicos do runtime do executável, dos Perfis de Operação/engine de
-sensores e do binding seguro/kernel da Shared Project Memory v2, respectivamente. O pacote raiz
-expõe Harness e Vault em `wendkeep/harness` e `wendkeep/vault`; a CLI continua pública somente
-pelos binários `wendkeep`/`wk`. Os imports históricos continuam funcionando por fachadas de
-compatibilidade e nenhum dado de sessão precisa ser migrado;
+`integrations` e `pi` — sem fragmentar a instalação. Os workspaces privados `cli`, `harness`,
+`vault` e `mcp` agora são donos canônicos do runtime do executável, dos Perfis de
+Operação/engine de sensores, do binding seguro/kernel da Shared Project Memory v2 e do kernel de
+configuração MCP, respectivamente. O pacote raiz expõe Harness e Vault em `wendkeep/harness` e
+`wendkeep/vault`; CLI e MCP permanecem superfícies privadas, acessíveis somente pelos binários e
+pelos efeitos de configuração do `init`. Os imports históricos continuam funcionando por
+fachadas de compatibilidade e nenhum dado de sessão precisa ser migrado;
 veja a [arquitetura modular](docs/pt-BR/architecture.md).
+
+Na fase **0.65 MCP Configuration Kernel**, `packages/mcp/src/config.mjs` passa a ser a autoridade
+canônica para a entrada do MCPVault, seleção de servidores descritos pelo catálogo e merge de
+`.mcp.json`. `src/taxonomy.mjs` fornece os descritores e `src/init.mjs` mantém somente a
+orquestração de filesystem. Chaves e servidores existentes continuam preservados; JSON inválido
+permanece byte a byte intacto e a proposta reconciliada vai para `.mcp.json.new`. O workspace
+continua privado, sem subpath público `wendkeep/mcp` ou pacote npm separado.
 
 Na fase **0.64 CLI Runtime**, `packages/cli/src/index.mjs` passa a concentrar help, versão,
 seleção de Vault, apresentação de erros e dispatch lazy. `bin/wendkeep.mjs` fica reduzido ao

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -26,6 +26,27 @@ canonically owns Operating Profile resolution/policy and the sensor engine under
 `packages/harness/src/`; `vault` continues to own binding/resolution, physical path safety, and the
 memory kernel under `packages/vault/src/`.
 
+## 0.65 MCP Configuration Kernel
+
+`packages/mcp/src/config.mjs` is the canonical authority for the `wendkeep-vault` key, the
+MCPVault transport entry, catalog-described server selection, and immutable MCP configuration
+merging. The private `packages/mcp/src/index.mjs` index collects this internal surface without
+starting processes, accessing the filesystem, or producing import-time effects.
+
+`src/taxonomy.mjs` continues to own the companion and host catalog, but supplies descriptors as
+data to the kernel. `src/init.mjs` continues to own filesystem orchestration and delegates
+configuration composition to MCP. This preserves the adapter direction and keeps the kernel from
+depending on either the catalog or the installer.
+
+`init` behavior does not change: existing top-level properties and servers are preserved,
+`wendkeep-vault` still uses `npx -y @bitbonsai/mcpvault@latest <vault>`, `--no-mcp` still disables
+that entry, and invalid JSON remains byte-for-byte intact while the proposal is written to
+`.mcp.json.new`. The installed-tarball test exercises this flow in an isolated consumer.
+
+The MCP workspace remains private in this phase. There is no root `wendkeep/mcp` export,
+`@wendkeep/mcp` publication, or native MCP server; installation remains the single `wendkeep`
+package.
+
 ## 0.64 Canonical CLI Runtime
 
 `packages/cli/src/index.mjs` is the canonical authority for help, version reporting, Vault
@@ -89,6 +110,7 @@ is no data migration.
 
 All six workspaces remain private and internal to the monorepo; they are not independent npm
 packages. Installation remains `wendkeep`; `wendkeep/harness` and `wendkeep/vault` are public
-subpaths of the root package, not separate publications. CLI now has a canonical implementation
-but remains exposed through the binaries. `mcp`, `integrations`, and `pi` are still reserved
-boundaries and will gain implementations in later phases.
+subpaths of the root package, not separate publications. CLI and MCP now have private canonical
+implementations: the former remains exposed through the binaries and the latter through `init`
+configuration effects. `integrations` and `pi` remain reserved boundaries; the planned migration
+sequence is MCP → Integrations → Pi.

--- a/docs/en/commands/getting-started.md
+++ b/docs/en/commands/getting-started.md
@@ -73,6 +73,11 @@ pnpm exec wendkeep sync --yes
 The project receives `.wendkeep.json`, managed Claude/Codex hooks, skill definitions, and an
 initialized vault. Existing files are merged or preserved, and the selected vault is printed.
 
+When MCP is enabled, `init` preserves existing properties and servers in `.mcp.json` and adds
+`wendkeep-vault`. If the existing JSON is invalid, the original file remains byte-for-byte intact
+and the reconciled proposal is written to `.mcp.json.new`. Since version 0.65, this composition is
+owned by the private MCP kernel without changing commands, flags, or the public npm surface.
+
 ## Common errors and diagnosis
 
 - Wrong vault: inspect `.wendkeep.json` and run `wendkeep doctor --vault <path>`.

--- a/docs/pt-BR/architecture.md
+++ b/docs/pt-BR/architecture.md
@@ -26,6 +26,26 @@ canônico da resolução/política dos Perfis de Operação e da engine de senso
 `packages/harness/src/`; o `vault` continua dono do binding/resolução, da segurança física de paths
 e do kernel de memória em `packages/vault/src/`.
 
+## 0.65 Kernel de configuração MCP
+
+`packages/mcp/src/config.mjs` é a autoridade canônica para a chave `wendkeep-vault`, a entrada de
+transporte do MCPVault, a seleção de servidores descritos pelo catálogo e o merge imutável de
+configuração MCP. O índice privado `packages/mcp/src/index.mjs` reúne essa superfície interna sem
+executar processos, acessar filesystem ou produzir efeitos durante o import.
+
+`src/taxonomy.mjs` continua dono do catálogo de companions e hosts, mas entrega descritores como
+dados ao kernel. `src/init.mjs` continua dono da orquestração do filesystem e delega a composição
+da configuração ao MCP. Isso preserva a direção entre adapters e evita que o kernel dependa do
+catálogo ou do instalador.
+
+O comportamento do `init` não muda: propriedades de topo e servidores existentes são preservados,
+`wendkeep-vault` continua usando `npx -y @bitbonsai/mcpvault@latest <vault>`, `--no-mcp` continua
+desabilitando essa entrada e JSON inválido permanece byte a byte intacto enquanto a proposta é
+gravada em `.mcp.json.new`. O teste de tarball executa esse fluxo em um consumidor isolado.
+
+O workspace MCP permanece privado nesta fase. Não existe export raiz `wendkeep/mcp`, publicação
+`@wendkeep/mcp` ou servidor MCP nativo; a instalação continua sendo o único pacote `wendkeep`.
+
 ## 0.64 Runtime canônico da CLI
 
 `packages/cli/src/index.mjs` é a autoridade canônica para help, versão, seleção de Vault,
@@ -89,6 +109,7 @@ migração de dados.
 
 Todos os seis workspaces permanecem privados e internos ao monorepo; eles não são pacotes npm
 independentes. A instalação continua sendo `wendkeep`; `wendkeep/harness` e `wendkeep/vault` são
-subpaths públicos do pacote raiz, não publicações separadas. A CLI já possui implementação
-canônica, mas continua exposta pelos binários. `mcp`, `integrations` e `pi` ainda são fronteiras
-reservadas e ganharão implementação em fases posteriores.
+subpaths públicos do pacote raiz, não publicações separadas. CLI e MCP já possuem implementações
+canônicas privadas: a primeira continua exposta pelos binários e a segunda pelos efeitos do
+`init`. `integrations` e `pi` permanecem fronteiras reservadas; a sequência planejada da migração
+é MCP → Integrations → Pi.

--- a/docs/pt-BR/commands/getting-started.md
+++ b/docs/pt-BR/commands/getting-started.md
@@ -74,6 +74,11 @@ O projeto recebe `.wendkeep.json`, hooks gerenciados de Claude/Codex, definiçõ
 cofre inicializado. Arquivos preexistentes são mesclados ou preservados; o comando informa o
 cofre efetivamente selecionado.
 
+Quando MCP está habilitado, o `init` preserva propriedades e servidores existentes em `.mcp.json`
+e adiciona `wendkeep-vault`. Se o JSON existente for inválido, o arquivo original permanece byte
+a byte intacto e a proposta reconciliada é gravada em `.mcp.json.new`. Desde a versão 0.65, essa
+composição pertence ao kernel MCP privado, sem alterar comandos, flags ou a superfície npm pública.
+
 ## Erros comuns e diagnóstico
 
 - Cofre errado: confira `.wendkeep.json` e rode `wendkeep doctor --vault <path>`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.64.0",
+      "version": "0.65.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [
@@ -31,7 +31,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "check": "node --check bin/wendkeep.mjs && node --check packages/cli/src/index.mjs && node --check src/init.mjs && node --check src/doctor.mjs && node --check src/project-vault.mjs && node --check src/operating-profile.mjs && node --check src/profile.mjs && node --check src/flow.mjs && node --check hooks/operating-profile-runtime.mjs && node --check hooks/flow-core.mjs && node --check hooks/flow-protected-policy.mjs && node --check hooks/git-snapshot.mjs && node --check hooks/vault-path-safety.mjs && node --check hooks/vault-runtime-store.mjs && node --check packages/harness/src/index.mjs && node --check packages/harness/src/flow-store.mjs && node --check packages/harness/src/operating-profile.mjs && node --check packages/harness/src/sensors-core.mjs && node --check packages/vault/src/index.mjs && node --check packages/vault/src/project-vault.mjs && node --check packages/vault/src/vault-path-safety.mjs && node --check packages/vault/src/locale.mjs && node --check packages/vault/src/memory-schema.mjs && node --check packages/vault/src/memory-mode.mjs && node --check packages/vault/src/memory-handoff.mjs && node --check packages/vault/src/memory-store.mjs && node --check packages/vault/src/validate-core.mjs && node --check packages/vault/src/validate-memory.mjs",
+    "check": "node --check bin/wendkeep.mjs && node --check packages/cli/src/index.mjs && node --check src/init.mjs && node --check src/doctor.mjs && node --check src/project-vault.mjs && node --check src/operating-profile.mjs && node --check src/profile.mjs && node --check src/flow.mjs && node --check hooks/operating-profile-runtime.mjs && node --check hooks/flow-core.mjs && node --check hooks/flow-protected-policy.mjs && node --check hooks/git-snapshot.mjs && node --check hooks/vault-path-safety.mjs && node --check hooks/vault-runtime-store.mjs && node --check packages/harness/src/index.mjs && node --check packages/harness/src/flow-store.mjs && node --check packages/harness/src/operating-profile.mjs && node --check packages/harness/src/sensors-core.mjs && node --check packages/mcp/src/config.mjs && node --check packages/mcp/src/index.mjs && node --check packages/vault/src/index.mjs && node --check packages/vault/src/project-vault.mjs && node --check packages/vault/src/vault-path-safety.mjs && node --check packages/vault/src/locale.mjs && node --check packages/vault/src/memory-schema.mjs && node --check packages/vault/src/memory-mode.mjs && node --check packages/vault/src/memory-handoff.mjs && node --check packages/vault/src/memory-store.mjs && node --check packages/vault/src/validate-core.mjs && node --check packages/vault/src/validate-memory.mjs",
     "test": "node --test",
     "release": "node scripts/release.mjs",
     "release:dry": "node scripts/release.mjs --dry-run",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@wendkeep/mcp",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "exports": "./src/index.mjs"
 }

--- a/packages/mcp/src/config.mjs
+++ b/packages/mcp/src/config.mjs
@@ -1,0 +1,33 @@
+export const MCP_SERVER_KEY = 'wendkeep-vault';
+
+export function mcpServerEntry(vaultPath) {
+  return {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', '@bitbonsai/mcpvault@latest', vaultPath],
+  };
+}
+
+export function selectMcpServers(descriptors, skipIds = []) {
+  const skipSet = new Set(skipIds);
+  const servers = {};
+  for (const descriptor of descriptors || []) {
+    if (!descriptor || skipSet.has(descriptor.id)) continue;
+    if (typeof descriptor.key !== 'string' || !descriptor.key) continue;
+    if (!descriptor.entry || typeof descriptor.entry !== 'object') continue;
+    servers[descriptor.key] = descriptor.entry;
+  }
+  return servers;
+}
+
+export function mergeMcpConfig(existing, {
+  vaultPath,
+  withVault = true,
+  servers = {},
+} = {}) {
+  const config = existing && typeof existing === 'object' ? { ...existing } : {};
+  config.mcpServers = { ...(config.mcpServers || {}) };
+  if (withVault) config.mcpServers[MCP_SERVER_KEY] = mcpServerEntry(vaultPath);
+  Object.assign(config.mcpServers, servers);
+  return config;
+}

--- a/packages/mcp/src/index.mjs
+++ b/packages/mcp/src/index.mjs
@@ -1,0 +1,1 @@
+export * from './config.mjs';

--- a/src/init.mjs
+++ b/src/init.mjs
@@ -6,13 +6,12 @@ import { spawnSync } from 'node:child_process';
 import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { basename, isAbsolute, join, resolve } from 'node:path';
 import { createInterface } from 'node:readline/promises';
+import { MCP_SERVER_KEY, mergeMcpConfig } from '../packages/mcp/src/index.mjs';
 import {
   VAULT_FOLDERS,
   SESSION_HOOKS,
   CHANGE_NUDGE_HOOKS,
   CHANGE_GATE_HOOKS,
-  MCP_SERVER_KEY,
-  mcpServerEntry,
   hookCommand,
   hookCommandLocal,
   hookCommandLocalLegacy,
@@ -245,11 +244,11 @@ export function mergeCodexHooks(existing, { force = false } = {}) {
 }
 
 export function mergeMcp(existing, { vaultPath, withVault = true, companions = [], skipMcp = [] }) {
-  const m = existing && typeof existing === 'object' ? { ...existing } : {};
-  m.mcpServers = { ...(m.mcpServers || {}) };
-  if (withVault) m.mcpServers[MCP_SERVER_KEY] = mcpServerEntry(vaultPath);
-  Object.assign(m.mcpServers, companionMcpPatch(companions, skipMcp));
-  return m;
+  return mergeMcpConfig(existing, {
+    vaultPath,
+    withVault,
+    servers: companionMcpPatch(companions, skipMcp),
+  });
 }
 
 // Run caveman's cross-agent installer (non-Claude skill coverage). Downloads the

--- a/src/taxonomy.mjs
+++ b/src/taxonomy.mjs
@@ -1,3 +1,11 @@
+import {
+  MCP_SERVER_KEY,
+  mcpServerEntry,
+  selectMcpServers,
+} from '../packages/mcp/src/index.mjs';
+
+export { MCP_SERVER_KEY, mcpServerEntry };
+
 // Shared, data-only constants for the wendkeep installer and CLI.
 // Kept free of side effects so both bin/ and src/ can import it cheaply.
 
@@ -92,17 +100,6 @@ export const RUNNABLE_HOOKS = [
   'change-nag',
   'plan-capture',
 ];
-
-// The MCP server entry wendkeep wires into .mcp.json so the agent can read/write the
-// vault. Uses the published mcpvault server (no secrets).
-export function mcpServerEntry(vaultPath) {
-  return {
-    type: 'stdio',
-    command: 'npx',
-    args: ['-y', '@bitbonsai/mcpvault@latest', vaultPath],
-  };
-}
-export const MCP_SERVER_KEY = 'wendkeep-vault';
 
 // The three Claude Code session hooks, expressed as `wendkeep hook <name>` so the
 // installed package is the single source of truth (update with `npm update wendkeep`,
@@ -281,14 +278,11 @@ export function companionSettingsPatch(ids) {
 // `skip` omits ids whose MCP is already configured elsewhere (e.g. dotcontext set
 // globally in ~/.claude.json — avoids a duplicate project-scoped server).
 export function companionMcpPatch(ids, skip = []) {
-  const skipSet = new Set(skip);
-  const servers = {};
-  for (const id of ids) {
-    if (skipSet.has(id)) continue;
-    const c = COMPANION_BY_ID[id];
-    if (c?.mcp) servers[c.mcp.key] = c.mcp.entry;
-  }
-  return servers;
+  const descriptors = ids.map((id) => {
+    const mcp = COMPANION_BY_ID[id]?.mcp;
+    return mcp ? { id, key: mcp.key, entry: mcp.entry } : { id };
+  });
+  return selectMcpServers(descriptors, skip);
 }
 
 // SessionStart hook specs wendkeep must author for companions that lack a native

--- a/tests/helpers/import-specifiers.mjs
+++ b/tests/helpers/import-specifiers.mjs
@@ -21,18 +21,326 @@ function literalSpecifier(node, kind) {
   return `<dynamic:${kind}>`;
 }
 
-function isCommonJsRequire(callee) {
-  if (callee?.type === 'Identifier' && callee.name === 'require') return true;
-  if (callee?.type !== 'MemberExpression' || callee.object?.type !== 'Identifier' || callee.object.name !== 'module') {
-    return false;
+function staticMemberName(member) {
+  if (!member?.computed) {
+    return member?.property?.type === 'Identifier' ? member.property.name : null;
   }
-  if (!callee.computed) return callee.property?.type === 'Identifier' && callee.property.name === 'require';
-  return callee.property?.type === 'Literal' && callee.property.value === 'require';
+  if (member.property?.type === 'Literal') return member.property.value;
+  if (member.property?.type === 'TemplateLiteral' && member.property.expressions.length === 0) {
+    return member.property.quasis[0]?.value.cooked ?? member.property.quasis[0]?.value.raw;
+  }
+  return undefined;
 }
 
-export function importSpecifiers(absolute) {
-  const source = readFileSync(absolute, 'utf8');
-  const sourceType = absolute.endsWith('.cjs') ? 'script' : 'module';
+const ALIAS_KINDS = new Set([
+  'require',
+  'module',
+  'global',
+  'loader',
+  'process',
+  'builtin-module-factory',
+  'require-factory',
+  'reflect',
+  'function',
+  'function-prototype',
+  'function-call',
+  'function-apply',
+  'dynamic',
+]);
+
+function memberLoaderKind(baseKind, name) {
+  if (baseKind === 'dynamic') return 'dynamic';
+  if (baseKind === 'module') {
+    if (name === 'require') return 'require';
+    if (name === 'constructor') return 'loader';
+    return name === undefined ? 'dynamic' : null;
+  }
+  if (baseKind === 'global') {
+    if (name === 'require') return 'require';
+    if (name === 'process') return 'process';
+    if (name === 'Reflect') return 'reflect';
+    if (name === 'Function') return 'function';
+    return name === undefined ? 'dynamic' : null;
+  }
+  if (baseKind === 'process') {
+    if (name === 'mainModule') return 'module';
+    if (name === 'getBuiltinModule') return 'builtin-module-factory';
+    return name === undefined ? 'dynamic' : null;
+  }
+  if (baseKind === 'builtin-module-factory') {
+    return name === undefined || ['bind', 'call', 'apply'].includes(name) ? 'dynamic' : null;
+  }
+  if (baseKind === 'loader') {
+    if (name === '_load') return 'require';
+    if (name === 'createRequire') return 'require-factory';
+    if (name === 'default' || name === 'Module') return 'loader';
+    return name === undefined ? 'dynamic' : null;
+  }
+  if (baseKind === 'reflect') {
+    if (name === 'apply') return 'require-reflect-apply';
+    return name === undefined ? 'dynamic' : null;
+  }
+  if (baseKind === 'function') {
+    if (name === 'prototype') return 'function-prototype';
+    return name === undefined ? 'dynamic' : null;
+  }
+  if (baseKind === 'function-prototype') {
+    if (name === 'call') return 'function-call';
+    if (name === 'apply') return 'function-apply';
+    return name === undefined ? 'dynamic' : null;
+  }
+  if (baseKind === 'function-call' || baseKind === 'function-apply') {
+    if (name === 'call') return `require-${baseKind}-call`;
+    if (name === 'apply') return `require-${baseKind}-apply`;
+    if (name === 'bind') return 'dynamic';
+    return name === undefined ? 'dynamic' : null;
+  }
+  if (baseKind === 'require') {
+    if (name === 'bind') return 'require-bind';
+    if (name === 'call') return 'require-call';
+    if (name === 'apply') return 'require-apply';
+  }
+  if (typeof baseKind === 'string' && baseKind.startsWith('require-')) {
+    return name === undefined || ['bind', 'call', 'apply'].includes(name) ? 'dynamic' : null;
+  }
+  return null;
+}
+
+function potentialLoaderKind(kind) {
+  return kind === 'require' || kind === 'dynamic' || kind?.startsWith('require-');
+}
+
+function staticArrayElements(node) {
+  return node?.type === 'ArrayExpression' ? node.elements : null;
+}
+
+function higherOrderInvocation(node, calleeKind) {
+  if (calleeKind === 'require-reflect-apply') {
+    return {
+      target: node.arguments[0],
+      receiver: node.arguments[1],
+      arguments: staticArrayElements(node.arguments[2]),
+    };
+  }
+  if (calleeKind === 'require-function-call-call') {
+    return {
+      target: node.arguments[0],
+      receiver: node.arguments[1],
+      arguments: node.arguments.slice(2),
+    };
+  }
+  if (calleeKind === 'require-function-apply-call') {
+    return {
+      target: node.arguments[0],
+      receiver: node.arguments[1],
+      arguments: staticArrayElements(node.arguments[2]),
+    };
+  }
+  if (calleeKind === 'require-function-call-apply'
+    || calleeKind === 'require-function-apply-apply') {
+    const invocationArguments = staticArrayElements(node.arguments[1]);
+    return {
+      target: node.arguments[0],
+      receiver: invocationArguments?.[0],
+      arguments: calleeKind === 'require-function-call-apply'
+        ? invocationArguments?.slice(1) ?? null
+        : staticArrayElements(invocationArguments?.[1]),
+    };
+  }
+  return null;
+}
+
+function higherOrderLoaderSpecifier(node, aliases, calleeKind) {
+  const invocation = higherOrderInvocation(node, calleeKind);
+  if (!invocation) return undefined;
+
+  const targetKind = expressionLoaderKind(invocation.target, aliases);
+  if (targetKind === 'require-factory') return '<dynamic:require>';
+  if (targetKind === 'builtin-module-factory') {
+    const moduleName = staticStringValue(invocation.arguments?.[0]);
+    return moduleName === null || moduleName === 'module' || moduleName === 'node:module'
+      ? '<dynamic:require>'
+      : null;
+  }
+  if (potentialLoaderKind(targetKind)) {
+    if (targetKind !== 'require') return '<dynamic:require>';
+    if (isModuleBuiltinSpecifier(invocation.arguments?.[0])) return '<dynamic:require>';
+    return invocation.arguments
+      ? literalSpecifier(invocation.arguments[0], 'require')
+      : '<dynamic:require>';
+  }
+  if (targetKind !== 'function-call' && targetKind !== 'function-apply') return null;
+
+  const receiverKind = expressionLoaderKind(invocation.receiver, aliases);
+  if (receiverKind === 'function-call' || receiverKind === 'function-apply') {
+    return '<dynamic:require>';
+  }
+  if (receiverKind === 'builtin-module-factory' || receiverKind === 'require-factory') {
+    return '<dynamic:require>';
+  }
+  if (!potentialLoaderKind(receiverKind)) return null;
+  if (receiverKind !== 'require' || !invocation.arguments) return '<dynamic:require>';
+  const argumentNode = targetKind === 'function-call'
+    ? invocation.arguments[1]
+    : invocation.arguments[1]?.type === 'ArrayExpression'
+      ? invocation.arguments[1].elements[0]
+      : null;
+  if (isModuleBuiltinSpecifier(argumentNode)) return '<dynamic:require>';
+  return literalSpecifier(argumentNode, 'require');
+}
+
+function staticStringValue(node) {
+  if (node?.type === 'Literal' && typeof node.value === 'string') return node.value;
+  if (node?.type === 'TemplateLiteral' && node.expressions.length === 0) {
+    return node.quasis[0]?.value.cooked ?? node.quasis[0]?.value.raw;
+  }
+  return null;
+}
+
+function isModuleBuiltinSpecifier(node) {
+  const specifier = staticStringValue(node);
+  return specifier === 'module' || specifier === 'node:module';
+}
+
+function expressionLoaderKind(node, aliases) {
+  if (!node) return null;
+  if (node.type === 'ChainExpression') return expressionLoaderKind(node.expression, aliases);
+  if (node.type === 'Identifier') return aliases.get(node.name) ?? null;
+  if (node.type === 'SequenceExpression') {
+    return expressionLoaderKind(node.expressions.at(-1), aliases);
+  }
+  if (node.type === 'AssignmentExpression') return expressionLoaderKind(node.right, aliases);
+  if (node.type === 'ConditionalExpression' || node.type === 'LogicalExpression') {
+    const branches = node.type === 'ConditionalExpression'
+      ? [node.consequent, node.alternate]
+      : [node.left, node.right];
+    const kinds = branches.map((branch) => expressionLoaderKind(branch, aliases));
+    if (kinds[0] && kinds[0] === kinds[1]) return kinds[0];
+    return kinds.some(Boolean) ? 'dynamic' : null;
+  }
+  if (node.type === 'MemberExpression') {
+    const name = staticMemberName(node);
+    if (node.object?.type === 'Identifier' && node.object.name === 'process') {
+      if (name === 'mainModule') return 'global';
+      if (name === undefined) return 'dynamic';
+    }
+    return memberLoaderKind(expressionLoaderKind(node.object, aliases), name);
+  }
+  if (node.type === 'CallExpression') {
+    const calleeKind = expressionLoaderKind(node.callee, aliases);
+    if (calleeKind === 'require-bind') return 'require';
+    if (calleeKind === 'require-factory') return 'require';
+    if (calleeKind === 'require' && isModuleBuiltinSpecifier(node.arguments[0])) return 'loader';
+    if (calleeKind === 'require-call' && isModuleBuiltinSpecifier(node.arguments[1])) return 'loader';
+    if (calleeKind === 'builtin-module-factory'
+      && isModuleBuiltinSpecifier(node.arguments[0])) return 'loader';
+  }
+  return null;
+}
+
+function patternPropertyName(property) {
+  if (!property?.computed && property?.key?.type === 'Identifier') return property.key.name;
+  if (property?.key?.type === 'Literal') return property.key.value;
+  if (property?.key?.type === 'TemplateLiteral' && property.key.expressions.length === 0) {
+    return property.key.quasis[0]?.value.cooked ?? property.key.quasis[0]?.value.raw;
+  }
+  return undefined;
+}
+
+function setAlias(aliases, name, kind) {
+  const normalizedKind = typeof kind === 'string'
+    && kind.startsWith('require-')
+    && kind !== 'require-factory'
+    ? 'dynamic'
+    : kind;
+  if (!name || !ALIAS_KINDS.has(normalizedKind)) return false;
+  const previous = aliases.get(name);
+  const next = previous && previous !== normalizedKind ? 'dynamic' : normalizedKind;
+  if (previous === next) return false;
+  aliases.set(name, next);
+  return true;
+}
+
+function assignPatternKind(pattern, kind, aliases) {
+  if (!pattern || !kind) return false;
+  if (pattern.type === 'Identifier') return setAlias(aliases, pattern.name, kind);
+  if (pattern.type === 'AssignmentPattern') return assignPatternKind(pattern.left, kind, aliases);
+  if (pattern.type === 'RestElement') {
+    return assignPatternKind(pattern.argument, ALIAS_KINDS.has(kind) ? 'dynamic' : null, aliases);
+  }
+  if (pattern.type === 'ArrayPattern') {
+    let changed = false;
+    for (const element of pattern.elements) {
+      changed = assignPatternKind(element, 'dynamic', aliases) || changed;
+    }
+    return changed;
+  }
+  if (pattern.type !== 'ObjectPattern') return false;
+  let changed = false;
+  for (const property of pattern.properties) {
+    if (property.type === 'RestElement') {
+      changed = assignPatternKind(property.argument, 'dynamic', aliases) || changed;
+      continue;
+    }
+    const propertyKind = memberLoaderKind(kind, patternPropertyName(property));
+    changed = assignPatternKind(property.value, propertyKind, aliases) || changed;
+  }
+  return changed;
+}
+
+function collectLoaderAliases(ast) {
+  const aliases = new Map([
+    ['require', 'require'],
+    ['module', 'module'],
+    ['globalThis', 'global'],
+    ['global', 'global'],
+    ['Module', 'loader'],
+    ['Reflect', 'reflect'],
+    ['Function', 'function'],
+    ['process', 'process'],
+  ]);
+  const nodes = [];
+  walkAst(ast, (node) => nodes.push(node));
+  let changed;
+  do {
+    changed = false;
+    for (const node of nodes) {
+      if (node.type === 'ImportDeclaration' && isModuleBuiltinSpecifier(node.source)) {
+        for (const specifier of node.specifiers) {
+          let kind = 'loader';
+          if (specifier.type === 'ImportSpecifier') {
+            const imported = specifier.imported?.name ?? specifier.imported?.value;
+            if (imported === 'createRequire') kind = 'require-factory';
+            else if (imported === '_load') kind = 'require';
+            else if (imported !== 'default' && imported !== 'Module') kind = null;
+          }
+          changed = setAlias(aliases, specifier.local?.name, kind) || changed;
+        }
+      } else if (node.type === 'VariableDeclarator') {
+        changed = assignPatternKind(
+          node.id,
+          expressionLoaderKind(node.init, aliases),
+          aliases,
+        ) || changed;
+      } else if (node.type === 'AssignmentExpression') {
+        changed = assignPatternKind(
+          node.left,
+          expressionLoaderKind(node.right, aliases),
+          aliases,
+        ) || changed;
+      } else if (node.type === 'AssignmentPattern') {
+        changed = assignPatternKind(
+          node.left,
+          expressionLoaderKind(node.right, aliases),
+          aliases,
+        ) || changed;
+      }
+    }
+  } while (changed);
+  return aliases;
+}
+
+export function importSpecifiersFromSource(source, { sourceType = 'module' } = {}) {
   const ast = parse(source, {
     ecmaVersion: 'latest',
     sourceType,
@@ -40,6 +348,7 @@ export function importSpecifiers(absolute) {
     allowHashBang: true,
     allowReturnOutsideFunction: true,
   });
+  const aliases = collectLoaderAliases(ast);
   const edges = [];
   const add = (node, specifier) => edges.push({ start: node.start, specifier });
   walkAst(ast, (node) => {
@@ -47,9 +356,25 @@ export function importSpecifiers(absolute) {
       if (node.source) add(node, literalSpecifier(node.source, 'import'));
     } else if (node.type === 'ImportExpression') {
       add(node, literalSpecifier(node.source, 'import'));
-    } else if (node.type === 'CallExpression' && isCommonJsRequire(node.callee)) {
-      add(node, literalSpecifier(node.arguments[0], 'require'));
+      if (isModuleBuiltinSpecifier(node.source)) add(node, '<dynamic:require>');
+    } else if (node.type === 'CallExpression') {
+      const requireKind = expressionLoaderKind(node.callee, aliases);
+      const higherOrderSpecifier = higherOrderLoaderSpecifier(node, aliases, requireKind);
+      if (higherOrderSpecifier !== undefined) {
+        if (higherOrderSpecifier !== null) add(node, higherOrderSpecifier);
+      } else if (requireKind === 'require') add(node, literalSpecifier(node.arguments[0], 'require'));
+      else if (requireKind === 'require-call') add(node, literalSpecifier(node.arguments[1], 'require'));
+      else if (requireKind === 'require-apply') add(node, '<dynamic:require>');
+      else if (requireKind === 'builtin-module-factory'
+        && staticStringValue(node.arguments[0]) === null) add(node, '<dynamic:require>');
+      else if (requireKind === 'dynamic') add(node, '<dynamic:require>');
     }
   });
   return edges.sort((left, right) => left.start - right.start).map((edge) => edge.specifier);
+}
+
+export function importSpecifiers(absolute) {
+  const source = readFileSync(absolute, 'utf8');
+  const sourceType = absolute.endsWith('.cjs') ? 'script' : 'module';
+  return importSpecifiersFromSource(source, { sourceType });
 }

--- a/tests/init-merge.test.mjs
+++ b/tests/init-merge.test.mjs
@@ -6,9 +6,44 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { mergeSettings, mergeMcp, hookCommandFor } from '../src/init.mjs';
-import { MCP_SERVER_KEY } from '../src/taxonomy.mjs';
+import {
+  MCP_SERVER_KEY as LEGACY_MCP_SERVER_KEY,
+  mcpServerEntry as legacyMcpServerEntry,
+  companionMcpPatch,
+} from '../src/taxonomy.mjs';
+import {
+  MCP_SERVER_KEY,
+  mcpServerEntry,
+  mergeMcpConfig,
+} from '../packages/mcp/src/index.mjs';
 
 const UA_CMD = 'npx wendkeep hook understand-inject';
+
+test('[req:MOD-17] [req:MOD-18] legacy MCP exports and merge preserve canonical identity and behavior', () => {
+  assert.strictEqual(LEGACY_MCP_SERVER_KEY, MCP_SERVER_KEY);
+  assert.strictEqual(legacyMcpServerEntry, mcpServerEntry);
+
+  const existing = {
+    custom: true,
+    mcpServers: {
+      user: { type: 'stdio', command: 'user', args: [] },
+    },
+  };
+  const options = {
+    vaultPath: '/v',
+    withVault: true,
+    companions: ['context-mode', 'dotcontext', 'dotcontext'],
+    skipMcp: [],
+  };
+  assert.deepEqual(
+    mergeMcp(existing, options),
+    mergeMcpConfig(existing, {
+      vaultPath: options.vaultPath,
+      withVault: options.withVault,
+      servers: companionMcpPatch(options.companions, options.skipMcp),
+    }),
+  );
+});
 
 // --- 0.31.0: hooks de lifecycle default + invocação node-direta -----------------
 

--- a/tests/init-vault.test.mjs
+++ b/tests/init-vault.test.mjs
@@ -324,6 +324,42 @@ test('wendkeep init --companions wires plugin layer, UA hook and MCP server', ()
   }
 });
 
+test('[req:MOD-18] init preserves invalid .mcp.json bytes and writes the canonical merge beside it', () => {
+  const parent = mkdtempSync(join(tmpdir(), 'wk-invalid-mcp-'));
+  const projectDir = join(parent, 'Acme');
+  const vaultDir = join(projectDir, '.Vault');
+  const mcpPath = join(projectDir, '.mcp.json');
+  const invalid = '{ invalid MCP JSON\n';
+  mkdirSync(projectDir);
+  writeFileSync(mcpPath, invalid);
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        BIN,
+        'init',
+        '--project', projectDir,
+        '--vault', vaultDir,
+        '--no-companions',
+        '--no-colors',
+        '--yes',
+      ],
+      { encoding: 'utf8' },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(readFileSync(mcpPath, 'utf8'), invalid, 'invalid consumer file is byte-identical');
+    const proposed = JSON.parse(readFileSync(`${mcpPath}.new`, 'utf8'));
+    assert.equal(proposed.mcpServers['wendkeep-vault'].command, 'npx');
+    assert.deepEqual(
+      proposed.mcpServers['wendkeep-vault'].args,
+      ['-y', '@bitbonsai/mcpvault@latest', vaultDir],
+    );
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
 // --- 0.46.0: Codex session wiring -------------------------------------------
 // Regression: a fresh project with Codex opened with the vault reachable via .mcp.json but
 // NO session — CURRENT_SESSION.md absent, registrySessions 0 — because init only ever wired

--- a/tests/mcp-config-boundary.test.mjs
+++ b/tests/mcp-config-boundary.test.mjs
@@ -1,0 +1,1411 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  linkSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, extname, isAbsolute, relative, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parse } from 'acorn';
+import { importSpecifiersFromSource } from './helpers/import-specifiers.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const MCP_WORKSPACE = resolve(ROOT, 'packages', 'mcp');
+const INTEGRATIONS_WORKSPACE = resolve(ROOT, 'packages', 'integrations');
+const MCP_PACKAGE = resolve(ROOT, 'packages', 'mcp', 'package.json');
+const MCP_INDEX = resolve(ROOT, 'packages', 'mcp', 'src', 'index.mjs');
+const MCP_CONFIG = resolve(ROOT, 'packages', 'mcp', 'src', 'config.mjs');
+const LEGACY_TAXONOMY = resolve(ROOT, 'src', 'taxonomy.mjs');
+const LEGACY_INIT = resolve(ROOT, 'src', 'init.mjs');
+const CANONICAL_MCP_IMPORT = '../packages/mcp/src/index.mjs';
+const MCP_KERNEL_SYMBOLS = new Set([
+  'MCP_SERVER_KEY',
+  'mcpServerEntry',
+  'selectMcpServers',
+  'mergeMcpConfig',
+]);
+
+function walk(node, visit) {
+  if (!node || typeof node !== 'object') return;
+  if (typeof node.type === 'string') visit(node);
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const child of value) walk(child, visit);
+    } else if (value?.type) {
+      walk(value, visit);
+    }
+  }
+}
+
+const FUNCTION_NODES = new Set([
+  'ArrowFunctionExpression',
+  'FunctionDeclaration',
+  'FunctionExpression',
+]);
+
+function walkImportPhase(node, visit, functionDepth = 0) {
+  if (!node || typeof node !== 'object') return;
+  if (typeof node.type === 'string') visit(node, functionDepth);
+  const childDepth = functionDepth + (FUNCTION_NODES.has(node.type) ? 1 : 0);
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const child of value) walkImportPhase(child, visit, childDepth);
+    } else if (value?.type) {
+      walkImportPhase(value, visit, childDepth);
+    }
+  }
+}
+
+function parsed(source, sourceType = 'module') {
+  return parse(source, {
+    ecmaVersion: 'latest',
+    sourceType,
+    allowAwaitOutsideFunction: true,
+    allowReturnOutsideFunction: sourceType === 'script',
+  });
+}
+
+function bindingNames(pattern, names = []) {
+  if (!pattern) return names;
+  if (pattern.type === 'Identifier') {
+    names.push(pattern.name);
+    return names;
+  }
+  if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties) {
+      bindingNames(property.type === 'Property' ? property.value : property.argument, names);
+    }
+    return names;
+  }
+  if (pattern.type === 'ArrayPattern') {
+    for (const element of pattern.elements) bindingNames(element, names);
+    return names;
+  }
+  if (pattern.type === 'AssignmentPattern') {
+    return bindingNames(pattern.left, names);
+  }
+  if (pattern.type === 'RestElement') {
+    return bindingNames(pattern.argument, names);
+  }
+  return names;
+}
+
+function declarationNames(node) {
+  const names = [];
+  if (
+    node.type === 'FunctionDeclaration'
+    || node.type === 'FunctionExpression'
+    || node.type === 'ArrowFunctionExpression'
+  ) {
+    if (node.id) names.push(node.id.name);
+    for (const parameter of node.params) bindingNames(parameter, names);
+    return names;
+  }
+  if (node.type === 'VariableDeclarator') return bindingNames(node.id);
+  if (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') {
+    return node.id ? [node.id.name] : [];
+  }
+  if (node.type === 'CatchClause') return bindingNames(node.param);
+  return names;
+}
+
+function directReturnCallNames(functionNode) {
+  const names = [];
+  const visit = (node) => {
+    if (!node || typeof node !== 'object') return;
+    if (node !== functionNode && FUNCTION_NODES.has(node.type)) return;
+    if (node.type === 'ReturnStatement') {
+      const argument = node.argument?.type === 'ChainExpression'
+        ? node.argument.expression
+        : node.argument;
+      const callee = argument?.type === 'CallExpression' ? argument.callee : null;
+      names.push(callee?.type === 'Identifier' ? callee.name : null);
+      return;
+    }
+    for (const value of Object.values(node)) {
+      if (Array.isArray(value)) {
+        for (const child of value) visit(child);
+      } else if (value?.type) {
+        visit(value);
+      }
+    }
+  };
+  visit(functionNode.body);
+  return names;
+}
+
+function directExportedFunctions(ast, name) {
+  return ast.body
+    .filter((node) => (
+      node.type === 'ExportNamedDeclaration'
+      && node.declaration?.type === 'FunctionDeclaration'
+      && node.declaration.id?.name === name
+    ))
+    .map((node) => node.declaration);
+}
+
+function namedExportCount(ast, name) {
+  let count = 0;
+  for (const node of ast.body) {
+    if (node.type !== 'ExportNamedDeclaration') continue;
+    if (node.declaration?.id?.name === name) count += 1;
+    for (const specifier of node.specifiers) {
+      const exportedName = specifier.exported?.name ?? specifier.exported?.value;
+      if (exportedName === name) count += 1;
+    }
+  }
+  return count;
+}
+
+function assignmentBindingNames(node) {
+  if (node.type === 'AssignmentExpression') return bindingNames(node.left);
+  if (node.type === 'UpdateExpression') return bindingNames(node.argument);
+  if (
+    (node.type === 'ForInStatement' || node.type === 'ForOfStatement')
+    && node.left.type !== 'VariableDeclaration'
+  ) {
+    return bindingNames(node.left);
+  }
+  return [];
+}
+
+function propertyName(node) {
+  if (!node) return null;
+  if (node.computed && node.property?.type === 'Literal') return node.property.value;
+  if (!node.computed && node.property?.type === 'Identifier') return node.property.name;
+  return null;
+}
+
+function assertMcpRuntimeOwnership(source) {
+  const declarations = new Set();
+  const stringValues = new Set();
+  let writesMcpServers = false;
+  let hasSelectionLoop = false;
+
+  walk(parsed(source), (node) => {
+    for (const name of declarationNames(node)) declarations.add(name);
+    if (node.type === 'Literal' && typeof node.value === 'string') {
+      stringValues.add(node.value);
+    }
+    if (node.type === 'ForOfStatement') hasSelectionLoop = true;
+    if (
+      node.type === 'AssignmentExpression'
+      && node.left.type === 'MemberExpression'
+      && propertyName(node.left) === 'mcpServers'
+    ) {
+      writesMcpServers = true;
+    }
+  });
+
+  for (const name of MCP_KERNEL_SYMBOLS) {
+    assert.ok(declarations.has(name), `MCP config kernel must own ${name}`);
+  }
+  for (const value of ['wendkeep-vault', 'npx', '@bitbonsai/mcpvault@latest']) {
+    assert.ok(stringValues.has(value), `MCP config kernel must own ${value}`);
+  }
+  assert.ok(hasSelectionLoop, 'MCP config kernel must own descriptor selection');
+  assert.ok(writesMcpServers, 'MCP config kernel must own mcpServers merge');
+}
+
+function assertAllowedMcpImports(source, {
+  sourceType = 'module',
+  fromFile = resolve(MCP_WORKSPACE, 'src', 'mutant.mjs'),
+} = {}) {
+  const forbidden = importSpecifiersFromSource(source, { sourceType })
+    .filter((specifier) => (
+      !specifier.startsWith('.')
+      || !isWithin(MCP_WORKSPACE, resolveFileSpecifier(fromFile, specifier) || '')
+    ));
+  assert.deepEqual(
+    forbidden,
+    [],
+    `MCP config kernel imports only local workspace modules: ${forbidden.join(', ')}`,
+  );
+}
+
+function assertNoImportPhaseEffects(source, { sourceType = 'module' } = {}) {
+  const effects = [];
+  const effectNodes = new Set([
+    'AssignmentExpression',
+    'AwaitExpression',
+    'CallExpression',
+    'DoWhileStatement',
+    'ForInStatement',
+    'ForOfStatement',
+    'ForStatement',
+    'IfStatement',
+    'ImportExpression',
+    'MemberExpression',
+    'NewExpression',
+    'SpreadElement',
+    'SwitchStatement',
+    'TaggedTemplateExpression',
+    'ThrowStatement',
+    'TryStatement',
+    'UpdateExpression',
+    'WhileStatement',
+  ]);
+  walkImportPhase(parsed(source, sourceType), (node, functionDepth) => {
+    if (functionDepth !== 0) return;
+    if (effectNodes.has(node.type) || (node.type === 'UnaryExpression' && node.operator === 'delete')) {
+      effects.push(node.type);
+    }
+  });
+  assert.deepEqual(
+    effects,
+    [],
+    `MCP config kernel has import-time effects: ${effects.join(', ')}`,
+  );
+}
+
+function workspaceSourceFiles(root) {
+  const files = [];
+  const visit = (current) => {
+    if (!existsSync(current)) return;
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const absolute = resolve(current, entry.name);
+      if (entry.isDirectory()) visit(absolute);
+      else if (['.mjs', '.js', '.cjs'].includes(extname(entry.name))) files.push(absolute);
+    }
+  };
+  visit(root);
+  return files.sort();
+}
+
+function canonicalPhysicalPath(input) {
+  const suffix = [];
+  let current = resolve(input);
+  while (!existsSync(current)) {
+    const parent = dirname(current);
+    if (parent === current) return resolve(input);
+    suffix.unshift(basename(current));
+    current = parent;
+  }
+  try {
+    const physical = realpathSync.native
+      ? realpathSync.native(current)
+      : realpathSync(current);
+    return resolve(physical, ...suffix);
+  } catch {
+    return resolve(input);
+  }
+}
+
+function fileIdentity(input) {
+  try {
+    const stats = statSync(input, { bigint: true });
+    if (!stats.isFile() || stats.ino === 0n) return null;
+    return { dev: stats.dev, ino: stats.ino, links: stats.nlink };
+  } catch {
+    return null;
+  }
+}
+
+function isHardlinkInto(root, candidate) {
+  const candidateIdentity = fileIdentity(candidate);
+  if (!candidateIdentity || candidateIdentity.links < 2n) return false;
+  const pending = [canonicalPhysicalPath(root)];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    let entries;
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const absolute = resolve(current, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(absolute);
+      } else if (entry.isFile()) {
+        const identity = fileIdentity(absolute);
+        if (
+          identity
+          && identity.dev === candidateIdentity.dev
+          && identity.ino === candidateIdentity.ino
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+function isWithin(root, candidate) {
+  if (!candidate) return false;
+  const physicalRoot = canonicalPhysicalPath(root);
+  const physicalCandidate = canonicalPhysicalPath(candidate);
+  const rel = relative(physicalRoot, physicalCandidate);
+  if (rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))) return true;
+  return isHardlinkInto(physicalRoot, physicalCandidate);
+}
+
+function isFileUrlSpecifier(specifier) {
+  try {
+    return new URL(specifier).protocol === 'file:';
+  } catch {
+    return false;
+  }
+}
+
+function resolveFileSpecifier(fromFile, specifier) {
+  try {
+    if (specifier.startsWith('.')) {
+      const target = new URL(specifier, pathToFileURL(fromFile));
+      if (target.protocol !== 'file:') return null;
+      return fileURLToPath(target);
+    }
+    if (isFileUrlSpecifier(specifier)) {
+      const target = new URL(specifier);
+      if (target.protocol !== 'file:') return null;
+      return fileURLToPath(target);
+    }
+    if (isAbsolute(specifier)) return resolve(specifier);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function targetsAdapter(specifier, fromFile, targetName, targetRoot) {
+  if (specifier.startsWith('<dynamic:')) return true;
+  const barePrefixes = [
+    `@wendkeep/${targetName}`,
+    `wendkeep/${targetName}`,
+    `wendkeep/packages/${targetName}`,
+  ];
+  if (barePrefixes.some((prefix) => specifier === prefix || specifier.startsWith(`${prefix}/`))) {
+    return true;
+  }
+  const pathLike = specifier.startsWith('.') || isFileUrlSpecifier(specifier) || isAbsolute(specifier);
+  if (!pathLike) return false;
+  const resolved = resolveFileSpecifier(fromFile, specifier);
+  return resolved === null || isWithin(targetRoot, resolved);
+}
+
+function assertSiblingAdapterIsolation(fromAdapter, source, fromFile) {
+  const fromRoot = fromAdapter === 'mcp' ? MCP_WORKSPACE : INTEGRATIONS_WORKSPACE;
+  const targetName = fromAdapter === 'mcp' ? 'integrations' : 'mcp';
+  const targetRoot = fromAdapter === 'mcp' ? INTEGRATIONS_WORKSPACE : MCP_WORKSPACE;
+  const absolute = fromFile || resolve(fromRoot, 'src', 'mutant.mjs');
+  const sourceType = absolute.endsWith('.cjs') ? 'script' : 'module';
+  const violations = importSpecifiersFromSource(source, { sourceType })
+    .filter((specifier) => targetsAdapter(specifier, absolute, targetName, targetRoot));
+  assert.deepEqual(
+    violations,
+    [],
+    `adapter siblings must not import directly (${fromAdapter} -> ${targetName}): ${violations.join(', ')}`,
+  );
+}
+
+function ownedKernelNames(source, sourceType) {
+  const names = new Set();
+  walk(parsed(source, sourceType), (node) => {
+    for (const name of declarationNames(node)) {
+      if (MCP_KERNEL_SYMBOLS.has(name)) names.add(name);
+    }
+    if (node.type === 'ExportNamedDeclaration' && !node.source) {
+      for (const specifier of node.specifiers) {
+        const exportedName = specifier.exported?.name ?? specifier.exported?.value;
+        if (MCP_KERNEL_SYMBOLS.has(exportedName)) names.add(exportedName);
+      }
+    }
+  });
+  return names;
+}
+
+function assertMcpSourceSet(files) {
+  assert.ok(files.length > 0, 'MCP source inventory must not be empty');
+  const owners = new Map([...MCP_KERNEL_SYMBOLS].map((name) => [name, []]));
+  for (const { absolute, source } of files) {
+    assert.ok(isWithin(MCP_WORKSPACE, absolute), `MCP source must stay inside its workspace: ${absolute}`);
+    const sourceType = absolute.endsWith('.cjs') ? 'script' : 'module';
+    assertAllowedMcpImports(source, { sourceType, fromFile: absolute });
+    assertNoImportPhaseEffects(source, { sourceType });
+    assertSiblingAdapterIsolation('mcp', source, absolute);
+    for (const name of ownedKernelNames(source, sourceType)) {
+      owners.get(name).push(canonicalPhysicalPath(absolute));
+    }
+  }
+  const canonicalOwner = canonicalPhysicalPath(MCP_CONFIG);
+  for (const [name, paths] of owners) {
+    assert.deepEqual(
+      [...new Set(paths)],
+      [canonicalOwner],
+      `MCP kernel ${name} must have config.mjs as its single physical owner`,
+    );
+  }
+}
+
+function assertMcpMergePrecedence(merge, { MCP_SERVER_KEY }) {
+  const existingCollision = { type: 'stdio', command: 'existing', args: [] };
+  const existingVault = { type: 'stdio', command: 'old-vault', args: [] };
+  const companionCollision = { type: 'stdio', command: 'companion', args: ['--last'] };
+  const companionVault = { type: 'stdio', command: 'companion-vault', args: ['--last'] };
+  const existing = {
+    keep: true,
+    mcpServers: {
+      collision: existingCollision,
+      [MCP_SERVER_KEY]: existingVault,
+    },
+  };
+  const baseline = structuredClone(existing);
+  const merged = merge(existing, {
+    vaultPath: 'C:\\Vault',
+    servers: {
+      collision: companionCollision,
+      [MCP_SERVER_KEY]: companionVault,
+    },
+  });
+
+  assert.strictEqual(
+    merged.mcpServers.collision,
+    companionCollision,
+    'companion descriptors must override existing servers',
+  );
+  assert.strictEqual(
+    merged.mcpServers[MCP_SERVER_KEY],
+    companionVault,
+    'companion descriptors must apply after the canonical Vault entry',
+  );
+  assert.deepEqual(existing, baseline, 'precedence merge must leave the input untouched');
+}
+
+function assertLegacyMcpComposition(taxonomySource, initSource) {
+  const taxonomyAst = parsed(taxonomySource);
+  const initAst = parsed(initSource);
+  const legacyDeclarations = [];
+  const nonCanonicalImports = [];
+  const canonicalTaxonomyImports = new Set();
+  const canonicalInitImports = new Set();
+  const taxonomyReturnCalls = [];
+  const initReturnCalls = [];
+  const initCalls = new Set();
+  const taxonomyCalls = new Set();
+  const publicBindingMutations = [];
+  let initWritesMcpServers = false;
+
+  const taxonomyWrappers = directExportedFunctions(taxonomyAst, 'companionMcpPatch');
+  const initWrappers = directExportedFunctions(initAst, 'mergeMcp');
+  for (const wrapper of taxonomyWrappers) {
+    taxonomyReturnCalls.push(...directReturnCallNames(wrapper));
+  }
+  for (const wrapper of initWrappers) {
+    initReturnCalls.push(...directReturnCallNames(wrapper));
+  }
+
+  const recordKernelImports = (node, label, canonicalImports) => {
+    if (node.type !== 'ImportDeclaration') return;
+    for (const specifier of node.specifiers) {
+      const localName = specifier.local?.name;
+      const importedName = specifier.type === 'ImportSpecifier'
+        ? (specifier.imported.name ?? specifier.imported.value)
+        : null;
+      if (!MCP_KERNEL_SYMBOLS.has(localName) && !MCP_KERNEL_SYMBOLS.has(importedName)) continue;
+      if (
+        node.source.value === CANONICAL_MCP_IMPORT
+        && importedName === localName
+        && MCP_KERNEL_SYMBOLS.has(importedName)
+      ) {
+        canonicalImports.add(localName);
+      } else {
+        nonCanonicalImports.push(`${label}:${importedName ?? 'default'}->${localName}:${node.source.value}`);
+      }
+    }
+  };
+
+  walk(taxonomyAst, (node) => {
+    recordKernelImports(node, 'taxonomy', canonicalTaxonomyImports);
+    for (const name of declarationNames(node)) {
+      if (MCP_KERNEL_SYMBOLS.has(name)) {
+        legacyDeclarations.push(`taxonomy:${name}`);
+      }
+    }
+    if (node.type === 'CallExpression' && node.callee.type === 'Identifier') {
+      taxonomyCalls.add(node.callee.name);
+      if (node.callee.name === 'eval') publicBindingMutations.push('taxonomy:direct-eval');
+    }
+    if (assignmentBindingNames(node).includes('companionMcpPatch')) {
+      publicBindingMutations.push('taxonomy:companionMcpPatch');
+    }
+  });
+  walk(initAst, (node) => {
+    recordKernelImports(node, 'init', canonicalInitImports);
+    for (const name of declarationNames(node)) {
+      if (MCP_KERNEL_SYMBOLS.has(name)) {
+        legacyDeclarations.push(`init:${name}`);
+      }
+    }
+    if (node.type === 'CallExpression' && node.callee.type === 'Identifier') {
+      initCalls.add(node.callee.name);
+      if (node.callee.name === 'eval') publicBindingMutations.push('init:direct-eval');
+    }
+    if (assignmentBindingNames(node).includes('mergeMcp')) {
+      publicBindingMutations.push('init:mergeMcp');
+    }
+    if (
+      node.type === 'AssignmentExpression'
+      && node.left.type === 'MemberExpression'
+      && propertyName(node.left) === 'mcpServers'
+    ) {
+      initWritesMcpServers = true;
+    }
+  });
+
+  assert.deepEqual(legacyDeclarations, [], 'legacy paths must not own MCP kernel declarations');
+  assert.deepEqual(nonCanonicalImports, [], 'legacy MCP bindings must import the canonical MCP kernel');
+  assert.equal(
+    taxonomyWrappers.length === 1 && namedExportCount(taxonomyAst, 'companionMcpPatch') === 1,
+    true,
+    'legacy taxonomy must directly export exactly one companionMcpPatch function',
+  );
+  assert.equal(
+    initWrappers.length === 1 && namedExportCount(initAst, 'mergeMcp') === 1,
+    true,
+    'legacy init must directly export exactly one mergeMcp function',
+  );
+  assert.deepEqual(publicBindingMutations, [], 'legacy wrapper public binding must not be reassigned');
+  for (const name of ['MCP_SERVER_KEY', 'mcpServerEntry', 'selectMcpServers']) {
+    assert.ok(canonicalTaxonomyImports.has(name), `legacy taxonomy must import ${name} from the canonical MCP kernel`);
+  }
+  for (const name of ['MCP_SERVER_KEY', 'mergeMcpConfig']) {
+    assert.ok(canonicalInitImports.has(name), `legacy init must import ${name} from the canonical MCP kernel`);
+  }
+  assert.ok(taxonomyCalls.has('selectMcpServers'), 'legacy taxonomy must delegate descriptor selection');
+  assert.ok(
+    taxonomyReturnCalls.length > 0 && taxonomyReturnCalls.every((name) => name === 'selectMcpServers'),
+    'legacy taxonomy companionMcpPatch must return the canonical MCP kernel selectMcpServers call',
+  );
+  assert.equal(initWritesMcpServers, false, 'legacy init must not own mcpServers merge');
+  assert.ok(initCalls.has('mergeMcpConfig'), 'legacy init must delegate MCP merge');
+  assert.ok(
+    initReturnCalls.length > 0 && initReturnCalls.every((name) => name === 'mergeMcpConfig'),
+    'legacy init mergeMcp must return the canonical MCP kernel mergeMcpConfig call',
+  );
+}
+
+test('[req:MOD-17] MCP workspace declares and owns its private configuration kernel', () => {
+  const pkg = JSON.parse(readFileSync(MCP_PACKAGE, 'utf8'));
+  assert.equal(pkg.private, true);
+  assert.equal(pkg.exports, './src/index.mjs');
+  assert.ok(existsSync(MCP_INDEX), 'packages/mcp/src/index.mjs must exist');
+  assert.ok(existsSync(MCP_CONFIG), 'packages/mcp/src/config.mjs must exist');
+
+  assertMcpRuntimeOwnership(readFileSync(MCP_CONFIG, 'utf8'));
+});
+
+test('[req:MOD-17] MCP ownership and dependency gates reject delegated or cross-adapter mutants', () => {
+  const delegated = `
+    export {
+      MCP_SERVER_KEY,
+      mcpServerEntry,
+      selectMcpServers,
+      mergeMcpConfig,
+    } from '../../../src/mcp-config.mjs';
+  `;
+  assert.throws(
+    () => assertMcpRuntimeOwnership(delegated),
+    /MCP config kernel must own/,
+  );
+
+  const crossAdapter = `import { COMPANIONS } from '../../../src/taxonomy.mjs';`;
+  assert.throws(
+    () => assertAllowedMcpImports(crossAdapter),
+    /imports only local workspace modules/,
+  );
+});
+
+test('[req:MOD-17] MCP configuration kernel is import-inert and adapter-independent', () => {
+  assertMcpSourceSet(
+    workspaceSourceFiles(MCP_WORKSPACE)
+      .map((absolute) => ({ absolute, source: readFileSync(absolute, 'utf8') })),
+  );
+
+  const moduleUrl = pathToFileURL(MCP_INDEX).href;
+  const probe = spawnSync(process.execPath, [
+    '--input-type=module',
+    '--eval',
+    `const m = await import(${JSON.stringify(moduleUrl)}); process.stdout.write([
+      m.MCP_SERVER_KEY,
+      typeof m.mcpServerEntry,
+      typeof m.selectMcpServers,
+      typeof m.mergeMcpConfig,
+    ].join('|'));`,
+  ], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    env: { ...process.env, OBSIDIAN_VAULT_PATH: '' },
+  });
+
+  assert.equal(probe.status, 0, probe.stderr);
+  assert.equal(probe.stderr, '');
+  assert.equal(probe.stdout, 'wendkeep-vault|function|function|function');
+});
+
+test('[req:MOD-17] MCP import gate rejects silent filesystem and subprocess mutants', () => {
+  assert.throws(
+    () => assertAllowedMcpImports(`
+      import { readFileSync } from 'node:fs';
+      export const state = readFileSync('silent-input');
+    `),
+    /local workspace modules/,
+  );
+  assert.throws(
+    () => assertAllowedMcpImports(`
+      import { spawnSync } from 'node:child_process';
+      spawnSync('node', ['--version'], { stdio: 'ignore' });
+    `),
+    /local workspace modules/,
+  );
+  assert.throws(
+    () => assertAllowedMcpImports(`
+      export * from './nested/../../../../src/taxonomy.mjs';
+    `),
+    /local workspace modules/,
+  );
+  assert.throws(
+    () => assertAllowedMcpImports(`
+      export * from './nested/%2e%2e/%2e%2e/%2e%2e/%2e%2e/src/taxonomy.mjs';
+    `),
+    /local workspace modules/,
+  );
+});
+
+test('[req:MOD-17] MCP import-inert gate rejects effects hidden in transitive local modules', () => {
+  const indexFile = resolve(MCP_WORKSPACE, 'src', 'index.mjs');
+  const hiddenFile = resolve(MCP_WORKSPACE, 'src', 'silent-effects.mjs');
+  assert.throws(
+    () => assertMcpSourceSet([
+      { absolute: indexFile, source: `export * from './silent-effects.mjs';` },
+      {
+        absolute: hiddenFile,
+        source: `process.getBuiltinModule('node:fs').readFileSync('silent-input');`,
+      },
+    ]),
+    /import-time effects/,
+  );
+  assert.throws(
+    () => assertMcpSourceSet([
+      { absolute: indexFile, source: `export * from './silent-effects.mjs';` },
+      {
+        absolute: hiddenFile,
+        source: `process.getBuiltinModule('node:child_process').spawnSync('node', ['--version']);`,
+      },
+    ]),
+    /import-time effects/,
+  );
+});
+
+test('[req:MOD-17] MCP source inventory rejects a second pure kernel implementation', () => {
+  const duplicateFile = resolve(MCP_WORKSPACE, 'src', 'duplicate-config.mjs');
+  assert.throws(
+    () => assertMcpSourceSet([
+      { absolute: MCP_CONFIG, source: readFileSync(MCP_CONFIG, 'utf8') },
+      { absolute: MCP_INDEX, source: readFileSync(MCP_INDEX, 'utf8') },
+      {
+        absolute: duplicateFile,
+        source: `
+          export const MCP_SERVER_KEY = 'duplicate-vault';
+          export function mcpServerEntry() { return {}; }
+          export function selectMcpServers() { return {}; }
+          export function mergeMcpConfig(existing) { return { ...existing }; }
+        `,
+      },
+    ]),
+    /single physical owner|unique owner|config\.mjs/,
+  );
+});
+
+test('[req:MOD-18] MCP and Integrations isolation rejects direct imports in both directions', () => {
+  assert.ok(existsSync(MCP_WORKSPACE));
+  assert.ok(existsSync(INTEGRATIONS_WORKSPACE));
+  for (const [adapter, workspace] of [
+    ['mcp', MCP_WORKSPACE],
+    ['integrations', INTEGRATIONS_WORKSPACE],
+  ]) {
+    for (const absolute of workspaceSourceFiles(workspace)) {
+      assertSiblingAdapterIsolation(adapter, readFileSync(absolute, 'utf8'), absolute);
+    }
+  }
+
+  assert.throws(
+    () => assertSiblingAdapterIsolation('integrations', `
+      import { mergeMcpConfig } from '@wendkeep/mcp';
+    `),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation('integrations', `
+      import { mergeMcpConfig } from '../../mcp/src/index.mjs';
+    `),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation('integrations', `
+      import './nested/%2e%2e/%2e%2e/%2e%2e/mcp/src/index.mjs';
+    `),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation('mcp', `
+      import { projectHooks } from '@wendkeep/integrations';
+    `),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation('mcp', `
+      import { projectHooks } from '../../integrations/src/index.mjs';
+    `),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation('mcp', `
+      import './nested/%2e%2e/%2e%2e/%2e%2e/integrations/src/index.mjs';
+    `),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation('integrations', `
+      import ${JSON.stringify(pathToFileURL(resolve(MCP_WORKSPACE, 'src', 'index.mjs')).href)};
+    `),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'integrations',
+      `module.require(${JSON.stringify(resolve(MCP_WORKSPACE, 'src', 'index.mjs'))});`,
+      resolve(INTEGRATIONS_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation('mcp', `
+      import ${JSON.stringify(pathToFileURL(resolve(INTEGRATIONS_WORKSPACE, 'src', 'index.mjs')).href)};
+    `),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'mcp',
+      `require(${JSON.stringify(resolve(INTEGRATIONS_WORKSPACE, 'src', 'index.mjs'))});`,
+      resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+
+  const aliasRoot = mkdtempSync(resolve(tmpdir(), 'wk-mcp-adapter-alias-'));
+  try {
+    const mcpAlias = resolve(aliasRoot, 'mcp-alias');
+    const integrationsAlias = resolve(aliasRoot, 'integrations-alias');
+    const linkType = process.platform === 'win32' ? 'junction' : 'dir';
+    symlinkSync(MCP_WORKSPACE, mcpAlias, linkType);
+    symlinkSync(INTEGRATIONS_WORKSPACE, integrationsAlias, linkType);
+    assert.throws(
+      () => assertSiblingAdapterIsolation('integrations', `
+        import ${JSON.stringify(pathToFileURL(resolve(mcpAlias, 'src', 'index.mjs')).href)};
+      `),
+      /adapter siblings/,
+    );
+    assert.throws(
+      () => assertSiblingAdapterIsolation('integrations', `
+        import ${JSON.stringify(pathToFileURL(resolve(mcpAlias, 'src', 'future-module.mjs')).href)};
+      `),
+      /adapter siblings/,
+    );
+    assert.throws(
+      () => assertSiblingAdapterIsolation(
+        'mcp',
+        `module.require(${JSON.stringify(resolve(integrationsAlias, 'package.json'))});`,
+        resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+      ),
+      /adapter siblings/,
+    );
+  } finally {
+    rmSync(aliasRoot, { recursive: true, force: true });
+  }
+});
+
+test('[req:MOD-18] adapter isolation recognizes case-insensitive file URLs and static computed require', () => {
+  const uppercaseFileUrl = pathToFileURL(MCP_INDEX).href.replace(/^file:/, 'FILE:');
+  assert.throws(
+    () => assertSiblingAdapterIsolation('integrations', `import ${JSON.stringify(uppercaseFileUrl)};`),
+    /adapter siblings/,
+  );
+
+  const integrationsPackage = resolve(INTEGRATIONS_WORKSPACE, 'package.json');
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'mcp',
+      'module[`require`](' + JSON.stringify(integrationsPackage) + ');',
+      resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'mcp',
+      "module['requ' + 'ire'](" + JSON.stringify(integrationsPackage) + ');',
+      resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'mcp',
+      "globalThis['requ' + 'ire'](" + JSON.stringify(integrationsPackage) + ');',
+      resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'mcp',
+      "module['constructor' + '']._load(" + JSON.stringify(integrationsPackage) + ');',
+      resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'mcp',
+      "module.constructor['_' + 'load'](" + JSON.stringify(integrationsPackage) + ');',
+      resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'mcp',
+      'const load = module.require.bind(module); load(' + JSON.stringify(integrationsPackage) + ');',
+      resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'mcp',
+      'const Loader = module.constructor; Loader._load(' + JSON.stringify(integrationsPackage) + ');',
+      resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'mcp',
+      'const invoke = module.require.call; invoke.call(module.require, null, '
+        + JSON.stringify(integrationsPackage) + ');',
+      resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'mcp',
+      'Reflect.apply(module.require, module, [' + JSON.stringify(integrationsPackage) + ']);',
+      resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'mcp',
+      'Reflect.apply(module.constructor._load, module.constructor, ['
+        + JSON.stringify(integrationsPackage) + ']);',
+      resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'mcp',
+      'Function.prototype.call.call(module.require, module, '
+        + JSON.stringify(integrationsPackage) + ');',
+      resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+  assert.deepEqual(
+    importSpecifiersFromSource(
+      'Reflect.apply(module.require, module, [' + JSON.stringify(integrationsPackage) + ']);',
+      { sourceType: 'script' },
+    ),
+    [integrationsPackage],
+  );
+  assert.deepEqual(
+    importSpecifiersFromSource(
+      'Reflect.apply(module.constructor._load, module.constructor, ['
+        + JSON.stringify(integrationsPackage) + ']);',
+      { sourceType: 'script' },
+    ),
+    [integrationsPackage],
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'mcp',
+      'const load = module.require; Reflect.apply(load, module, ['
+        + JSON.stringify(integrationsPackage) + ']);',
+      resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+  assert.throws(
+    () => assertSiblingAdapterIsolation(
+      'mcp',
+      'const invoke = Reflect.apply; invoke(module.require, module, ['
+        + JSON.stringify(integrationsPackage) + ']);',
+      resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+    ),
+    /adapter siblings/,
+  );
+  assert.deepEqual(
+    importSpecifiersFromSource(
+      'const args = [' + JSON.stringify(integrationsPackage)
+        + ']; Reflect.apply(module.require, module, args);',
+      { sourceType: 'script' },
+    ),
+    ['<dynamic:require>'],
+  );
+  for (const source of [
+    'globalThis.Reflect.apply(module.require, module, ['
+      + JSON.stringify(integrationsPackage) + ']);',
+    'Reflect.apply.call(null, module.require, module, ['
+      + JSON.stringify(integrationsPackage) + ']);',
+    'const load = Function.prototype.call.bind(module.require); load(module, '
+      + JSON.stringify(integrationsPackage) + ');',
+    'const load = Function.prototype.apply.bind(module.constructor._load); '
+      + 'load(module.constructor, [' + JSON.stringify(integrationsPackage) + ']);',
+    'const load = Reflect.apply.bind(Reflect, module.require, module, ['
+      + JSON.stringify(integrationsPackage) + ']); load();',
+    'Function.prototype.call.bind(Function.prototype.call)(module.require, module, '
+      + JSON.stringify(integrationsPackage) + ');',
+  ]) {
+    assert.throws(
+      () => assertSiblingAdapterIsolation(
+        'mcp',
+        source,
+        resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+      ),
+      /adapter siblings/,
+    );
+  }
+  assert.deepEqual(
+    importSpecifiersFromSource(
+      "Reflect.apply(Math.max, null, [1, 2]); Function.prototype.call.call(String.prototype.toUpperCase, 'x');",
+      { sourceType: 'script' },
+    ),
+    [],
+  );
+});
+
+test('[req:MOD-18] adapter isolation tracks higher-order receivers and Module loaders', () => {
+  const integrationsPackage = resolve(INTEGRATIONS_WORKSPACE, 'package.json');
+  const encodedTarget = JSON.stringify(integrationsPackage);
+  for (const source of [
+    `Reflect.apply(Function.prototype.call, module.require, [module, ${encodedTarget}]);`,
+    `Reflect.apply(Function.prototype.apply, module.require, [module, [${encodedTarget}]]);`,
+    'Function.prototype.call.call(Function.prototype.call, module.require, module, '
+      + `${encodedTarget});`,
+    'Function.prototype.call.apply(Function.prototype.call, '
+      + `[module.require, module, ${encodedTarget}]);`,
+    `require('node:module')._load(${encodedTarget});`,
+    `const Loader = require('node:module'); Loader._load(${encodedTarget});`,
+    `require('node:module').createRequire(__filename)(${encodedTarget});`,
+    "const { createRequire } = require('node:module'); "
+      + `createRequire(__filename)(${encodedTarget});`,
+    `process.getBuiltinModule('node:module')._load(${encodedTarget});`,
+  ]) {
+    assert.throws(
+      () => assertSiblingAdapterIsolation(
+        'mcp',
+        source,
+        resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+      ),
+      /adapter siblings/,
+    );
+  }
+
+  for (const source of [
+    `import Module from 'node:module'; Module._load(${encodedTarget});`,
+    "import { createRequire } from 'node:module'; "
+      + `createRequire(import.meta.url)(${encodedTarget});`,
+  ]) {
+    assert.throws(
+      () => assertSiblingAdapterIsolation(
+        'mcp',
+        source,
+        resolve(MCP_WORKSPACE, 'src', 'mutant.mjs'),
+      ),
+      /adapter siblings/,
+    );
+  }
+});
+
+test('[req:MOD-18] adapter isolation fails closed on indirect Module acquisition', () => {
+  const integrationsPackage = resolve(INTEGRATIONS_WORKSPACE, 'package.json');
+  const encodedTarget = JSON.stringify(integrationsPackage);
+  for (const source of [
+    `Reflect.apply(require, null, ['node:module'])._load(${encodedTarget});`,
+    'Function.prototype.call.call(require, null, '
+      + `'node:module')._load(${encodedTarget});`,
+    "Reflect.apply(process.getBuiltinModule, process, ['node:module'])"
+      + `._load(${encodedTarget});`,
+    `process.getBuiltinModule.call(process, 'node:module')._load(${encodedTarget});`,
+    `process.getBuiltinModule('node:' + 'module')._load(${encodedTarget});`,
+    "const name = 'node:module'; "
+      + `process.getBuiltinModule(name)._load(${encodedTarget});`,
+    "Reflect.apply(require('node:module').createRequire, null, [__filename])"
+      + `(${encodedTarget});`,
+  ]) {
+    assert.throws(
+      () => assertSiblingAdapterIsolation(
+        'mcp',
+        source,
+        resolve(MCP_WORKSPACE, 'src', 'mutant.cjs'),
+      ),
+      /adapter siblings/,
+    );
+  }
+
+  for (const source of [
+    "const { createRequire } = await import('node:module'); "
+      + `createRequire(import.meta.url)(${encodedTarget});`,
+    `(await import('node:module')).default._load(${encodedTarget});`,
+    "const Module = await import('node:module'); "
+      + `Module.default._load(${encodedTarget});`,
+    "import('node:module').then(({ createRequire }) => "
+      + `createRequire(import.meta.url)(${encodedTarget}));`,
+  ]) {
+    assert.throws(
+      () => assertSiblingAdapterIsolation(
+        'mcp',
+        source,
+        resolve(MCP_WORKSPACE, 'src', 'mutant.mjs'),
+      ),
+      /adapter siblings/,
+    );
+  }
+
+  assert.deepEqual(
+    importSpecifiersFromSource("process.getBuiltinModule('node:path').join('a', 'b');", {
+      sourceType: 'script',
+    }),
+    [],
+  );
+});
+
+test('[req:MOD-18] adapter isolation recognizes file URLs with loader-trimmed ASCII whitespace', () => {
+  const paddedFileUrl = ` \t${pathToFileURL(MCP_INDEX).href} `;
+  assert.throws(
+    () => assertSiblingAdapterIsolation('integrations', `import ${JSON.stringify(paddedFileUrl)};`),
+    /adapter siblings/,
+  );
+});
+
+test('[req:MOD-18] adapter isolation rejects hardlink aliases in both directions', () => {
+  const hardlinkRoot = mkdtempSync(resolve(ROOT, '.wk-mcp-hardlink-'));
+  try {
+    const mcpHardlink = resolve(hardlinkRoot, 'mcp-config-hardlink.mjs');
+    const integrationsHardlink = resolve(hardlinkRoot, 'integrations-package-hardlink.json');
+    linkSync(MCP_CONFIG, mcpHardlink);
+    linkSync(resolve(INTEGRATIONS_WORKSPACE, 'package.json'), integrationsHardlink);
+
+    for (const [adapter, target] of [
+      ['integrations', mcpHardlink],
+      ['mcp', integrationsHardlink],
+    ]) {
+      assert.throws(
+        () => assertSiblingAdapterIsolation(
+          adapter,
+          `import ${JSON.stringify(pathToFileURL(target).href)};`,
+        ),
+        /adapter siblings/,
+      );
+      assert.throws(
+        () => assertSiblingAdapterIsolation(
+          adapter,
+          `require(${JSON.stringify(target)});`,
+          resolve(adapter === 'mcp' ? MCP_WORKSPACE : INTEGRATIONS_WORKSPACE, 'src', 'mutant.cjs'),
+        ),
+        /adapter siblings/,
+      );
+    }
+  } finally {
+    rmSync(hardlinkRoot, { recursive: true, force: true });
+  }
+});
+
+test('[req:MOD-17] [req:MOD-18] legacy MCP paths preserve identity and compose the canonical kernel', async () => {
+  const taxonomySource = readFileSync(LEGACY_TAXONOMY, 'utf8');
+  const initSource = readFileSync(LEGACY_INIT, 'utf8');
+  assertLegacyMcpComposition(taxonomySource, initSource);
+
+  const ownershipMutant = `
+    function selectMcpServers() { return {}; }
+    export const MCP_SERVER_KEY = 'mutant';
+    export function mcpServerEntry() { return {}; }
+    export function companionMcpPatch() { return selectMcpServers(); }
+  `;
+  assert.throws(
+    () => assertLegacyMcpComposition(ownershipMutant, initSource),
+    /legacy paths must not own/,
+  );
+  assert.throws(
+    () => assertLegacyMcpComposition(
+      taxonomySource,
+      initSource.replace('return mergeMcpConfig(', 'const m = {}; m.mcpServers = {}; return mergeMcpConfig('),
+    ),
+    /legacy init must not own/,
+  );
+  assert.throws(
+    () => assertLegacyMcpComposition(`
+      function selectMcpServers() { return {}; }
+      export function companionMcpPatch() { return selectMcpServers(); }
+    `, initSource),
+    /legacy paths must not own/,
+  );
+  assert.throws(
+    () => assertLegacyMcpComposition(taxonomySource, `
+      function mergeMcpConfig() { return {}; }
+      export function mergeMcp() { return mergeMcpConfig(); }
+    `),
+    /legacy paths must not own/,
+  );
+  assert.throws(
+    () => assertLegacyMcpComposition(`
+      const { selectMcpServers } = { selectMcpServers() { return {}; } };
+      export function companionMcpPatch() { return selectMcpServers(); }
+    `, initSource),
+    /legacy paths must not own/,
+  );
+  assert.throws(
+    () => assertLegacyMcpComposition(taxonomySource, `
+      const { mergeMcpConfig } = { mergeMcpConfig() { return {}; } };
+      export function mergeMcp() { return mergeMcpConfig(); }
+    `),
+    /legacy paths must not own/,
+  );
+
+  const canonical = await import(pathToFileURL(MCP_INDEX).href);
+  const legacy = await import(pathToFileURL(LEGACY_TAXONOMY).href);
+  assert.strictEqual(legacy.MCP_SERVER_KEY, canonical.MCP_SERVER_KEY);
+  assert.strictEqual(legacy.mcpServerEntry, canonical.mcpServerEntry);
+});
+
+test('[req:MOD-17] legacy composition rejects parameter ownership and noncanonical kernel imports', () => {
+  const taxonomySource = readFileSync(LEGACY_TAXONOMY, 'utf8');
+  const initSource = readFileSync(LEGACY_INIT, 'utf8');
+  assert.throws(
+    () => assertLegacyMcpComposition(`
+      export function companionMcpPatch({ selectMcpServers = () => ({}) } = {}) {
+        return selectMcpServers();
+      }
+    `, initSource),
+    /legacy paths must not own/,
+  );
+  assert.throws(
+    () => assertLegacyMcpComposition(taxonomySource, `
+      export function mergeMcp(existing, mergeMcpConfig = () => ({})) {
+        return mergeMcpConfig(existing);
+      }
+    `),
+    /legacy paths must not own/,
+  );
+  assert.throws(
+    () => assertLegacyMcpComposition(`
+      import { selectMcpServers } from './rogue.mjs';
+      export function companionMcpPatch() { return selectMcpServers(); }
+    `, initSource),
+    /canonical MCP kernel/,
+  );
+});
+
+test('[req:MOD-17] legacy wrappers must return the canonical imported kernel call', () => {
+  const taxonomySource = readFileSync(LEGACY_TAXONOMY, 'utf8');
+  const initSource = readFileSync(LEGACY_INIT, 'utf8');
+  assert.throws(
+    () => assertLegacyMcpComposition(`
+      import {
+        MCP_SERVER_KEY,
+        mcpServerEntry,
+        selectMcpServers,
+      } from ${JSON.stringify(CANONICAL_MCP_IMPORT)};
+      import { selectMcpServers as rogueSelect } from './rogue.mjs';
+      export { MCP_SERVER_KEY, mcpServerEntry };
+      export function companionMcpPatch() {
+        selectMcpServers([], []);
+        return rogueSelect([], []);
+      }
+    `, initSource),
+    /canonical MCP kernel|must return/,
+  );
+  assert.throws(
+    () => assertLegacyMcpComposition(taxonomySource, `
+      import { MCP_SERVER_KEY, mergeMcpConfig } from ${JSON.stringify(CANONICAL_MCP_IMPORT)};
+      import { mergeMcpConfig as rogueMerge } from './rogue.mjs';
+      export function mergeMcp(existing) {
+        mergeMcpConfig(existing, {});
+        return rogueMerge(existing, {});
+      }
+    `),
+    /canonical MCP kernel|must return/,
+  );
+});
+
+test('[req:MOD-17] legacy wrappers must own their exported binding without later reassignment', () => {
+  const taxonomySource = readFileSync(LEGACY_TAXONOMY, 'utf8');
+  const initSource = readFileSync(LEGACY_INIT, 'utf8');
+  assert.throws(
+    () => assertLegacyMcpComposition(`
+      import {
+        MCP_SERVER_KEY,
+        mcpServerEntry,
+        selectMcpServers,
+      } from ${JSON.stringify(CANONICAL_MCP_IMPORT)};
+      export { MCP_SERVER_KEY, mcpServerEntry };
+      function companionMcpPatch() { return selectMcpServers([], []); }
+      export { default as companionMcpPatch } from './rogue.mjs';
+    `, initSource),
+    /directly export|public binding/,
+  );
+  assert.throws(
+    () => assertLegacyMcpComposition(taxonomySource, `
+      import { MCP_SERVER_KEY, mergeMcpConfig } from ${JSON.stringify(CANONICAL_MCP_IMPORT)};
+      function mergeMcp(existing) { return mergeMcpConfig(existing, {}); }
+      export { default as mergeMcp } from './rogue.mjs';
+    `),
+    /directly export|public binding/,
+  );
+  assert.throws(
+    () => assertLegacyMcpComposition(`
+      import {
+        MCP_SERVER_KEY,
+        mcpServerEntry,
+        selectMcpServers,
+      } from ${JSON.stringify(CANONICAL_MCP_IMPORT)};
+      export { MCP_SERVER_KEY, mcpServerEntry };
+      export function companionMcpPatch() { return selectMcpServers([], []); }
+      companionMcpPatch = () => ({});
+    `, initSource),
+    /public binding/,
+  );
+  assert.throws(
+    () => assertLegacyMcpComposition(`
+      import {
+        MCP_SERVER_KEY,
+        mcpServerEntry,
+        selectMcpServers,
+      } from ${JSON.stringify(CANONICAL_MCP_IMPORT)};
+      export { MCP_SERVER_KEY, mcpServerEntry };
+      export function companionMcpPatch() { return selectMcpServers([], []); }
+      eval('companionMcpPatch = () => ({ rogue: true })');
+    `, initSource),
+    /public binding|dynamic evaluation/,
+  );
+  assert.throws(
+    () => assertLegacyMcpComposition(taxonomySource, `
+      import { MCP_SERVER_KEY, mergeMcpConfig } from ${JSON.stringify(CANONICAL_MCP_IMPORT)};
+      export function mergeMcp(existing) { return mergeMcpConfig(existing, {}); }
+      eval('mergeMcp = () => ({ rogue: true })');
+    `),
+    /public binding|dynamic evaluation/,
+  );
+});
+
+test('[req:MOD-18] MCP kernel preserves the canonical transport and selects descriptors deterministically', async () => {
+  const {
+    mcpServerEntry,
+    selectMcpServers,
+  } = await import(pathToFileURL(MCP_INDEX).href);
+
+  assert.deepEqual(mcpServerEntry('C:\\Vault'), {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', '@bitbonsai/mcpvault@latest', 'C:\\Vault'],
+  });
+
+  const first = { type: 'stdio', command: 'first', args: [] };
+  const last = { type: 'stdio', command: 'last', args: ['--safe'] };
+  assert.deepEqual(
+    selectMcpServers([
+      { id: 'ignored' },
+      { id: 'first', key: 'shared', entry: first },
+      { id: 'skipped', key: 'skip-me', entry: first },
+      { id: 'last', key: 'shared', entry: last },
+    ], ['skipped']),
+    { shared: last },
+  );
+});
+
+test('[req:MOD-18] MCP merge is immutable, idempotent, and preserves existing configuration', async () => {
+  const {
+    MCP_SERVER_KEY,
+    mergeMcpConfig,
+  } = await import(pathToFileURL(MCP_INDEX).href);
+
+  const existing = {
+    custom: { keep: true },
+    mcpServers: {
+      user: { type: 'stdio', command: 'user', args: [] },
+      [MCP_SERVER_KEY]: { type: 'stdio', command: 'old', args: [] },
+    },
+  };
+  const baseline = structuredClone(existing);
+  const options = {
+    vaultPath: 'C:\\Vault',
+    servers: {
+      companion: { type: 'stdio', command: 'companion', args: [] },
+    },
+  };
+  const merged = mergeMcpConfig(existing, options);
+
+  assert.deepEqual(existing, baseline, 'merge must not mutate consumer configuration');
+  assert.deepEqual(merged.custom, { keep: true });
+  assert.deepEqual(merged.mcpServers.user, baseline.mcpServers.user);
+  assert.deepEqual(merged.mcpServers[MCP_SERVER_KEY], {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', '@bitbonsai/mcpvault@latest', 'C:\\Vault'],
+  });
+  assert.deepEqual(merged.mcpServers.companion, options.servers.companion);
+  assert.deepEqual(mergeMcpConfig(merged, options), merged, 'merge must be idempotent');
+
+  const withoutVault = mergeMcpConfig(existing, {
+    ...options,
+    withVault: false,
+  });
+  assert.deepEqual(
+    withoutVault.mcpServers[MCP_SERVER_KEY],
+    baseline.mcpServers[MCP_SERVER_KEY],
+    'withVault false preserves a consumer entry instead of deleting it',
+  );
+});
+
+test('[req:MOD-18] MCP merge preserves baseline precedence: existing, Vault, then companions', async () => {
+  const canonical = await import(pathToFileURL(MCP_INDEX).href);
+  assertMcpMergePrecedence(canonical.mergeMcpConfig, canonical);
+
+  const existingWinsMutant = (existing, options) => {
+    const merged = canonical.mergeMcpConfig(existing, options);
+    return {
+      ...merged,
+      mcpServers: {
+        ...merged.mcpServers,
+        collision: existing.mcpServers.collision,
+      },
+    };
+  };
+  assert.throws(
+    () => assertMcpMergePrecedence(existingWinsMutant, canonical),
+    /companion descriptors must override existing servers/,
+  );
+});

--- a/tests/tarball-smoke.test.mjs
+++ b/tests/tarball-smoke.test.mjs
@@ -73,7 +73,7 @@ test('every published hook passes node --check (no broken syntax shipped)', () =
   }
 });
 
-test('[req:MOD-4] [req:MOD-8] [req:MOD-10] [req:MOD-11] [req:MOD-12] [req:MOD-13] [req:MOD-16] published tarball contains the modular surfaces', () => {
+test('[req:MOD-4] [req:MOD-8] [req:MOD-10] [req:MOD-11] [req:MOD-12] [req:MOD-13] [req:MOD-16] [req:MOD-19] published tarball contains the modular surfaces', () => {
   const published = publishedFiles();
   for (const path of [
     'packages/cli/package.json',
@@ -84,6 +84,8 @@ test('[req:MOD-4] [req:MOD-8] [req:MOD-10] [req:MOD-11] [req:MOD-12] [req:MOD-13
     'packages/harness/src/operating-profile.mjs',
     'packages/harness/src/sensors-core.mjs',
     'packages/mcp/package.json',
+    'packages/mcp/src/config.mjs',
+    'packages/mcp/src/index.mjs',
     'packages/integrations/package.json',
     'packages/pi/package.json',
     'packages/vault/package.json',
@@ -111,7 +113,18 @@ test('[req:MOD-14] [req:MOD-16] CLI workspace declares its private runtime witho
   assert.equal(Object.hasOwn(root.exports, './cli'), false);
 });
 
-test('[req:MOD-4] [req:MOD-6] [req:MOD-9] [req:MOD-10] [req:MOD-11] [req:MOD-12] [req:MOD-13] [req:MOD-16] installed tarball exposes strict canonical, public, and legacy identities', () => {
+test('[req:MOD-17] [req:MOD-19] MCP workspace declares its private kernel without publishing wendkeep/mcp', () => {
+  const root = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8'));
+  const mcp = JSON.parse(readFileSync(join(pkgRoot, 'packages', 'mcp', 'package.json'), 'utf8'));
+
+  assert.equal(mcp.private, true);
+  assert.equal(mcp.exports, './src/index.mjs');
+  assert.equal(Object.hasOwn(root.exports, './mcp'), false);
+  assert.match(root.scripts.check, /node --check packages\/mcp\/src\/config\.mjs/);
+  assert.match(root.scripts.check, /node --check packages\/mcp\/src\/index\.mjs/);
+});
+
+test('[req:MOD-4] [req:MOD-6] [req:MOD-9] [req:MOD-10] [req:MOD-11] [req:MOD-12] [req:MOD-13] [req:MOD-16] [req:MOD-18] [req:MOD-19] installed tarball exposes strict canonical, public, and legacy identities', () => {
   const temp = mkdtempSync(join(tmpdir(), 'wendkeep-installed-tarball-'));
   try {
     const packed = spawnSync(`npm pack --json --pack-destination "${temp}"`, {
@@ -138,6 +151,7 @@ test('[req:MOD-4] [req:MOD-6] [req:MOD-9] [req:MOD-10] [req:MOD-11] [req:MOD-12]
     const imported = spawnSync(process.execPath, ['--input-type=module', '--eval', [
       "const vault = await import('wendkeep/vault');",
       "const harness = await import('wendkeep/harness');",
+      "const canonicalMcp = await import('wendkeep/packages/mcp/src/index.mjs');",
       "const canonicalLocale = await import('wendkeep/packages/vault/src/locale.mjs');",
       "const canonicalFlowStore = await import('wendkeep/packages/harness/src/flow-store.mjs');",
       "const legacyLocale = await import('wendkeep/hooks/locale.mjs');",
@@ -146,6 +160,7 @@ test('[req:MOD-4] [req:MOD-6] [req:MOD-9] [req:MOD-10] [req:MOD-11] [req:MOD-12]
       "const legacyFlowStore = await import('wendkeep/hooks/vault-runtime-store.mjs');",
       "const legacyProfile = await import('wendkeep/src/operating-profile.mjs');",
       "const legacySensors = await import('wendkeep/hooks/sensors-core.mjs');",
+      "const legacyTaxonomy = await import('wendkeep/src/taxonomy.mjs');",
       "if (typeof vault.resolveProjectVault !== 'function') process.exit(11);",
       "if (typeof legacy.assertVaultPathSafe !== 'function') process.exit(12);",
       "const shared = vault.renderSharedMemory({ updatedAt: '2026-07-28T00:00:00.000Z', reviewAfter: '2026-08-04T00:00:00.000Z' });",
@@ -217,6 +232,16 @@ test('[req:MOD-4] [req:MOD-6] [req:MOD-9] [req:MOD-10] [req:MOD-11] [req:MOD-12]
       "});",
       "const promoted = canonicalFlowStore.readFlow(runtimeVault, { sessionId: 'session-promoted', flowId: 'flow-promoted' });",
       "if (promoted.state !== 'promoted' || canonicalFlowStore.listFlows(runtimeVault).length !== 2) process.exit(26);",
+      "if (canonicalMcp.MCP_SERVER_KEY !== legacyTaxonomy.MCP_SERVER_KEY) process.exit(27);",
+      "if (canonicalMcp.mcpServerEntry !== legacyTaxonomy.mcpServerEntry) process.exit(28);",
+      "const mcpMerged = canonicalMcp.mergeMcpConfig({ mcpServers: { user: { command: 'user' } } }, { vaultPath: 'C:/vault' });",
+      "if (mcpMerged.mcpServers.user.command !== 'user') process.exit(29);",
+      "if (mcpMerged.mcpServers['wendkeep-vault'].args.at(-1) !== 'C:/vault') process.exit(30);",
+      "for (const specifier of ['wendkeep/mcp', '@wendkeep/mcp']) {",
+      "  try { await import(specifier); process.exit(31); } catch (error) {",
+      "    if (!['ERR_MODULE_NOT_FOUND', 'ERR_PACKAGE_PATH_NOT_EXPORTED'].includes(error.code)) process.exit(32);",
+      "  }",
+      "}",
     ].join('\n')], { cwd: consumer, encoding: 'utf8' });
     assert.equal(imported.status, 0, `installed imports failed:\n${imported.stderr}`);
 
@@ -241,6 +266,33 @@ test('[req:MOD-4] [req:MOD-6] [req:MOD-9] [req:MOD-10] [req:MOD-11] [req:MOD-12]
       assert.equal(versionResult.status, 0, `${alias} failed:\n${versionResult.stderr}`);
       assert.equal(versionResult.stdout.trim(), installedVersion);
     }
+
+    const installedProject = join(consumer, 'mcp-init-project');
+    const installedVault = join(installedProject, '.Vault');
+    mkdirSync(installedProject);
+    writeFileSync(join(installedProject, '.mcp.json'), JSON.stringify({
+      custom: { keep: true },
+      mcpServers: {
+        user: { type: 'stdio', command: 'user', args: [] },
+      },
+    }, null, 2));
+    const installedInit = spawnSync(process.execPath, [
+      join(consumer, 'node_modules', 'wendkeep', 'bin', 'wendkeep.mjs'),
+      'init',
+      '--project', installedProject,
+      '--vault', installedVault,
+      '--no-companions',
+      '--no-colors',
+      '--yes',
+    ], { cwd: consumer, encoding: 'utf8' });
+    assert.equal(installedInit.status, 0, `installed init failed:\n${installedInit.stderr}`);
+    const installedMcp = JSON.parse(readFileSync(join(installedProject, '.mcp.json'), 'utf8'));
+    assert.deepEqual(installedMcp.custom, { keep: true });
+    assert.equal(installedMcp.mcpServers.user.command, 'user');
+    assert.deepEqual(
+      installedMcp.mcpServers['wendkeep-vault'].args,
+      ['-y', '@bitbonsai/mcpvault@latest', installedVault],
+    );
   } finally {
     rmSync(temp, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
   }


### PR DESCRIPTION
## Resumo

- extrai o kernel canônico e import-inert de configuração MCP para o workspace privado `packages/mcp`
- preserva as fachadas históricas de taxonomy/init, a precedência do merge, `skipMcp`, `withVault` e a reconciliação de JSON inválido
- mantém MCP e Integrations como adapters irmãos, com scanner AST fail-closed para loaders ESM/CJS, aliases, helpers de função e aliases físicos
- valida o tarball instalado sem publicar prematuramente `wendkeep/mcp` ou um pacote `@wendkeep/mcp`
- atualiza documentação PT-BR/EN, CHANGELOG e versão para 0.65.0

## Validação

- `wendkeep verify --deep`: tests, docs-bilingual, release-tests e check verdes
- suíte completa: 1078/1078
- matriz focal final: 105/105
- verificação independente: MOD-17, MOD-18 e MOD-19 cobertos; 5 probes adversariais adicionais rejeitados
- `npm run check` e `git diff --check` verdes

## CHANGELOG

### Added

- O workspace privado MCP passa a ter um kernel canônico de configuração.
- O tarball instalado prova a composição MCP fora do checkout.

### Changed

- Taxonomia e instalador agora delegam ao kernel MCP.
- A publicação continua unificada e compatível, sem servidor nativo, subpath público ou pacote npm separado nesta fase.