### PR TITLE
feat: add private Integrations kernel (0.66.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.66.0] — 2026-07-29
+
+### Added
+
+- **O workspace privado Integrations passa a ter um kernel canônico para Claude Code e Codex.**
+  Catálogo/projeção de hooks, envelope e provider, filtros de conteúdo, normalização de uso,
+  parsers de transcript e identidade de sessão/turno agora vivem em módulos puros sob
+  `packages/integrations/src/`, sem filesystem, ambiente global, Vault ou registry no import.
+- **O tarball instalado prova a fronteira completa fora do checkout.** O teste executa `init` e
+  um hook `session-ensure` em consumidor temporário, valida estado persistido e as projeções
+  Claude/Codex contra o kernel empacotado, e confirma que Integrations permanece interno à
+  única publicação `wendkeep`.
+
+### Changed
+
+- **As fachadas históricas agora injetam efeitos no kernel de Integrations.** Taxonomia e hooks
+  preservam assinaturas e identidade dos exports enquanto stdin/stdout, `process.env`, leitura de
+  transcripts, acesso ao Vault e ao registry continuam nas bordas; paths, schemas, configs e
+  sessões existentes não exigem migração.
+- **Os workspaces privados deixaram de vazar por deep imports do wildcard raiz.** A allowlist de
+  exports mantém `wendkeep/harness`, `wendkeep/vault` e os caminhos históricos publicados, mas
+  bloqueia `packages/*`, inclusive variantes percent-encoded; MCP e Integrations seguem como
+  adapters irmãos sem dependência direta.
+
+### Fixed
+
+- **A reconexão de sessão por transcript agora respeita o provider.** Uma entrada do registry de
+  outro host é ignorada sem substituir uma identidade canônica válida já inspecionada.
+- **A suíte integral mantém determinismo sob carga de I/O no Windows.** O runner limita a duas as
+  files executadas em paralelo, preservando a concorrência multiprocesso dentro dos testes de
+  CAS/locks e todos os asserts, sem falsos vermelhos causados por starvation entre suítes.
+
 ## [0.65.0] — 2026-07-29
 
 ### Added

--- a/README.en.md
+++ b/README.en.md
@@ -17,13 +17,23 @@
 
 The runtime is being separated into six physical boundaries — `cli`, `harness`, `vault`, `mcp`,
 `integrations`, and `pi` — without fragmenting installation. The private `cli`, `harness`,
-`vault`, and `mcp` workspaces now canonically own the executable runtime, Operating Profiles/the
-sensor engine, safe binding/the Shared Project Memory v2 kernel, and the MCP configuration kernel,
-respectively. The root package exposes Harness and Vault through `wendkeep/harness` and
-`wendkeep/vault`; CLI and MCP remain private surfaces, reached only through the binaries and the
-configuration effects of `init`. Historical imports keep working through compatibility facades
+`vault`, `mcp`, and `integrations` workspaces now canonically own the executable runtime,
+Operating Profiles/the sensor engine, safe binding/the Shared Project Memory v2 kernel, the MCP
+configuration kernel, and pure Claude/Codex integration rules, respectively. The root package
+exposes Harness and Vault through `wendkeep/harness` and `wendkeep/vault`; CLI, MCP, and
+Integrations remain private surfaces, reached only through the binaries, the configuration effects
+of `init`, and historical facades. Historical imports keep working through compatibility facades
 and no session data needs migration;
 see the [modular architecture](docs/en/architecture.md).
+
+In the **0.66 Integrations Kernel** phase, `packages/integrations/src/` becomes the canonical
+authority for the hook catalog and projection, the envelope/provider, transcript content and usage
+filters and parsers, and session identity. These rules are pure: stdin/stdout, environment,
+filesystem, Vault, and registry effects remain in the historical facades. MCP and Integrations are
+sibling adapters with no dependency between them, and the direction remains
+`cli/mcp/integrations/pi → Harness → Vault`. Hooks, sessions, paths, configuration, and schemas
+remain equivalent; the private `@wendkeep/integrations` workspace stays inside the single
+published `wendkeep` package, with no public `wendkeep/integrations` subpath. Pi is the next phase.
 
 In the **0.65 MCP Configuration Kernel** phase, `packages/mcp/src/config.mjs` becomes the
 canonical authority for the MCPVault entry, catalog-described server selection, and `.mcp.json`

--- a/README.md
+++ b/README.md
@@ -17,13 +17,23 @@
 
 O runtime está sendo separado em seis fronteiras físicas — `cli`, `harness`, `vault`, `mcp`,
 `integrations` e `pi` — sem fragmentar a instalação. Os workspaces privados `cli`, `harness`,
-`vault` e `mcp` agora são donos canônicos do runtime do executável, dos Perfis de
-Operação/engine de sensores, do binding seguro/kernel da Shared Project Memory v2 e do kernel de
-configuração MCP, respectivamente. O pacote raiz expõe Harness e Vault em `wendkeep/harness` e
-`wendkeep/vault`; CLI e MCP permanecem superfícies privadas, acessíveis somente pelos binários e
-pelos efeitos de configuração do `init`. Os imports históricos continuam funcionando por
+`vault`, `mcp` e `integrations` agora são donos canônicos do runtime do executável, dos Perfis de
+Operação/engine de sensores, do binding seguro/kernel da Shared Project Memory v2, do kernel de
+configuração MCP e das regras puras de integração com Claude/Codex, respectivamente. O pacote raiz
+expõe Harness e Vault em `wendkeep/harness` e `wendkeep/vault`; CLI, MCP e Integrations permanecem
+superfícies privadas, acessíveis somente pelos binários, pelos efeitos de configuração do `init` e
+pelas fachadas históricas. Os imports históricos continuam funcionando por
 fachadas de compatibilidade e nenhum dado de sessão precisa ser migrado;
 veja a [arquitetura modular](docs/pt-BR/architecture.md).
+
+Na fase **0.66 Integrations Kernel**, `packages/integrations/src/` passa a ser a autoridade
+canônica para o catálogo e a projeção de hooks, o envelope/provider, os filtros e parsers de
+conteúdo e uso de transcripts e a identidade de sessão. Essas regras são puras: stdin/stdout,
+ambiente, filesystem, Vault e registry continuam nas fachadas históricas. MCP e Integrations são
+adapters irmãos sem dependência entre si, e a direção continua `cli/mcp/integrations/pi → Harness
+→ Vault`. Hooks, sessões, paths, configs e schemas permanecem equivalentes; o workspace privado
+`@wendkeep/integrations` segue dentro do único pacote publicado `wendkeep`, sem subpath público
+`wendkeep/integrations`. A próxima fase é Pi.
 
 Na fase **0.65 MCP Configuration Kernel**, `packages/mcp/src/config.mjs` passa a ser a autoridade
 canônica para a entrada do MCPVault, seleção de servidores descritos pelo catálogo e merge de

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -9,7 +9,7 @@ into private workspaces so migration can be incremental and dependency direction
 | `harness` | Profiles, policies, changes, sensors, and verification. |
 | `vault` | Keep Core, project binding, memory kernel, and safe local I/O. |
 | `mcp` | MCP transport and configuration. |
-| `integrations` | Agent-host event adapters. |
+| `integrations` | Pure host-integration rules for hooks, envelopes, transcripts, and identity. |
 | `pi` | Pi-specific extension and hooks. |
 
 ## Dependency direction
@@ -25,6 +25,25 @@ adapters (cli/mcp/integrations/pi) -> Harness -> Vault
 canonically owns Operating Profile resolution/policy and the sensor engine under
 `packages/harness/src/`; `vault` continues to own binding/resolution, physical path safety, and the
 memory kernel under `packages/vault/src/`.
+
+## 0.66 Integrations Kernel
+
+The private `@wendkeep/integrations` workspace under `packages/integrations/src/` is the canonical
+authority for pure rules shared by Claude Code and Codex: the hook catalog and projection;
+envelope parsing, provider detection, and metadata; content filters and extraction; usage
+normalization; transcript parsing and matching; and session/turn identity resolution.
+
+This boundary performs no stdin/stdout, ambient environment, filesystem, Vault, or registry
+effects. Those effects remain in the historical facades under
+`hooks/` and `src/`, which re-export the same bindings and inject host data into the pure kernel.
+Claude/Codex hooks and sessions therefore remain semantically equivalent, with no Vault,
+configuration, path, or schema migration.
+
+MCP and Integrations are sibling adapters with no dependency between them. Both follow
+`cli/mcp/integrations/pi → Harness → Vault`, and boundary tests reject cycles or ambient access
+inside the kernel. Integrations remains internal to the root tarball: there is no separate
+`@wendkeep/integrations` npm publication or public `wendkeep/integrations` subpath. Pi is the next
+phase of the modular migration.
 
 ## 0.65 MCP Configuration Kernel
 
@@ -110,7 +129,7 @@ is no data migration.
 
 All six workspaces remain private and internal to the monorepo; they are not independent npm
 packages. Installation remains `wendkeep`; `wendkeep/harness` and `wendkeep/vault` are public
-subpaths of the root package, not separate publications. CLI and MCP now have private canonical
-implementations: the former remains exposed through the binaries and the latter through `init`
-configuration effects. `integrations` and `pi` remain reserved boundaries; the planned migration
-sequence is MCP → Integrations → Pi.
+subpaths of the root package, not separate publications. CLI, MCP, and Integrations now have
+private canonical implementations: the first remains exposed through the binaries, the second
+through `init` configuration effects, and the third through the historical host facades. `pi`
+remains the reserved boundary and is the next planned migration phase.

--- a/docs/en/commands/getting-started.md
+++ b/docs/en/commands/getting-started.md
@@ -78,6 +78,14 @@ When MCP is enabled, `init` preserves existing properties and servers in `.mcp.j
 and the reconciled proposal is written to `.mcp.json.new`. Since version 0.65, this composition is
 owned by the private MCP kernel without changing commands, flags, or the public npm surface.
 
+Pure rules that project Claude/Codex hooks and interpret envelopes, transcripts, usage, and
+identity belong to the private `@wendkeep/integrations` workspace. Historical facades retain
+stdin/stdout, environment, filesystem, Vault, and registry effects. This adds no commands or flags,
+changes neither hooks nor sessions, and requires no Vault, configuration, path, or schema migration.
+MCP and Integrations remain sibling adapters with no dependency between them, and the direction
+remains `cli/mcp/integrations/pi → Harness → Vault`. Everything stays inside the single published
+`wendkeep` package; there is no public `wendkeep/integrations` surface. Pi is the next modular phase.
+
 ## Common errors and diagnosis
 
 - Wrong vault: inspect `.wendkeep.json` and run `wendkeep doctor --vault <path>`.

--- a/docs/pt-BR/architecture.md
+++ b/docs/pt-BR/architecture.md
@@ -9,7 +9,7 @@ em workspaces privados para permitir migração incremental e testes explícitos
 | `harness` | Perfis, políticas, changes, sensores e verificação. |
 | `vault` | Keep Core, binding do projeto, kernel de memória e I/O local seguro. |
 | `mcp` | Transporte e configuração MCP. |
-| `integrations` | Adaptadores de eventos dos hosts de agentes. |
+| `integrations` | Regras puras de integração com hosts: hooks, envelopes, transcripts e identidade. |
 | `pi` | Extensão e hooks específicos do Pi. |
 
 ## Direção de dependências
@@ -25,6 +25,26 @@ adapters (cli/mcp/integrations/pi) -> Harness -> Vault
 canônico da resolução/política dos Perfis de Operação e da engine de sensores em
 `packages/harness/src/`; o `vault` continua dono do binding/resolução, da segurança física de paths
 e do kernel de memória em `packages/vault/src/`.
+
+## 0.66 Kernel de Integrations
+
+O workspace privado `@wendkeep/integrations`, em `packages/integrations/src/`, é a autoridade
+canônica para as regras puras compartilhadas por Claude Code e Codex: catálogo e projeção de
+hooks; parsing do envelope, detecção do provider e metadados; filtros e extração de conteúdo;
+normalização de uso; parsing e comparação de transcripts; e resolução de identidade de sessão e
+turno.
+
+Essa fronteira não opera stdin/stdout, consulta ambiente global, toca filesystem/Vault nem opera o
+registry. Esses efeitos continuam nas fachadas históricas em `hooks/` e `src/`, que
+reexportam os mesmos bindings e injetam os dados do host no kernel puro. Assim, os hooks e sessões
+de Claude/Codex permanecem semanticamente equivalentes, sem migração de Vault, config, paths ou
+schemas.
+
+MCP e Integrations são adapters irmãos, sem dependência entre si. Ambos seguem a direção
+`cli/mcp/integrations/pi → Harness → Vault`, e os testes de fronteira rejeitam ciclos ou acesso
+ambiental dentro do kernel. Integrations permanece interno ao tarball raiz: não há publicação npm
+separada de `@wendkeep/integrations` nem subpath público `wendkeep/integrations`. A próxima fase da
+migração modular é Pi.
 
 ## 0.65 Kernel de configuração MCP
 
@@ -109,7 +129,7 @@ migração de dados.
 
 Todos os seis workspaces permanecem privados e internos ao monorepo; eles não são pacotes npm
 independentes. A instalação continua sendo `wendkeep`; `wendkeep/harness` e `wendkeep/vault` são
-subpaths públicos do pacote raiz, não publicações separadas. CLI e MCP já possuem implementações
-canônicas privadas: a primeira continua exposta pelos binários e a segunda pelos efeitos do
-`init`. `integrations` e `pi` permanecem fronteiras reservadas; a sequência planejada da migração
-é MCP → Integrations → Pi.
+subpaths públicos do pacote raiz, não publicações separadas. CLI, MCP e Integrations já possuem
+implementações canônicas privadas: a primeira continua exposta pelos binários, a segunda pelos
+efeitos do `init` e a terceira pelas fachadas históricas de host. `pi` permanece a fronteira
+reservada e é a próxima fase planejada da migração.

--- a/docs/pt-BR/commands/getting-started.md
+++ b/docs/pt-BR/commands/getting-started.md
@@ -79,6 +79,14 @@ e adiciona `wendkeep-vault`. Se o JSON existente for inválido, o arquivo origin
 a byte intacto e a proposta reconciliada é gravada em `.mcp.json.new`. Desde a versão 0.65, essa
 composição pertence ao kernel MCP privado, sem alterar comandos, flags ou a superfície npm pública.
 
+As regras puras que projetam os hooks de Claude/Codex e interpretam envelopes, transcripts, uso e
+identidade pertencem ao workspace privado `@wendkeep/integrations`. As fachadas históricas mantêm
+os efeitos de stdin/stdout, ambiente, filesystem, Vault e registry. Isso não acrescenta comandos ou
+flags, não altera hooks ou sessões e não exige migração de cofre, config, paths ou schemas. MCP e
+Integrations permanecem adapters irmãos sem dependência, e a direção continua
+`cli/mcp/integrations/pi → Harness → Vault`. Tudo permanece dentro do único pacote publicado
+`wendkeep`; não existe `wendkeep/integrations` público. A próxima fase modular é Pi.
+
 ## Erros comuns e diagnóstico
 
 - Cofre errado: confira `.wendkeep.json` e rode `wendkeep doctor --vault <path>`.

--- a/hooks/obsidian-common.mjs
+++ b/hooks/obsidian-common.mjs
@@ -7,6 +7,26 @@ import { resolveProjectVault } from '../src/project-vault.mjs';
 import {
   assertVaultPathSafe, mkdirVaultPath, writeVaultFileAtomic,
 } from './vault-path-safety.mjs';
+import {
+  salvageTruncatedJson,
+  parseHookInput,
+  stringifyHookOutput,
+  detectProvider as detectProviderFromEnvironment,
+  providerMeta as providerMetaFromProvider,
+  extractHookPrompt,
+} from '../packages/integrations/src/hook-envelope.mjs';
+import {
+  isBootstrapPrompt,
+  redactSecrets,
+} from '../packages/integrations/src/prompt-content.mjs';
+import { transcriptsMatch } from '../packages/integrations/src/session-identity.mjs';
+export {
+  salvageTruncatedJson,
+  extractHookPrompt,
+  isBootstrapPrompt,
+  redactSecrets,
+  transcriptsMatch,
+};
 
 // Deprecated export kept for consumers that imported it before 0.39.0. Automatic
 // hooks never use this fallback: an unbound project fails closed.
@@ -27,56 +47,12 @@ export const VAULT_COMPLEMENT_RULES = [
   'Atualize `SHARED_MEMORY.md` somente quando a síntese mudar estado ativo que outro agente precise saber.',
 ];
 
-// Codex on Windows serializes the Stop payload with `last_assistant_message` cut mid-string
-// and never closed when the assistant text carries non-ASCII (openai/codex#23784). That field
-// is LAST in codex-rs's StopCommandInput, so everything wendkeep consumes — session_id,
-// turn_id, transcript_path, cwd — sits in the intact prefix.
-//
-// One pass, tracking quotes/escapes/depth, remembering the offset of the last top-level comma
-// that was NOT inside a string. Re-closing there yields the well-formed prefix. Deliberately
-// NOT a decreasing brute-force parse: this runs on every turn and the payload can be tens of
-// KB. The truncated field is dropped, never reconstructed — half an assistant message is
-// invented data, and it is the one field we do not need.
-export function salvageTruncatedJson(raw) {
-  const text = String(raw || '');
-  if (text[0] !== '{') return null;
-  let inString = false;
-  let escaped = false;
-  let depth = 0;
-  let lastBoundary = -1;
-  for (let i = 0; i < text.length; i += 1) {
-    const ch = text[i];
-    if (escaped) { escaped = false; continue; }
-    if (ch === '\\') { if (inString) escaped = true; continue; }
-    if (ch === '"') { inString = !inString; continue; }
-    if (inString) continue;
-    if (ch === '{' || ch === '[') depth += 1;
-    else if (ch === '}' || ch === ']') depth -= 1;
-    else if (ch === ',' && depth === 1) lastBoundary = i;
-  }
-  if (lastBoundary === -1) return null;
-  try {
-    const parsed = JSON.parse(`${text.slice(0, lastBoundary)}}`);
-    return parsed && typeof parsed === 'object' ? parsed : null;
-  } catch { return null; }
-}
-
 export function readHookInput() {
-  const raw = readFileSync(0, 'utf-8').trim();
-  if (!raw) return {};
-  try {
-    return JSON.parse(raw);
-  } catch (error) {
-    const salvaged = salvageTruncatedJson(raw);
-    // `_wk` prefix: the object is the harness payload merged with our own metadata, and a
-    // silent key collision here would be worse than the ugly prefix.
-    if (salvaged) return { ...salvaged, _wkSalvaged: true };
-    throw error;
-  }
+  return parseHookInput(readFileSync(0, 'utf-8'));
 }
 
 export function writeHookOutput(payload = {}) {
-  process.stdout.write(JSON.stringify(payload));
+  process.stdout.write(stringifyHookOutput(payload));
 }
 
 // Resolve from explicit hook payload or the nearest project-local binding. A legacy
@@ -118,17 +94,11 @@ export function warnIfDefaultVault(input = {}) {
 // Detecta o agente real que está executando o hook. Claude Code expõe
 // CLAUDECODE / CLAUDE_CODE_SESSION_ID / CLAUDE_PROJECT_DIR; Codex não.
 export function detectProvider() {
-  if (process.env.CLAUDECODE === '1' || process.env.CLAUDE_CODE_SESSION_ID || process.env.CLAUDE_PROJECT_DIR) {
-    return 'claude';
-  }
-  return 'codex';
+  return detectProviderFromEnvironment(process.env);
 }
 
 export function providerMeta(provider = detectProvider()) {
-  if (provider === 'claude') {
-    return { id: 'claude', label: 'Claude Code', tag: 'claude', source: 'claude-hook' };
-  }
-  return { id: 'codex', label: 'Codex', tag: 'codex', source: 'codex-hook' };
+  return providerMetaFromProvider(provider);
 }
 
 export function ensureDir(path) {
@@ -807,44 +777,6 @@ export function keysBate(a = '', b = '') {
   return a === b || a.startsWith(b) || b.startsWith(a);
 }
 
-export function extractHookPrompt(input = {}) {
-  const candidates = [
-    input.prompt,
-    input.user_prompt,
-    input.userPrompt,
-    input.message,
-    input.input,
-  ];
-
-  for (const candidate of candidates) {
-    if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
-  }
-
-  if (Array.isArray(input.messages)) {
-    const text = input.messages
-      .map((message) => message?.content || message?.text || '')
-      .filter((item) => typeof item === 'string' && item.trim())
-      .join('\n')
-      .trim();
-    if (text) return text;
-  }
-
-  return '';
-}
-
-export function isBootstrapPrompt(text = '') {
-  const clean = String(text || '').trim();
-  return clean.startsWith('# AGENTS.md instructions')
-    || clean.startsWith('<environment_context>')
-    || clean.startsWith('<permissions instructions>')
-    // Codex injects the available-plugins catalogue as the first userPrompt of turn 1.
-    // Anchored with startsWith on purpose: matching the bare substring would discard a
-    // legitimate prompt that merely asks about plugins.
-    || clean.startsWith('<recommended_plugins>')
-    || clean.includes('You are Codex, a coding agent')
-    || clean.startsWith('## Memory');
-}
-
 export function summarizePromptForTitle(text = '', fallback = 'session') {
   const cleaned = redactSecrets(String(text || ''))
     .replace(/\[@[^\]]+\]\([^)]+\)/g, ' ')
@@ -901,27 +833,6 @@ export function shouldReuseActiveSession(control = {}, now = new Date()) {
   return now.getTime() - startedMs <= windowMinutes * 60 * 1000;
 }
 
-function normalizeTranscript(p) {
-  return String(p || '').replace(/\\/g, '/').toLowerCase();
-}
-
-function transcriptBasename(p) {
-  const n = normalizeTranscript(p);
-  const i = n.lastIndexOf('/');
-  return i === -1 ? n : n.slice(i + 1);
-}
-
-// Mesmo transcript apesar de caixa/separador diferentes (o Claude Code emite o
-// slug do projeto ora `c--`, ora `C--`) ou prefixo de path diferente (WSL vs
-// Windows). Compara normalizado e, em último caso, pelo basename
-// (`<session_id>.jsonl`, globalmente único). Evita rupturas de sessão no restart.
-export function transcriptsMatch(a, b) {
-  if (!a || !b) return false;
-  if (normalizeTranscript(a) === normalizeTranscript(b)) return true;
-  const ba = transcriptBasename(a);
-  return !!ba && ba === transcriptBasename(b);
-}
-
 // O `transcript_path` é estável dentro de uma conversa mesmo quando o
 // SessionStart re-dispara (compactação/resume) com `session_id` novo. Achar a
 // sessão ativa do mesmo transcript evita criar placeholders `HH-MM-codex`.
@@ -938,17 +849,6 @@ export function findActiveSessionByTranscript(vaultBase, transcriptPath) {
     }
   }
   return best;
-}
-
-export function redactSecrets(text) {
-  if (!text) return '';
-  return String(text)
-    .replace(/\b(sk-[A-Za-z0-9_-]{12,})\b/g, '[REDACTED_SECRET]')
-    .replace(/\b(whsec_[A-Za-z0-9_/-]{8,})\b/g, '[REDACTED_SECRET]')
-    .replace(/\b(gh[pousr]_[A-Za-z0-9_]{12,})\b/g, '[REDACTED_SECRET]')
-    .replace(/\b(xox[baprs]-[A-Za-z0-9-]{12,})\b/g, '[REDACTED_SECRET]')
-    .replace(/\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY)[A-Z0-9_]*)\s*[:=]\s*["']?[^"'\s]+/gi, '$1=[REDACTED_SECRET]')
-    .replace(/:\/\/([^:\s/@]+):([^@\s/]+)@/g, '://[REDACTED_SECRET]@');
 }
 
 export function truncate(text, max = 240) {

--- a/hooks/session-identity.mjs
+++ b/hooks/session-identity.mjs
@@ -1,152 +1,37 @@
 import { existsSync, readFileSync } from 'fs';
 import { basename } from 'path';
-import { detectProvider, readSessionRegistry, transcriptsMatch } from './obsidian-common.mjs';
-
-function parseLines(path) {
-  if (!path || !existsSync(path)) return [];
-  return readFileSync(path, 'utf-8').split('\n').filter(Boolean).map((line) => {
-    try { return JSON.parse(line); } catch { return null; }
-  }).filter(Boolean);
-}
+import { detectProvider, readSessionRegistry } from './obsidian-common.mjs';
+import {
+  inspectTranscriptIdentityContent,
+  resolveSessionIdentitySnapshot,
+} from '../packages/integrations/src/session-identity.mjs';
 
 export function inspectTranscriptIdentity(transcriptPath) {
-  const lines = parseLines(transcriptPath);
-  const codexMeta = lines.find((event) => event.type === 'session_meta')?.payload;
-  if (codexMeta) {
-    return {
-      transcriptProvider: 'openai',
-      provider: 'codex',
-      canonicalConversationId: codexMeta.session_id || codexMeta.id || '',
-      transcriptId: codexMeta.id || basename(transcriptPath, '.jsonl'),
-      parentConversationId: codexMeta.parent_thread_id || codexMeta.forked_from_id || '',
-    };
-  }
-  const claudeEvent = lines.find((event) => event.sessionId);
-  if (claudeEvent) {
-    return {
-      transcriptProvider: 'anthropic',
-      provider: 'claude',
-      canonicalConversationId: claudeEvent.sessionId,
-      transcriptId: basename(transcriptPath, '.jsonl'),
-      parentConversationId: '',
-    };
-  }
-  return { transcriptProvider: 'unknown', provider: 'unknown', canonicalConversationId: '', transcriptId: '', parentConversationId: '' };
-}
-
-function compatible(provider, transcriptProvider) {
-  return (provider === 'codex' && transcriptProvider === 'openai')
-    || (provider === 'claude' && transcriptProvider === 'anthropic');
-}
-
-function canonicalUuid(value = '') {
-  const id = String(value || '').trim().toLowerCase();
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(id) ? id : '';
+  const content = transcriptPath && existsSync(transcriptPath)
+    ? readFileSync(transcriptPath, 'utf-8')
+    : '';
+  return inspectTranscriptIdentityContent(content, {
+    fallbackTranscriptId: transcriptPath ? basename(transcriptPath, '.jsonl') : '',
+  });
 }
 
 export function resolveSessionIdentity(vaultBase, input = {}, provider = detectProvider()) {
   const transcriptPath = input.transcript_path || input.transcriptPath || '';
-  const inspected = inspectTranscriptIdentity(transcriptPath);
-  const hookId = input.session_id || input.sessionId || '';
-  const codexThreadId = canonicalUuid(input.codex_thread_id || input.codexThreadId || process.env.CODEX_THREAD_ID || '');
-
-  // Codex Desktop exposes the stable canonical conversation through
-  // CODEX_THREAD_ID even when SessionStart/UserPromptSubmit omit transcript_path.
-  // This is safer than the hook session_id (which may rotate on resume). Once the
-  // rollout materializes, require both canonical sources to agree.
-  const transcriptConversationId = canonicalUuid(inspected.canonicalConversationId);
-  if (provider === 'codex' && transcriptConversationId && codexThreadId
-    && transcriptConversationId !== codexThreadId) {
-    return {
-      state: 'deferred', provider, transcriptPath,
-      diagnostics: [`CODEX_THREAD_ID diverge do session_id do transcript (${codexThreadId} != ${transcriptConversationId})`],
-    };
-  }
-  if (provider === 'codex' && !inspected.canonicalConversationId && codexThreadId) {
-    return {
-      state: 'resolved',
-      provider,
-      canonicalConversationId: codexThreadId,
-      hookSessionId: hookId,
-      transcriptPath,
-      transcriptId: transcriptPath ? basename(transcriptPath, '.jsonl') : codexThreadId,
-      parentConversationId: '',
-      diagnostics: [],
-    };
-  }
-
-  // Claude: input.session_id já é o id canônico e estável da conversa — idêntico
-  // ao sessionId que cada linha do transcript grava. Numa sessão nova o arquivo
-  // ainda não materializou em disco quando o hook roda, então inspectTranscriptIdentity
-  // volta vazio e o gate abaixo adiaria o 1º turno inteiro (SessionStart + 1º prompt
-  // sem nota; sessão curta nunca registrada). Não adiar: usar o hookId direto.
-  // Codex NÃO entra aqui de propósito — lá o id do hook no resume é efêmero e ≠ do
-  // thread canônico, então seguimos exigindo rollout/registry (incidente 2026-07-11,
-  // contaminação cross-provider de sessão).
-  if (provider === 'claude' && hookId && !inspected.canonicalConversationId) {
-    return {
-      state: 'resolved',
-      provider,
-      canonicalConversationId: hookId,
-      hookSessionId: hookId,
-      transcriptPath,
-      transcriptId: transcriptPath ? basename(transcriptPath, '.jsonl') : hookId,
-      parentConversationId: '',
-      diagnostics: [],
-    };
-  }
-
-  // Codex on Windows can deliver a Stop payload whose transcript_path never arrives (or is
-  // lost to a truncated JSON, openai/codex#23784). The registry already knows the mapping —
-  // the lookup below just sat under this gate, unreachable in the one case it solves. The
-  // comment above says we require "rollout/registry"; the registry half was never wired.
-  // Requiring the entry's provider to match preserves the cross-provider invariant from the
-  // 2026-07-11 incident: we are not minting a canonical id, we are finding an ALREADY
-  // REGISTERED session whose key is the hook's own id. A resume with a fresh id simply
-  // misses and stays deferred.
-  if (!transcriptPath && hookId) {
-    const entry = readSessionRegistry(vaultBase).sessions?.[hookId];
-    if (entry?.transcript_path && entry.provider === provider) {
-      return {
-        state: 'resolved',
-        provider,
-        canonicalConversationId: hookId,
-        hookSessionId: hookId,
-        transcriptPath: entry.transcript_path,
-        transcriptId: entry.transcript_id || basename(entry.transcript_path, '.jsonl'),
-        parentConversationId: '',
-        diagnostics: ['transcript recuperado do SESSION_REGISTRY'],
-      };
-    }
-  }
-
-  if (!transcriptPath || !inspected.canonicalConversationId) {
-    return { state: 'deferred', provider, transcriptPath, diagnostics: ['transcript ausente ou sem identidade canônica'] };
-  }
-  if (!compatible(provider, inspected.transcriptProvider)) {
-    return { state: 'deferred', provider, transcriptPath, diagnostics: [`provider ${provider} incompatível com transcript ${inspected.transcriptProvider}`] };
-  }
-
-  const registry = readSessionRegistry(vaultBase);
-  const byTranscript = Object.entries(registry.sessions || {}).find(([, entry]) => {
-    const paths = [...(Array.isArray(entry?.transcript_paths) ? entry.transcript_paths : []), entry?.transcript_path].filter(Boolean);
-    return paths.some((path) => transcriptsMatch(path, transcriptPath));
-  });
-  const canonicalConversationId = byTranscript?.[0] || inspected.canonicalConversationId;
-  return {
-    state: 'resolved',
+  return resolveSessionIdentitySnapshot({
+    input,
     provider,
-    canonicalConversationId,
-    hookSessionId: hookId,
+    codexThreadId: process.env.CODEX_THREAD_ID || '',
     transcriptPath,
-    transcriptId: inspected.transcriptId,
-    parentConversationId: inspected.parentConversationId,
-    diagnostics: [],
-  };
+    inspected: inspectTranscriptIdentity(transcriptPath),
+    registry: readSessionRegistry(vaultBase),
+  });
 }
 
 export function resolveSessionEntry(vaultBase, input = {}, provider = detectProvider()) {
   const identity = resolveSessionIdentity(vaultBase, input, provider);
   if (identity.state !== 'resolved') return { identity, entry: null };
-  return { identity, entry: readSessionRegistry(vaultBase).sessions?.[identity.canonicalConversationId] || null };
+  return {
+    identity,
+    entry: readSessionRegistry(vaultBase).sessions?.[identity.canonicalConversationId] || null,
+  };
 }

--- a/hooks/session-stop.mjs
+++ b/hooks/session-stop.mjs
@@ -23,6 +23,13 @@ import {
   stageStopMemoryAttempt,
 } from './session-memory-lifecycle.mjs';
 import {
+  parseClaudeTranscriptContent,
+  parseCodexTranscriptContent,
+  parseTranscriptContent,
+  resolveTurnIdentity,
+} from '../packages/integrations/src/transcripts.mjs';
+export { resolveTurnIdentity };
+import {
   ensureDir,
   findActiveSessionByTranscript,
   formatDate,
@@ -51,16 +58,6 @@ import {
   resolveStopActivation,
   applyStopActivation,
 } from './obsidian-common.mjs';
-
-function extractContentText(content) {
-  if (typeof content === 'string') return content;
-  if (!Array.isArray(content)) return '';
-  return content
-    .map((item) => item?.text || item?.input_text || item?.output_text || '')
-    .filter(Boolean)
-    .join('\n')
-    .trim();
-}
 
 // Tags injetadas pelo harness (não são fala humana): notificações de task,
 // reminders do sistema, stdout de comando local, wrappers de slash-command e
@@ -99,36 +96,6 @@ function createTurn(turnId = '', timestamp = '') {
     usage: emptyTokenUsage(),
     model: '',
   };
-}
-
-function addConversation(turn, role, value) {
-  if (!turn) return;
-  const text = redactSecrets(String(value || '').trim());
-  if (!text) return;
-  const exists = turn.conversation.some((item) => item.role === role && item.text === text);
-  if (!exists) turn.conversation.push({ role, text });
-}
-
-function extractPaths(text) {
-  const paths = [];
-  const addPath = (value) => {
-    const path = normalizeExtractedPath(value);
-    if (!shouldIgnoreExtractedPath(path) && !paths.includes(path)) paths.push(path);
-  };
-
-  const windowsRegex = /[A-Za-z]:[\\/]+[^"'`\r\n{}()[\],]+\.[A-Za-z0-9]+(?::\d+)?/g;
-  let match;
-  const source = String(text || '');
-  while ((match = windowsRegex.exec(source)) !== null) {
-    addPath(match[0]);
-  }
-
-  const masked = source.replace(windowsRegex, ' ');
-  const regex = /(?:^|[\s"'`(])((?:\/(?:home|mnt)\/|\.{1,2}\/|[A-Za-z0-9_.-]+\/)[A-Za-z0-9_./@+:-]+\.[A-Za-z0-9]+(?::\d+)?)/g;
-  while ((match = regex.exec(masked)) !== null) {
-    addPath(match[1]);
-  }
-  return paths.slice(0, 20);
 }
 
 const REPO_ROOT = String(process.cwd() || '')
@@ -196,361 +163,28 @@ function normalizeFileListLine(line) {
   return `- \`${normalizeExtractedPath(match[1])}\``;
 }
 
-function extractPatchFiles(text) {
-  const files = [];
-  const regex = /^\*\*\* (?:Add|Update|Delete) File:\s+(.+)$/gm;
-  let match;
-  while ((match = regex.exec(text || '')) !== null) addUnique(files, match[1]);
-  return files;
+function transcriptContent(transcriptPath) {
+  return transcriptPath && existsSync(transcriptPath)
+    ? readFileSync(transcriptPath, 'utf-8')
+    : '';
 }
 
-function parseToolArguments(args) {
-  if (!args) return {};
-  if (typeof args === 'object') return args;
-  try {
-    return JSON.parse(args);
-  } catch {
-    return { raw: String(args) };
-  }
-}
-
-function toolArgumentText(value) {
-  if (value == null) return '';
-  if (typeof value === 'string') return value;
-  if (Array.isArray(value)) return value.map(toolArgumentText).filter(Boolean).join('\n');
-  if (typeof value === 'object') return Object.values(value).map(toolArgumentText).filter(Boolean).join('\n');
-  return String(value);
+function transcriptOptions() {
+  let vaultRoot = '';
+  try { vaultRoot = getVaultBase(); } catch { /* projeto sem binding */ }
+  return { repoRoot: process.cwd(), vaultRoot };
 }
 
 export function parseCodexTranscript(transcriptPath) {
-  const result = {
-    provider: 'codex',
-    sessionId: '',
-    model: '',
-    latestTurnId: '',
-    latestUserPrompt: '',
-    latestAssistantMessage: '',
-    userPrompts: [],
-    assistantMessages: [],
-    tools: [],
-    consultedFiles: [],
-    changedFiles: [],
-    turns: [],
-    rawTextForDetection: '',
-  };
-
-  if (!transcriptPath || !existsSync(transcriptPath)) return result;
-
-  const eventUserPrompts = [];
-  let currentTurn = null;
-  const ensureTurn = (turnId = '', timestamp = '') => {
-    const normalized = turnId || currentTurn?.turnId || `turn-${result.turns.length + 1}`;
-    const existing = result.turns.find((turn) => turn.turnId === normalized);
-    if (existing) {
-      currentTurn = existing;
-      return existing;
-    }
-    currentTurn = createTurn(normalized, timestamp);
-    result.turns.push(currentTurn);
-    return currentTurn;
-  };
-
-  const lines = readFileSync(transcriptPath, 'utf-8').split('\n').filter(Boolean);
-  for (const line of lines) {
-    let event;
-    try { event = JSON.parse(line); } catch { continue; }
-
-    if (event.type === 'session_meta') {
-      result.sessionId = event.payload?.id || result.sessionId;
-      result.model = event.payload?.model || event.payload?.model_provider || result.model;
-      continue;
-    }
-
-    if (event.type === 'event_msg' && event.payload?.type === 'task_started') {
-      result.latestTurnId = event.payload.turn_id || result.latestTurnId;
-      ensureTurn(result.latestTurnId, event.timestamp);
-      continue;
-    }
-
-    if (event.type === 'turn_context') {
-      result.latestTurnId = event.payload?.turn_id || result.latestTurnId;
-      result.model = event.payload?.model || result.model;
-      ensureTurn(result.latestTurnId, event.timestamp);
-      continue;
-    }
-
-    if (event.type === 'event_msg' && event.payload?.type === 'user_message') {
-      const text = event.payload.message || '';
-      if (text && !shouldIgnoreUserText(text)) {
-        const turn = ensureTurn(event.payload.turn_id || result.latestTurnId, event.timestamp);
-        addUnique(eventUserPrompts, text);
-        addUnique(result.userPrompts, text);
-        addUnique(turn.userPrompts, text);
-        addConversation(turn, 'Usuário', text);
-      }
-      continue;
-    }
-
-    if (event.type === 'event_msg' && event.payload?.type === 'agent_message') {
-      const text = event.payload.message || event.payload.text || '';
-      if (text) {
-        const turn = ensureTurn(event.payload.turn_id || result.latestTurnId, event.timestamp);
-        addUnique(result.assistantMessages, text);
-        addUnique(turn.assistantMessages, text);
-        addConversation(turn, 'Assistente', text);
-      }
-      continue;
-    }
-
-    if (event.type === 'event_msg' && event.payload?.type === 'token_count') {
-      const raw = event.payload?.info?.last_token_usage;
-      if (raw) {
-        const turn = currentTurn || ensureTurn(result.latestTurnId, event.timestamp);
-        addUsage(turn.usage, normalizeCodexUsage(raw));
-        if (event.payload?.info?.model) turn.model = event.payload.info.model;
-      }
-      continue;
-    }
-
-    if (event.type !== 'response_item') continue;
-    const payload = event.payload || {};
-
-    if (payload.type === 'message') {
-      const text = extractContentText(payload.content);
-      if (!text) continue;
-      const turn = ensureTurn(payload.turn_id || event.turn_id || result.latestTurnId, event.timestamp);
-      if (payload.role === 'user' && !shouldIgnoreUserText(text)) {
-        addUnique(result.userPrompts, text);
-        addUnique(turn.userPrompts, text);
-        addConversation(turn, 'Usuário', text);
-      }
-      if (payload.role === 'assistant') {
-        addUnique(result.assistantMessages, text);
-        addUnique(turn.assistantMessages, text);
-        addConversation(turn, 'Assistente', text);
-      }
-      continue;
-    }
-
-    if (payload.type === 'function_call') {
-      addUnique(result.tools, payload.name || 'function_call');
-      const turn = ensureTurn(payload.turn_id || event.turn_id || result.latestTurnId, event.timestamp);
-      addUnique(turn.tools, payload.name || 'function_call');
-      const parsed = parseToolArguments(payload.arguments);
-      const combined = typeof parsed.raw === 'string'
-        ? parsed.raw
-        : toolArgumentText(parsed);
-
-      for (const path of extractPaths(combined)) {
-        addUnique(result.consultedFiles, path);
-        addUnique(turn.consultedFiles, path);
-      }
-      for (const path of extractPatchFiles(combined)) {
-        addUnique(result.changedFiles, path);
-        addUnique(turn.changedFiles, path);
-      }
-
-      if (/apply_patch|edit|write|create/i.test(payload.name || '')) {
-        for (const path of extractPaths(combined)) {
-          addUnique(result.changedFiles, path);
-          addUnique(turn.changedFiles, path);
-        }
-      }
-    }
-
-    if (payload.type === 'tool_search_call') {
-      const turn = ensureTurn(payload.turn_id || event.turn_id || result.latestTurnId, event.timestamp);
-      addUnique(result.tools, 'tool_search');
-      addUnique(turn.tools, 'tool_search');
-    }
-    if (payload.type === 'web_search_call') {
-      const turn = ensureTurn(payload.turn_id || event.turn_id || result.latestTurnId, event.timestamp);
-      addUnique(result.tools, 'web_search');
-      addUnique(turn.tools, 'web_search');
-    }
-  }
-
-  for (const prompt of eventUserPrompts) addUnique(result.userPrompts, prompt);
-  const latestTurn = result.turns.find((turn) => turn.turnId === result.latestTurnId)
-    || result.turns.at(-1);
-  result.latestUserPrompt = latestTurn?.userPrompts.at(-1)
-    || eventUserPrompts.at(-1)
-    || result.userPrompts.at(-1)
-    || '';
-  result.latestAssistantMessage = latestTurn?.assistantMessages.at(-1)
-    || result.assistantMessages.at(-1)
-    || '';
-  result.rawTextForDetection = redactSecrets([
-    ...result.userPrompts,
-    ...result.assistantMessages,
-  ].join('\n\n'));
-
-  return result;
+  return parseCodexTranscriptContent(transcriptContent(transcriptPath), transcriptOptions());
 }
 
-// Texto humano de uma mensagem de usuário do Claude Code: mantém só blocos
-// `text`, descartando tool_result e contexto injetado (system-reminder etc.).
-function claudeUserText(content) {
-  if (typeof content === 'string') return content.trim();
-  if (!Array.isArray(content)) return '';
-  return content
-    .map((block) => (typeof block === 'string' ? block : (block?.type === 'text' ? block.text || '' : '')))
-    .map((text) => String(text || '').trim())
-    .filter((text) => text && !text.startsWith('<'))
-    .join('\n')
-    .trim();
-}
-
-// Parser do transcript do Claude Code. Schema por linha:
-// { type:'user'|'assistant', message:{ role, content:[{type:'text'|'thinking'|'tool_use'|'tool_result',...}] } }.
-// Diferente do Codex (sem `payload`), por isso precisa de parser próprio.
 export function parseClaudeTranscript(transcriptPath) {
-  const result = {
-    provider: 'claude',
-    sessionId: '',
-    model: '',
-    latestTurnId: '',
-    latestUserPrompt: '',
-    latestAssistantMessage: '',
-    userPrompts: [],
-    assistantMessages: [],
-    tools: [],
-    consultedFiles: [],
-    changedFiles: [],
-    turns: [],
-    rawTextForDetection: '',
-  };
-
-  if (!transcriptPath || !existsSync(transcriptPath)) return result;
-
-  let currentTurn = null;
-  const ensureTurn = (turnId = '', timestamp = '') => {
-    const normalized = turnId || currentTurn?.turnId || `turn-${result.turns.length + 1}`;
-    const existing = result.turns.find((turn) => turn.turnId === normalized);
-    if (existing) {
-      currentTurn = existing;
-      return existing;
-    }
-    currentTurn = createTurn(normalized, timestamp);
-    result.turns.push(currentTurn);
-    return currentTurn;
-  };
-
-  const recordToolFiles = (turn, name, input) => {
-    const text = toolArgumentText(input);
-    for (const path of extractPaths(text)) {
-      addUnique(result.consultedFiles, path);
-      addUnique(turn.consultedFiles, path);
-    }
-    for (const path of extractPatchFiles(text)) {
-      addUnique(result.changedFiles, path);
-      addUnique(turn.changedFiles, path);
-    }
-    if (/edit|write|create|apply_patch|notebook/i.test(name)) {
-      for (const path of extractPaths(text)) {
-        addUnique(result.changedFiles, path);
-        addUnique(turn.changedFiles, path);
-      }
-    }
-  };
-
-  const lines = readFileSync(transcriptPath, 'utf-8').split('\n').filter(Boolean);
-  for (const line of lines) {
-    let event;
-    try { event = JSON.parse(line); } catch { continue; }
-    if (event.isSidechain || event.isMeta) continue;
-    if (event.sessionId && !result.sessionId) result.sessionId = event.sessionId;
-
-    if (event.type === 'user') {
-      const text = claudeUserText(event.message?.content);
-      if (!text || shouldIgnoreUserText(text)) continue;
-      const turn = ensureTurn(event.uuid || event.promptId || event.timestamp || '', event.timestamp || '');
-      result.latestTurnId = turn.turnId;
-      addUnique(result.userPrompts, text);
-      addUnique(turn.userPrompts, text);
-      addConversation(turn, 'Usuário', text);
-      continue;
-    }
-
-    if (event.type === 'assistant') {
-      const turn = currentTurn || ensureTurn(event.uuid || event.timestamp || '', event.timestamp || '');
-      result.model = event.message?.model || result.model;
-      if (event.message?.model) turn.model = event.message.model;
-      if (event.message?.usage) addUsage(turn.usage, normalizeClaudeUsage(event.message.usage));
-      const content = Array.isArray(event.message?.content) ? event.message.content : [];
-      for (const block of content) {
-        if (!block) continue;
-        if (block.type === 'text' && block.text && block.text.trim()) {
-          addUnique(result.assistantMessages, block.text);
-          addUnique(turn.assistantMessages, block.text);
-          addConversation(turn, 'Assistente', block.text);
-        } else if (block.type === 'tool_use') {
-          const name = block.name || 'tool_use';
-          addUnique(result.tools, name);
-          addUnique(turn.tools, name);
-          recordToolFiles(turn, name, block.input);
-        }
-      }
-      continue;
-    }
-  }
-
-  const latestTurn = result.turns.find((turn) => turn.turnId === result.latestTurnId)
-    || result.turns.at(-1);
-  result.latestUserPrompt = latestTurn?.userPrompts.at(-1) || result.userPrompts.at(-1) || '';
-  result.latestAssistantMessage = latestTurn?.assistantMessages.at(-1) || result.assistantMessages.at(-1) || '';
-  result.rawTextForDetection = redactSecrets([
-    ...result.userPrompts,
-    ...result.assistantMessages,
-  ].join('\n\n'));
-
-  return result;
+  return parseClaudeTranscriptContent(transcriptContent(transcriptPath), transcriptOptions());
 }
 
-function looksLikeCodexEvent(event) {
-  return event.payload !== undefined
-    || event.type === 'session_meta'
-    || event.type === 'response_item'
-    || event.type === 'turn_context'
-    || event.type === 'event_msg';
-}
-
-function looksLikeClaudeEvent(event) {
-  return (event.type === 'user' || event.type === 'assistant') && event.message !== undefined;
-}
-
-// Despacha para o parser certo conforme o schema do transcript (Codex x Claude),
-// já que o mesmo hook Stop atende os dois agentes.
 export function parseTranscript(transcriptPath) {
-  if (!transcriptPath || !existsSync(transcriptPath)) return parseCodexTranscript(transcriptPath);
-  const lines = readFileSync(transcriptPath, 'utf-8').split('\n').filter(Boolean);
-  for (const line of lines) {
-    let event;
-    try { event = JSON.parse(line); } catch { continue; }
-    if (looksLikeCodexEvent(event)) return parseCodexTranscript(transcriptPath);
-    if (looksLikeClaudeEvent(event)) return parseClaudeTranscript(transcriptPath);
-  }
-  return parseCodexTranscript(transcriptPath);
-}
-
-export function resolveTurnIdentity(transcript, requestedTurnId = '') {
-  const turns = Array.isArray(transcript?.turns) ? transcript.turns : [];
-  const requested = String(requestedTurnId || '');
-  let index = requested
-    ? turns.findIndex((turn) => String(turn?.turnId || '') === requested)
-    : -1;
-  if (requested && index < 0) return null;
-  if (index < 0 && transcript?.latestTurnId) {
-    index = turns.findIndex((turn) => String(turn?.turnId || '') === String(transcript.latestTurnId));
-  }
-  if (index < 0) index = turns.length - 1;
-  const turn = turns[index];
-  if (!turn?.turnId) return null;
-  return {
-    id: String(turn.turnId),
-    order: index + 1,
-    observedAt: String(turn.timestamp || ''),
-  };
+  return parseTranscriptContent(transcriptContent(transcriptPath), transcriptOptions());
 }
 
 function escapeMarkdownBackticks(text) {

--- a/hooks/token-usage.mjs
+++ b/hooks/token-usage.mjs
@@ -8,6 +8,18 @@ import {
   readControl,
   truncate,
 } from './obsidian-common.mjs';
+import {
+  addUsage,
+  emptyTokenUsage,
+  normalizeClaudeUsage,
+  normalizeCodexUsage,
+} from '../packages/integrations/src/transcript-usage.mjs';
+export {
+  addUsage,
+  emptyTokenUsage,
+  normalizeClaudeUsage,
+  normalizeCodexUsage,
+};
 
 // Preços API por milhão de tokens. cachedInput = cache read.
 // Cache write: 5m = 1.25x input, 1h = 2x input (multiplicadores em calculateCost).
@@ -180,62 +192,6 @@ const MANAGED_FRONTMATTER_KEYS = new Set([
 // input = tokens de entrada NÃO cacheados; cached = cache read; cacheWrite = cache write
 // (cacheWrite1h = subparcela 1h, para custo 2x); thinking = tokens de raciocínio
 // (Claude: estimado de chars/3.5; Codex: reasoning_output_tokens, já contidos em output).
-export function emptyTokenUsage() {
-  return {
-    input: 0,
-    cached: 0,
-    cacheWrite: 0,
-    cacheWrite1h: 0,
-    output: 0,
-    reasoning: 0,
-    total: 0,
-  };
-}
-
-// Formato Codex: cached_input_tokens é SUBCONJUNTO de input_tokens — separa aqui.
-export function normalizeCodexUsage(raw = {}) {
-  const inputAll = Number(raw.input_tokens || 0);
-  const cached = Math.min(Number(raw.cached_input_tokens || 0), inputAll);
-  const output = Number(raw.output_tokens || 0);
-  return {
-    input: inputAll - cached,
-    cached,
-    cacheWrite: 0,
-    cacheWrite1h: 0,
-    output,
-    reasoning: Number(raw.reasoning_output_tokens || 0),
-    total: Number(raw.total_tokens || 0) || inputAll + output,
-  };
-}
-
-// Formato Claude Code: campos já disjuntos.
-export function normalizeClaudeUsage(raw = {}) {
-  const input = Number(raw.input_tokens || 0);
-  const cached = Number(raw.cache_read_input_tokens || 0);
-  const cacheWrite = Number(raw.cache_creation_input_tokens || 0);
-  const cacheWrite1h = Number(raw.cache_creation?.ephemeral_1h_input_tokens || 0);
-  const output = Number(raw.output_tokens || 0);
-  return {
-    input,
-    cached,
-    cacheWrite,
-    cacheWrite1h: Math.min(cacheWrite1h, cacheWrite),
-    output,
-    reasoning: 0,
-    total: input + cached + cacheWrite + output,
-  };
-}
-
-export function addUsage(target, usage) {
-  target.input += usage.input;
-  target.cached += usage.cached;
-  target.cacheWrite += usage.cacheWrite;
-  target.cacheWrite1h += usage.cacheWrite1h;
-  target.output += usage.output;
-  target.reasoning += usage.reasoning;
-  target.total += usage.total;
-}
-
 function normalizeModelName(model) {
   const clean = String(model || 'unknown').trim() || 'unknown';
   // Strip a trailing context-window tag (e.g. `claude-opus-4-8[1m]`, `claude-fable-5[1m]`) so the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.65.0",
+      "version": "0.66.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [
@@ -9,7 +9,16 @@
   "exports": {
     "./harness": "./packages/harness/src/index.mjs",
     "./vault": "./packages/vault/src/index.mjs",
-    "./*": "./*"
+    "./hooks/*": "./hooks/*",
+    "./src/*": "./src/*",
+    "./bin/*": "./bin/*",
+    "./schema/*": "./schema/*",
+    "./docs/*": "./docs/*",
+    "./package.json": "./package.json",
+    "./README.md": "./README.md",
+    "./README.en.md": "./README.en.md",
+    "./CHANGELOG.md": "./CHANGELOG.md",
+    "./LICENSE": "./LICENSE"
   },
   "bin": {
     "wendkeep": "bin/wendkeep.mjs",
@@ -31,8 +40,8 @@
     "node": ">=18"
   },
   "scripts": {
-    "check": "node --check bin/wendkeep.mjs && node --check packages/cli/src/index.mjs && node --check src/init.mjs && node --check src/doctor.mjs && node --check src/project-vault.mjs && node --check src/operating-profile.mjs && node --check src/profile.mjs && node --check src/flow.mjs && node --check hooks/operating-profile-runtime.mjs && node --check hooks/flow-core.mjs && node --check hooks/flow-protected-policy.mjs && node --check hooks/git-snapshot.mjs && node --check hooks/vault-path-safety.mjs && node --check hooks/vault-runtime-store.mjs && node --check packages/harness/src/index.mjs && node --check packages/harness/src/flow-store.mjs && node --check packages/harness/src/operating-profile.mjs && node --check packages/harness/src/sensors-core.mjs && node --check packages/mcp/src/config.mjs && node --check packages/mcp/src/index.mjs && node --check packages/vault/src/index.mjs && node --check packages/vault/src/project-vault.mjs && node --check packages/vault/src/vault-path-safety.mjs && node --check packages/vault/src/locale.mjs && node --check packages/vault/src/memory-schema.mjs && node --check packages/vault/src/memory-mode.mjs && node --check packages/vault/src/memory-handoff.mjs && node --check packages/vault/src/memory-store.mjs && node --check packages/vault/src/validate-core.mjs && node --check packages/vault/src/validate-memory.mjs",
-    "test": "node --test",
+    "check": "node --check bin/wendkeep.mjs && node --check packages/cli/src/index.mjs && node --check src/init.mjs && node --check src/doctor.mjs && node --check src/project-vault.mjs && node --check src/operating-profile.mjs && node --check src/profile.mjs && node --check src/flow.mjs && node --check hooks/operating-profile-runtime.mjs && node --check hooks/flow-core.mjs && node --check hooks/flow-protected-policy.mjs && node --check hooks/git-snapshot.mjs && node --check hooks/vault-path-safety.mjs && node --check hooks/vault-runtime-store.mjs && node --check packages/harness/src/index.mjs && node --check packages/harness/src/flow-store.mjs && node --check packages/harness/src/operating-profile.mjs && node --check packages/harness/src/sensors-core.mjs && node --check packages/integrations/src/host-hooks.mjs && node --check packages/integrations/src/hook-envelope.mjs && node --check packages/integrations/src/prompt-content.mjs && node --check packages/integrations/src/transcript-usage.mjs && node --check packages/integrations/src/transcripts.mjs && node --check packages/integrations/src/session-identity.mjs && node --check packages/integrations/src/index.mjs && node --check packages/mcp/src/config.mjs && node --check packages/mcp/src/index.mjs && node --check packages/vault/src/index.mjs && node --check packages/vault/src/project-vault.mjs && node --check packages/vault/src/vault-path-safety.mjs && node --check packages/vault/src/locale.mjs && node --check packages/vault/src/memory-schema.mjs && node --check packages/vault/src/memory-mode.mjs && node --check packages/vault/src/memory-handoff.mjs && node --check packages/vault/src/memory-store.mjs && node --check packages/vault/src/validate-core.mjs && node --check packages/vault/src/validate-memory.mjs",
+    "test": "node --test --test-concurrency=2",
     "release": "node scripts/release.mjs",
     "release:dry": "node scripts/release.mjs --dry-run",
     "prepack": "node scripts/readme-pack.mjs pre",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@wendkeep/integrations",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "exports": "./src/index.mjs"
 }

--- a/packages/integrations/src/hook-envelope.mjs
+++ b/packages/integrations/src/hook-envelope.mjs
@@ -1,0 +1,103 @@
+// Pure host-envelope rules. This module deliberately has no ambient process or I/O access:
+// legacy adapters inject stdin, stdout, and environment at their boundary.
+
+// Codex on Windows can serialize a Stop payload with the final
+// `last_assistant_message` cut mid-string. Everything consumed by WendKeep precedes that
+// field, so retain the last complete top-level object prefix without inventing truncated
+// content. A single pass avoids repeatedly parsing payloads that may be tens of KB.
+export function salvageTruncatedJson(raw) {
+  const text = String(raw ?? '');
+  if (text[0] !== '{') return null;
+
+  let inString = false;
+  let escaped = false;
+  let depth = 0;
+  let lastBoundary = -1;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      if (inString) escaped = true;
+      continue;
+    }
+    if (character === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+
+    if (character === '{' || character === '[') depth += 1;
+    else if (character === '}' || character === ']') depth -= 1;
+    else if (character === ',' && depth === 1) lastBoundary = index;
+  }
+
+  if (lastBoundary === -1) return null;
+  try {
+    const parsed = JSON.parse(`${text.slice(0, lastBoundary)}}`);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseHookInput(raw) {
+  const text = String(raw ?? '').trim();
+  if (!text) return {};
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    const salvaged = salvageTruncatedJson(text);
+    if (salvaged) return { ...salvaged, _wkSalvaged: true };
+    throw error;
+  }
+}
+
+export function stringifyHookOutput(payload = {}) {
+  return JSON.stringify(payload);
+}
+
+export function detectProvider(environment = {}) {
+  if (environment.CLAUDECODE === '1'
+    || environment.CLAUDE_CODE_SESSION_ID
+    || environment.CLAUDE_PROJECT_DIR) {
+    return 'claude';
+  }
+  return 'codex';
+}
+
+export function providerMeta(provider) {
+  if (provider === 'claude') {
+    return { id: 'claude', label: 'Claude Code', tag: 'claude', source: 'claude-hook' };
+  }
+  return { id: 'codex', label: 'Codex', tag: 'codex', source: 'codex-hook' };
+}
+
+export function extractHookPrompt(input = {}) {
+  const candidates = [
+    input.prompt,
+    input.user_prompt,
+    input.userPrompt,
+    input.message,
+    input.input,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
+  }
+
+  if (Array.isArray(input.messages)) {
+    const text = input.messages
+      .map((message) => message?.content || message?.text || '')
+      .filter((item) => typeof item === 'string' && item.trim())
+      .join('\n')
+      .trim();
+    if (text) return text;
+  }
+
+  return '';
+}

--- a/packages/integrations/src/host-hooks.mjs
+++ b/packages/integrations/src/host-hooks.mjs
@@ -1,0 +1,80 @@
+// Host hook specifications shared by the installer and CLI. This catalog is
+// data-only and side-effect free so host adapters can import it cheaply.
+
+// The three Claude Code session hooks, expressed as `wendkeep hook <name>` so the
+// installed package is the single source of truth (update with `npm update wendkeep`,
+// no re-copying). Returned as a spec the merge logic folds into settings.json.
+export const SESSION_HOOKS = [
+  // Memory + active-change injection. Runs FIRST on SessionStart (order -10, folds before
+  // session-start) so the agent gets CORE + DIGEST + the active change + lessons as context.
+  // matcher 'startup|clear|compact' re-injects after a compaction/clear, not only cold startup.
+  // timeout 45 (was 15): measured ~4s warm via npx, but Windows startup contention (several npx
+  // cold-starts at once — a sibling MCP took 26s in a real log) blew 15s and silently dropped the
+  // memory injection for the whole session.
+  { event: 'SessionStart', matcher: 'startup|clear|compact', name: 'brain-inject', timeout: 45, order: -10, codex: true, statusMessage: 'wendkeep: injecting memory + active change' },
+  { event: 'SessionStart', matcher: 'startup', name: 'session-start', timeout: 30, codex: true, statusMessage: 'wendkeep: opening Obsidian session' },
+  { event: 'Stop', matcher: null, name: 'session-stop', timeout: 60, codex: true, statusMessage: 'wendkeep: writing session checkpoint' },
+  { event: 'UserPromptSubmit', matcher: null, name: 'session-ensure', timeout: 30, codex: true, statusMessage: 'wendkeep: ensuring active session' },
+  // Capture an interactive decision (AskUserQuestion) — options + the user's choice — into 04-Decisões.
+  // codex: AskUserQuestion is a Claude-only tool; there is nothing to match on.
+  { event: 'PostToolUse', matcher: 'AskUserQuestion', name: 'decision-capture', timeout: 15, statusMessage: 'wendkeep: recording decision' },
+  // Refresh subagent/workflow telemetry as each subagent finishes (resilient to a missed Stop).
+  { event: 'SubagentStop', matcher: null, name: 'subagent-stop', timeout: 20, codex: true, statusMessage: 'wendkeep: subagent telemetry' },
+  // Log plan/task progress into the active session note when a task is marked complete.
+  // codex: TaskCompleted is not in Codex's hook event enum.
+  { event: 'TaskCompleted', matcher: null, name: 'task-log', timeout: 10, statusMessage: 'wendkeep: plan progress' },
+];
+
+export function hookCommand(name) {
+  return `npx wendkeep hook ${name}`;
+}
+
+// Forma node-direta do comando de hook: 1 processo (~100-250ms) em vez dos 3 do npx (cold-start
+// de segundos no Windows). Usada pelos hooks de ALTA FREQUÊNCIA (por prompt / por tool-call)
+// quando o projeto tem wendkeep instalado localmente; o init decide (hookCommandFor).
+export function hookCommandLocal(name) {
+  return `node "${'${CLAUDE_PROJECT_DIR}'}/node_modules/wendkeep/hooks/${name}.mjs"`;
+}
+
+export function hookCommandLocalLegacy(name) {
+  return `node node_modules/wendkeep/hooks/${name}.mjs`;
+}
+
+// Hooks do lifecycle de change (0.31.0) — enforcement do loop a2. Nudges (contexto/aviso/
+// cobrança/captura de plano) e gate (deny/ask no Bash). Separados em dois grupos para
+// preservar a opção futura de gates opt-in; hoje o init wira TODOS por default.
+// preferLocal: alta frequência → invocação node-direta quando houver instalação local.
+export const CHANGE_NUDGE_HOOKS = [
+  { event: 'UserPromptSubmit', matcher: null, name: 'change-context', timeout: 15, order: 10, preferLocal: true, codex: true, statusMessage: 'wendkeep: change ping' },
+  // codex: reads tool_input.file_path, which Codex's apply_patch envelope does not carry.
+  { event: 'PostToolUse', matcher: 'Edit|Write|MultiEdit', name: 'change-warn', timeout: 10, order: 10, preferLocal: true, statusMessage: 'wendkeep: change warn' },
+  // codex: no ExitPlanMode equivalent — update_plan is the running TODO list, not an approval.
+  { event: 'PostToolUse', matcher: 'ExitPlanMode', name: 'plan-capture', timeout: 15, order: 10, preferLocal: true, statusMessage: 'wendkeep: capturing approved plan' },
+  { event: 'Stop', matcher: null, name: 'change-nag', timeout: 15, order: 10, preferLocal: true, codex: true, statusMessage: 'wendkeep: open tasks check' },
+];
+
+export const CHANGE_GATE_HOOKS = [
+  // codex: reads tool_input.command; Codex's exec sends a raw string and exec_command an argv,
+  // so the guard would silently fail OPEN — worse than absent, since the docs would promise it.
+  { event: 'PreToolUse', matcher: 'Bash', name: 'change-guard', timeout: 10, order: 10, preferLocal: true, statusMessage: 'wendkeep: change gate' },
+];
+
+// --- Codex projection ---------------------------------------------------------
+// Codex reads <project>/.codex/hooks.json (PascalCase event keys, same group shape as
+// Claude's settings.json). Only specs that opt in with `codex: true` are projected — the
+// rest carry a `// codex:` comment above them saying why. Three deltas from Claude, each
+// verified against codex-rs and each silent when wrong: the timeout key is `timeoutSec`
+// (`timeout` is not a field and falls through to a 600s default), there is no
+// ${CLAUDE_PROJECT_DIR} so `preferLocal` never applies, and matcher is only honoured on
+// SessionStart (UserPromptSubmit/Stop null it at discovery).
+export const CODEX_MATCHER_EVENTS = new Set(['SessionStart']);
+
+export function codexHookSpecs(specs) {
+  return specs.filter((h) => h.codex === true && !h.command);
+}
+
+export function codexHookEntry(spec) {
+  const entry = { type: 'command', command: hookCommand(spec.name), timeoutSec: spec.timeout };
+  if (spec.statusMessage) entry.statusMessage = spec.statusMessage;
+  return entry;
+}

--- a/packages/integrations/src/index.mjs
+++ b/packages/integrations/src/index.mjs
@@ -1,0 +1,6 @@
+export * from './host-hooks.mjs';
+export * from './hook-envelope.mjs';
+export * from './prompt-content.mjs';
+export * from './transcript-usage.mjs';
+export * from './transcripts.mjs';
+export * from './session-identity.mjs';

--- a/packages/integrations/src/prompt-content.mjs
+++ b/packages/integrations/src/prompt-content.mjs
@@ -1,0 +1,20 @@
+export function isBootstrapPrompt(text = '') {
+  const clean = String(text || '').trim();
+  return clean.startsWith('# AGENTS.md instructions')
+    || clean.startsWith('<environment_context>')
+    || clean.startsWith('<permissions instructions>')
+    || clean.startsWith('<recommended_plugins>')
+    || clean.includes('You are Codex, a coding agent')
+    || clean.startsWith('## Memory');
+}
+
+export function redactSecrets(text) {
+  if (!text) return '';
+  return String(text)
+    .replace(/\b(sk-[A-Za-z0-9_-]{12,})\b/g, '[REDACTED_SECRET]')
+    .replace(/\b(whsec_[A-Za-z0-9_/-]{8,})\b/g, '[REDACTED_SECRET]')
+    .replace(/\b(gh[pousr]_[A-Za-z0-9_]{12,})\b/g, '[REDACTED_SECRET]')
+    .replace(/\b(xox[baprs]-[A-Za-z0-9-]{12,})\b/g, '[REDACTED_SECRET]')
+    .replace(/\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY)[A-Z0-9_]*)\s*[:=]\s*["']?[^"'\s]+/gi, '$1=[REDACTED_SECRET]')
+    .replace(/:\/\/([^:\s/@]+):([^@\s/]+)@/g, '://[REDACTED_SECRET]@');
+}

--- a/packages/integrations/src/session-identity.mjs
+++ b/packages/integrations/src/session-identity.mjs
@@ -1,0 +1,171 @@
+function parseJsonLines(content = '') {
+  return String(content || '').split('\n').filter(Boolean).map((line) => {
+    try { return JSON.parse(line); } catch { return null; }
+  }).filter(Boolean);
+}
+
+export function inspectTranscriptIdentityContent(content, { fallbackTranscriptId = '' } = {}) {
+  const lines = parseJsonLines(content);
+  const codexMeta = lines.find((event) => event.type === 'session_meta')?.payload;
+  if (codexMeta) {
+    return {
+      transcriptProvider: 'openai',
+      provider: 'codex',
+      canonicalConversationId: codexMeta.session_id || codexMeta.id || '',
+      transcriptId: codexMeta.id || fallbackTranscriptId,
+      parentConversationId: codexMeta.parent_thread_id || codexMeta.forked_from_id || '',
+    };
+  }
+  const claudeEvent = lines.find((event) => event.sessionId);
+  if (claudeEvent) {
+    return {
+      transcriptProvider: 'anthropic',
+      provider: 'claude',
+      canonicalConversationId: claudeEvent.sessionId,
+      transcriptId: fallbackTranscriptId,
+      parentConversationId: '',
+    };
+  }
+  return {
+    transcriptProvider: 'unknown',
+    provider: 'unknown',
+    canonicalConversationId: '',
+    transcriptId: '',
+    parentConversationId: '',
+  };
+}
+
+function compatible(provider, transcriptProvider) {
+  return (provider === 'codex' && transcriptProvider === 'openai')
+    || (provider === 'claude' && transcriptProvider === 'anthropic');
+}
+
+function canonicalUuid(value = '') {
+  const id = String(value || '').trim().toLowerCase();
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(id) ? id : '';
+}
+
+function pathBasename(path = '') {
+  const normalized = String(path || '').replace(/\\/g, '/');
+  return normalized.slice(normalized.lastIndexOf('/') + 1).replace(/\.jsonl$/i, '');
+}
+
+function providerMatches(entry, provider) {
+  return entry?.provider === provider;
+}
+
+export function transcriptsMatch(a, b) {
+  if (!a || !b) return false;
+  const normalize = (path) => String(path || '').replace(/\\/g, '/').toLowerCase();
+  const normalizedA = normalize(a);
+  const normalizedB = normalize(b);
+  if (normalizedA === normalizedB) return true;
+  const basename = (path) => path.slice(path.lastIndexOf('/') + 1);
+  const basenameA = basename(normalizedA);
+  return Boolean(basenameA) && basenameA === basename(normalizedB);
+}
+
+export function resolveSessionIdentitySnapshot({
+  input = {},
+  provider = 'codex',
+  codexThreadId = '',
+  transcriptPath = '',
+  inspected = {},
+  registry = { version: 2, sessions: {} },
+} = {}) {
+  const explicitTranscriptPath = String(transcriptPath || '');
+  const hookId = input.session_id || input.sessionId || '';
+  const threadId = canonicalUuid(
+    input.codex_thread_id || input.codexThreadId || codexThreadId || '',
+  );
+  const transcriptConversationId = canonicalUuid(inspected.canonicalConversationId);
+
+  if (provider === 'codex' && transcriptConversationId && threadId
+    && transcriptConversationId !== threadId) {
+    return {
+      state: 'deferred',
+      provider,
+      transcriptPath: explicitTranscriptPath,
+      diagnostics: [`CODEX_THREAD_ID diverge do session_id do transcript (${threadId} != ${transcriptConversationId})`],
+    };
+  }
+
+  if (provider === 'codex' && !inspected.canonicalConversationId && threadId) {
+    return {
+      state: 'resolved',
+      provider,
+      canonicalConversationId: threadId,
+      hookSessionId: hookId,
+      transcriptPath: explicitTranscriptPath,
+      transcriptId: explicitTranscriptPath ? pathBasename(explicitTranscriptPath) : threadId,
+      parentConversationId: '',
+      diagnostics: [],
+    };
+  }
+
+  if (provider === 'claude' && hookId && !inspected.canonicalConversationId) {
+    return {
+      state: 'resolved',
+      provider,
+      canonicalConversationId: hookId,
+      hookSessionId: hookId,
+      transcriptPath: explicitTranscriptPath,
+      transcriptId: explicitTranscriptPath ? pathBasename(explicitTranscriptPath) : hookId,
+      parentConversationId: '',
+      diagnostics: [],
+    };
+  }
+
+  if (!explicitTranscriptPath && hookId) {
+    const entry = registry?.sessions?.[hookId];
+    if (entry?.transcript_path && providerMatches(entry, provider)) {
+      return {
+        state: 'resolved',
+        provider,
+        canonicalConversationId: hookId,
+        hookSessionId: hookId,
+        transcriptPath: entry.transcript_path,
+        transcriptId: entry.transcript_id || pathBasename(entry.transcript_path),
+        parentConversationId: '',
+        diagnostics: ['transcript recuperado do SESSION_REGISTRY'],
+      };
+    }
+  }
+
+  if (!explicitTranscriptPath || !inspected.canonicalConversationId) {
+    return {
+      state: 'deferred',
+      provider,
+      transcriptPath: explicitTranscriptPath,
+      diagnostics: ['transcript ausente ou sem identidade canônica'],
+    };
+  }
+  if (!compatible(provider, inspected.transcriptProvider)) {
+    return {
+      state: 'deferred',
+      provider,
+      transcriptPath: explicitTranscriptPath,
+      diagnostics: [`provider ${provider} incompatível com transcript ${inspected.transcriptProvider}`],
+    };
+  }
+
+  const byTranscript = Object.entries(registry?.sessions || {}).find(([, entry]) => {
+    if (!providerMatches(entry, provider)) return false;
+    const paths = [
+      ...(Array.isArray(entry?.transcript_paths) ? entry.transcript_paths : []),
+      entry?.transcript_path,
+    ].filter(Boolean);
+    return paths.some((path) => transcriptsMatch(path, explicitTranscriptPath));
+  });
+
+  return {
+    state: 'resolved',
+    provider,
+    canonicalConversationId: byTranscript?.[0] || inspected.canonicalConversationId,
+    hookSessionId: hookId,
+    transcriptPath: explicitTranscriptPath,
+    transcriptId: inspected.transcriptId,
+    parentConversationId: inspected.parentConversationId,
+    diagnostics: [],
+  };
+}

--- a/packages/integrations/src/transcript-usage.mjs
+++ b/packages/integrations/src/transcript-usage.mjs
@@ -1,0 +1,53 @@
+export function emptyTokenUsage() {
+  return {
+    input: 0,
+    cached: 0,
+    cacheWrite: 0,
+    cacheWrite1h: 0,
+    output: 0,
+    reasoning: 0,
+    total: 0,
+  };
+}
+
+export function normalizeCodexUsage(raw = {}) {
+  const inputAll = Number(raw.input_tokens || 0);
+  const cached = Math.min(Number(raw.cached_input_tokens || 0), inputAll);
+  const output = Number(raw.output_tokens || 0);
+  return {
+    input: inputAll - cached,
+    cached,
+    cacheWrite: 0,
+    cacheWrite1h: 0,
+    output,
+    reasoning: Number(raw.reasoning_output_tokens || 0),
+    total: Number(raw.total_tokens || 0) || inputAll + output,
+  };
+}
+
+export function normalizeClaudeUsage(raw = {}) {
+  const input = Number(raw.input_tokens || 0);
+  const cached = Number(raw.cache_read_input_tokens || 0);
+  const cacheWrite = Number(raw.cache_creation_input_tokens || 0);
+  const cacheWrite1h = Number(raw.cache_creation?.ephemeral_1h_input_tokens || 0);
+  const output = Number(raw.output_tokens || 0);
+  return {
+    input,
+    cached,
+    cacheWrite,
+    cacheWrite1h: Math.min(cacheWrite1h, cacheWrite),
+    output,
+    reasoning: 0,
+    total: input + cached + cacheWrite + output,
+  };
+}
+
+export function addUsage(target, usage) {
+  target.input += usage.input;
+  target.cached += usage.cached;
+  target.cacheWrite += usage.cacheWrite;
+  target.cacheWrite1h += usage.cacheWrite1h;
+  target.output += usage.output;
+  target.reasoning += usage.reasoning;
+  target.total += usage.total;
+}

--- a/packages/integrations/src/transcripts.mjs
+++ b/packages/integrations/src/transcripts.mjs
@@ -1,0 +1,423 @@
+import { isBootstrapPrompt, redactSecrets } from './prompt-content.mjs';
+import {
+  addUsage,
+  emptyTokenUsage,
+  normalizeClaudeUsage,
+  normalizeCodexUsage,
+} from './transcript-usage.mjs';
+
+function extractContentText(content) {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((item) => item?.text || item?.input_text || item?.output_text || '')
+    .filter(Boolean)
+    .join('\n')
+    .trim();
+}
+
+const SYNTHETIC_EVENT_TAG = /^<\/?(?:task-notification|system-reminder|local-command-stdout|local-command-stderr|command-message|command-name|command-args|user-prompt-submit-hook|ide_selection|ide_opened_file|environment_context)\b/i;
+
+function shouldIgnoreUserText(text) {
+  const trimmed = String(text || '').trim();
+  return SYNTHETIC_EVENT_TAG.test(trimmed)
+    || isBootstrapPrompt(trimmed)
+    || /^Generate a concise( UI)? title/i.test(trimmed)
+    || /^You are a helpful assistant\. You will be presented with a user prompt/i.test(trimmed);
+}
+
+function addUnique(list, value) {
+  const clean = redactSecrets(String(value || '').trim());
+  if (clean && !list.includes(clean)) list.push(clean);
+}
+
+function createTurn(turnId = '', timestamp = '') {
+  return {
+    turnId,
+    timestamp,
+    userPrompts: [],
+    assistantMessages: [],
+    tools: [],
+    consultedFiles: [],
+    changedFiles: [],
+    conversation: [],
+    usage: emptyTokenUsage(),
+    model: '',
+  };
+}
+
+function createResult(provider) {
+  return {
+    provider,
+    sessionId: '',
+    model: '',
+    latestTurnId: '',
+    latestUserPrompt: '',
+    latestAssistantMessage: '',
+    userPrompts: [],
+    assistantMessages: [],
+    tools: [],
+    consultedFiles: [],
+    changedFiles: [],
+    turns: [],
+    rawTextForDetection: '',
+  };
+}
+
+function addConversation(turn, role, value) {
+  if (!turn) return;
+  const text = redactSecrets(String(value || '').trim());
+  if (!text) return;
+  if (!turn.conversation.some((item) => item.role === role && item.text === text)) {
+    turn.conversation.push({ role, text });
+  }
+}
+
+function normalizeRoot(value) {
+  return String(value || '').replace(/\\+/g, '/').replace(/\/+$/, '');
+}
+
+function pathContext(options = {}) {
+  const repoRoot = normalizeRoot(options.repoRoot);
+  const vaultRoot = normalizeRoot(options.vaultRoot).toLowerCase();
+  const repoLower = repoRoot.toLowerCase();
+  const vaultRel = vaultRoot && repoLower && vaultRoot.startsWith(`${repoLower}/`)
+    ? vaultRoot.slice(repoLower.length + 1)
+    : '';
+  return { repoRoot, repoLower, vaultRoot, vaultRel };
+}
+
+function normalizeExtractedPath(value, context) {
+  const cleaned = String(value || '')
+    .replace(/\\+/g, '/')
+    .replace(/\/+/g, '/')
+    .replace(/^(?:\.\/)+/, '')
+    .replace(/[:.,;)}\]]+$/, '');
+  if (context.repoRoot && cleaned.toLowerCase().startsWith(`${context.repoLower}/`)) {
+    return cleaned.slice(context.repoRoot.length + 1);
+  }
+  return cleaned;
+}
+
+function shouldIgnoreExtractedPath(path, context) {
+  if (!path) return true;
+  const lower = path.toLowerCase();
+  if (context.vaultRoot && lower.startsWith(`${context.vaultRoot}/`)) return true;
+  if (context.vaultRel && lower.startsWith(`${context.vaultRel}/`)) return true;
+  if (lower.includes('/.codex/sessions/')) return true;
+  if (lower.includes('/.claude/projects/')) return true;
+  if (path.startsWith('../') || path.includes('/../')) return true;
+  if (/(?:^|\/)(?:CURRENT_SESSION\.md|SESSION_REGISTRY\.json)$/i.test(path)) return true;
+  if (/^[A-Za-z]:\/[A-Za-z]:\//.test(path)) return true;
+  if (/^Alves\/\.codex\//i.test(path)) return true;
+  if (/\/\.[A-Za-z0-9]+(?::\d+)?$/.test(path)) return true;
+  return false;
+}
+
+function extractPaths(text, context) {
+  const paths = [];
+  const addPath = (value) => {
+    const path = normalizeExtractedPath(value, context);
+    if (!shouldIgnoreExtractedPath(path, context) && !paths.includes(path)) paths.push(path);
+  };
+  const windowsRegex = /[A-Za-z]:[\\/]+[^"'`\r\n{}()[\],]+\.[A-Za-z0-9]+(?::\d+)?/g;
+  const source = String(text || '');
+  let match;
+  while ((match = windowsRegex.exec(source)) !== null) addPath(match[0]);
+  const masked = source.replace(windowsRegex, ' ');
+  const regex = /(?:^|[\s"'`(])((?:\/(?:home|mnt)\/|\.{1,2}\/|[A-Za-z0-9_.-]+\/)[A-Za-z0-9_./@+:-]+\.[A-Za-z0-9]+(?::\d+)?)/g;
+  while ((match = regex.exec(masked)) !== null) addPath(match[1]);
+  return paths.slice(0, 20);
+}
+
+function extractPatchFiles(text) {
+  const files = [];
+  const regex = /^\*\*\* (?:Add|Update|Delete) File:\s+(.+)$/gm;
+  let match;
+  while ((match = regex.exec(text || '')) !== null) addUnique(files, match[1]);
+  return files;
+}
+
+function parseToolArguments(args) {
+  if (!args) return {};
+  if (typeof args === 'object') return args;
+  try { return JSON.parse(args); } catch { return { raw: String(args) }; }
+}
+
+function toolArgumentText(value) {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value.map(toolArgumentText).filter(Boolean).join('\n');
+  if (typeof value === 'object') return Object.values(value).map(toolArgumentText).filter(Boolean).join('\n');
+  return String(value);
+}
+
+function jsonLines(content) {
+  return String(content || '').split('\n').filter(Boolean).map((line) => {
+    try { return JSON.parse(line); } catch { return null; }
+  }).filter(Boolean);
+}
+
+export function parseCodexTranscriptContent(content, options = {}) {
+  const result = createResult('codex');
+  const eventUserPrompts = [];
+  const paths = pathContext(options);
+  let currentTurn = null;
+  const ensureTurn = (turnId = '', timestamp = '') => {
+    const normalized = turnId || currentTurn?.turnId || `turn-${result.turns.length + 1}`;
+    const existing = result.turns.find((turn) => turn.turnId === normalized);
+    if (existing) {
+      currentTurn = existing;
+      return existing;
+    }
+    currentTurn = createTurn(normalized, timestamp);
+    result.turns.push(currentTurn);
+    return currentTurn;
+  };
+
+  for (const event of jsonLines(content)) {
+    if (event.type === 'session_meta') {
+      result.sessionId = event.payload?.id || result.sessionId;
+      result.model = event.payload?.model || event.payload?.model_provider || result.model;
+      continue;
+    }
+    if (event.type === 'event_msg' && event.payload?.type === 'task_started') {
+      result.latestTurnId = event.payload.turn_id || result.latestTurnId;
+      ensureTurn(result.latestTurnId, event.timestamp);
+      continue;
+    }
+    if (event.type === 'turn_context') {
+      result.latestTurnId = event.payload?.turn_id || result.latestTurnId;
+      result.model = event.payload?.model || result.model;
+      ensureTurn(result.latestTurnId, event.timestamp);
+      continue;
+    }
+    if (event.type === 'event_msg' && event.payload?.type === 'user_message') {
+      const text = event.payload.message || '';
+      if (text && !shouldIgnoreUserText(text)) {
+        const turn = ensureTurn(event.payload.turn_id || result.latestTurnId, event.timestamp);
+        addUnique(eventUserPrompts, text);
+        addUnique(result.userPrompts, text);
+        addUnique(turn.userPrompts, text);
+        addConversation(turn, 'Usuário', text);
+      }
+      continue;
+    }
+    if (event.type === 'event_msg' && event.payload?.type === 'agent_message') {
+      const text = event.payload.message || event.payload.text || '';
+      if (text) {
+        const turn = ensureTurn(event.payload.turn_id || result.latestTurnId, event.timestamp);
+        addUnique(result.assistantMessages, text);
+        addUnique(turn.assistantMessages, text);
+        addConversation(turn, 'Assistente', text);
+      }
+      continue;
+    }
+    if (event.type === 'event_msg' && event.payload?.type === 'token_count') {
+      const raw = event.payload?.info?.last_token_usage;
+      if (raw) {
+        const turn = currentTurn || ensureTurn(result.latestTurnId, event.timestamp);
+        addUsage(turn.usage, normalizeCodexUsage(raw));
+        if (event.payload?.info?.model) turn.model = event.payload.info.model;
+      }
+      continue;
+    }
+    if (event.type !== 'response_item') continue;
+    const payload = event.payload || {};
+    if (payload.type === 'message') {
+      const text = extractContentText(payload.content);
+      if (!text) continue;
+      const turn = ensureTurn(payload.turn_id || event.turn_id || result.latestTurnId, event.timestamp);
+      if (payload.role === 'user' && !shouldIgnoreUserText(text)) {
+        addUnique(result.userPrompts, text);
+        addUnique(turn.userPrompts, text);
+        addConversation(turn, 'Usuário', text);
+      }
+      if (payload.role === 'assistant') {
+        addUnique(result.assistantMessages, text);
+        addUnique(turn.assistantMessages, text);
+        addConversation(turn, 'Assistente', text);
+      }
+      continue;
+    }
+    if (payload.type === 'function_call') {
+      const name = payload.name || 'function_call';
+      const turn = ensureTurn(payload.turn_id || event.turn_id || result.latestTurnId, event.timestamp);
+      addUnique(result.tools, name);
+      addUnique(turn.tools, name);
+      const parsed = parseToolArguments(payload.arguments);
+      const combined = typeof parsed.raw === 'string' ? parsed.raw : toolArgumentText(parsed);
+      for (const path of extractPaths(combined, paths)) {
+        addUnique(result.consultedFiles, path);
+        addUnique(turn.consultedFiles, path);
+      }
+      for (const path of extractPatchFiles(combined)) {
+        addUnique(result.changedFiles, path);
+        addUnique(turn.changedFiles, path);
+      }
+      if (/apply_patch|edit|write|create/i.test(name)) {
+        for (const path of extractPaths(combined, paths)) {
+          addUnique(result.changedFiles, path);
+          addUnique(turn.changedFiles, path);
+        }
+      }
+    }
+    if (payload.type === 'tool_search_call') {
+      const turn = ensureTurn(payload.turn_id || event.turn_id || result.latestTurnId, event.timestamp);
+      addUnique(result.tools, 'tool_search');
+      addUnique(turn.tools, 'tool_search');
+    }
+    if (payload.type === 'web_search_call') {
+      const turn = ensureTurn(payload.turn_id || event.turn_id || result.latestTurnId, event.timestamp);
+      addUnique(result.tools, 'web_search');
+      addUnique(turn.tools, 'web_search');
+    }
+  }
+
+  for (const prompt of eventUserPrompts) addUnique(result.userPrompts, prompt);
+  const latestTurn = result.turns.find((turn) => turn.turnId === result.latestTurnId)
+    || result.turns.at(-1);
+  result.latestUserPrompt = latestTurn?.userPrompts.at(-1)
+    || eventUserPrompts.at(-1)
+    || result.userPrompts.at(-1)
+    || '';
+  result.latestAssistantMessage = latestTurn?.assistantMessages.at(-1)
+    || result.assistantMessages.at(-1)
+    || '';
+  result.rawTextForDetection = redactSecrets([
+    ...result.userPrompts,
+    ...result.assistantMessages,
+  ].join('\n\n'));
+  return result;
+}
+
+function claudeUserText(content) {
+  if (typeof content === 'string') return content.trim();
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((block) => (typeof block === 'string' ? block : (block?.type === 'text' ? block.text || '' : '')))
+    .map((text) => String(text || '').trim())
+    .filter((text) => text && !text.startsWith('<'))
+    .join('\n')
+    .trim();
+}
+
+export function parseClaudeTranscriptContent(content, options = {}) {
+  const result = createResult('claude');
+  const paths = pathContext(options);
+  let currentTurn = null;
+  const ensureTurn = (turnId = '', timestamp = '') => {
+    const normalized = turnId || currentTurn?.turnId || `turn-${result.turns.length + 1}`;
+    const existing = result.turns.find((turn) => turn.turnId === normalized);
+    if (existing) {
+      currentTurn = existing;
+      return existing;
+    }
+    currentTurn = createTurn(normalized, timestamp);
+    result.turns.push(currentTurn);
+    return currentTurn;
+  };
+  const recordToolFiles = (turn, name, input) => {
+    const text = toolArgumentText(input);
+    for (const path of extractPaths(text, paths)) {
+      addUnique(result.consultedFiles, path);
+      addUnique(turn.consultedFiles, path);
+    }
+    for (const path of extractPatchFiles(text)) {
+      addUnique(result.changedFiles, path);
+      addUnique(turn.changedFiles, path);
+    }
+    if (/edit|write|create|apply_patch|notebook/i.test(name)) {
+      for (const path of extractPaths(text, paths)) {
+        addUnique(result.changedFiles, path);
+        addUnique(turn.changedFiles, path);
+      }
+    }
+  };
+
+  for (const event of jsonLines(content)) {
+    if (event.isSidechain || event.isMeta) continue;
+    if (event.sessionId && !result.sessionId) result.sessionId = event.sessionId;
+    if (event.type === 'user') {
+      const text = claudeUserText(event.message?.content);
+      if (!text || shouldIgnoreUserText(text)) continue;
+      const turn = ensureTurn(event.uuid || event.promptId || event.timestamp || '', event.timestamp || '');
+      result.latestTurnId = turn.turnId;
+      addUnique(result.userPrompts, text);
+      addUnique(turn.userPrompts, text);
+      addConversation(turn, 'Usuário', text);
+      continue;
+    }
+    if (event.type === 'assistant') {
+      const turn = currentTurn || ensureTurn(event.uuid || event.timestamp || '', event.timestamp || '');
+      result.model = event.message?.model || result.model;
+      if (event.message?.model) turn.model = event.message.model;
+      if (event.message?.usage) addUsage(turn.usage, normalizeClaudeUsage(event.message.usage));
+      const blocks = Array.isArray(event.message?.content) ? event.message.content : [];
+      for (const block of blocks) {
+        if (block?.type === 'text' && block.text && block.text.trim()) {
+          addUnique(result.assistantMessages, block.text);
+          addUnique(turn.assistantMessages, block.text);
+          addConversation(turn, 'Assistente', block.text);
+        } else if (block?.type === 'tool_use') {
+          const name = block.name || 'tool_use';
+          addUnique(result.tools, name);
+          addUnique(turn.tools, name);
+          recordToolFiles(turn, name, block.input);
+        }
+      }
+    }
+  }
+
+  const latestTurn = result.turns.find((turn) => turn.turnId === result.latestTurnId)
+    || result.turns.at(-1);
+  result.latestUserPrompt = latestTurn?.userPrompts.at(-1) || result.userPrompts.at(-1) || '';
+  result.latestAssistantMessage = latestTurn?.assistantMessages.at(-1)
+    || result.assistantMessages.at(-1)
+    || '';
+  result.rawTextForDetection = redactSecrets([
+    ...result.userPrompts,
+    ...result.assistantMessages,
+  ].join('\n\n'));
+  return result;
+}
+
+function looksLikeCodexEvent(event) {
+  return event.payload !== undefined
+    || event.type === 'session_meta'
+    || event.type === 'response_item'
+    || event.type === 'turn_context'
+    || event.type === 'event_msg';
+}
+
+function looksLikeClaudeEvent(event) {
+  return (event.type === 'user' || event.type === 'assistant') && event.message !== undefined;
+}
+
+export function parseTranscriptContent(content, options = {}) {
+  for (const event of jsonLines(content)) {
+    if (looksLikeCodexEvent(event)) return parseCodexTranscriptContent(content, options);
+    if (looksLikeClaudeEvent(event)) return parseClaudeTranscriptContent(content, options);
+  }
+  return parseCodexTranscriptContent(content, options);
+}
+
+export function resolveTurnIdentity(transcript, requestedTurnId = '') {
+  const turns = Array.isArray(transcript?.turns) ? transcript.turns : [];
+  const requested = String(requestedTurnId || '');
+  let index = requested
+    ? turns.findIndex((turn) => String(turn?.turnId || '') === requested)
+    : -1;
+  if (requested && index < 0) return null;
+  if (index < 0 && transcript?.latestTurnId) {
+    index = turns.findIndex((turn) => String(turn?.turnId || '') === String(transcript.latestTurnId));
+  }
+  if (index < 0) index = turns.length - 1;
+  const turn = turns[index];
+  if (!turn?.turnId) return null;
+  return {
+    id: String(turn.turnId),
+    order: index + 1,
+    observedAt: String(turn.timestamp || ''),
+  };
+}

--- a/src/taxonomy.mjs
+++ b/src/taxonomy.mjs
@@ -3,8 +3,31 @@ import {
   mcpServerEntry,
   selectMcpServers,
 } from '../packages/mcp/src/index.mjs';
+import {
+  CHANGE_GATE_HOOKS,
+  CHANGE_NUDGE_HOOKS,
+  CODEX_MATCHER_EVENTS,
+  SESSION_HOOKS,
+  codexHookEntry,
+  codexHookSpecs,
+  hookCommand,
+  hookCommandLocal,
+  hookCommandLocalLegacy,
+} from '../packages/integrations/src/host-hooks.mjs';
 
-export { MCP_SERVER_KEY, mcpServerEntry };
+export {
+  CHANGE_GATE_HOOKS,
+  CHANGE_NUDGE_HOOKS,
+  CODEX_MATCHER_EVENTS,
+  MCP_SERVER_KEY,
+  SESSION_HOOKS,
+  codexHookEntry,
+  codexHookSpecs,
+  hookCommand,
+  hookCommandLocal,
+  hookCommandLocalLegacy,
+  mcpServerEntry,
+};
 
 // Shared, data-only constants for the wendkeep installer and CLI.
 // Kept free of side effects so both bin/ and src/ can import it cheaply.
@@ -100,83 +123,6 @@ export const RUNNABLE_HOOKS = [
   'change-nag',
   'plan-capture',
 ];
-
-// The three Claude Code session hooks, expressed as `wendkeep hook <name>` so the
-// installed package is the single source of truth (update with `npm update wendkeep`,
-// no re-copying). Returned as a spec the merge logic folds into settings.json.
-export const SESSION_HOOKS = [
-  // Memory + active-change injection. Runs FIRST on SessionStart (order -10, folds before
-  // session-start) so the agent gets CORE + DIGEST + the active change + lessons as context.
-  // matcher 'startup|clear|compact' re-injects after a compaction/clear, not only cold startup.
-  // timeout 45 (was 15): measured ~4s warm via npx, but Windows startup contention (several npx
-  // cold-starts at once — a sibling MCP took 26s in a real log) blew 15s and silently dropped the
-  // memory injection for the whole session.
-  { event: 'SessionStart', matcher: 'startup|clear|compact', name: 'brain-inject', timeout: 45, order: -10, codex: true, statusMessage: 'wendkeep: injecting memory + active change' },
-  { event: 'SessionStart', matcher: 'startup', name: 'session-start', timeout: 30, codex: true, statusMessage: 'wendkeep: opening Obsidian session' },
-  { event: 'Stop', matcher: null, name: 'session-stop', timeout: 60, codex: true, statusMessage: 'wendkeep: writing session checkpoint' },
-  { event: 'UserPromptSubmit', matcher: null, name: 'session-ensure', timeout: 30, codex: true, statusMessage: 'wendkeep: ensuring active session' },
-  // Capture an interactive decision (AskUserQuestion) — options + the user's choice — into 04-Decisões.
-  // codex: AskUserQuestion is a Claude-only tool; there is nothing to match on.
-  { event: 'PostToolUse', matcher: 'AskUserQuestion', name: 'decision-capture', timeout: 15, statusMessage: 'wendkeep: recording decision' },
-  // Refresh subagent/workflow telemetry as each subagent finishes (resilient to a missed Stop).
-  { event: 'SubagentStop', matcher: null, name: 'subagent-stop', timeout: 20, codex: true, statusMessage: 'wendkeep: subagent telemetry' },
-  // Log plan/task progress into the active session note when a task is marked complete.
-  // codex: TaskCompleted is not in Codex's hook event enum.
-  { event: 'TaskCompleted', matcher: null, name: 'task-log', timeout: 10, statusMessage: 'wendkeep: plan progress' },
-];
-
-export function hookCommand(name) {
-  return `npx wendkeep hook ${name}`;
-}
-
-// Forma node-direta do comando de hook: 1 processo (~100-250ms) em vez dos 3 do npx (cold-start
-// de segundos no Windows). Usada pelos hooks de ALTA FREQUÊNCIA (por prompt / por tool-call)
-// quando o projeto tem wendkeep instalado localmente; o init decide (hookCommandFor).
-export function hookCommandLocal(name) {
-  return `node "${'${CLAUDE_PROJECT_DIR}'}/node_modules/wendkeep/hooks/${name}.mjs"`;
-}
-
-export function hookCommandLocalLegacy(name) {
-  return `node node_modules/wendkeep/hooks/${name}.mjs`;
-}
-
-// Hooks do lifecycle de change (0.31.0) — enforcement do loop a2. Nudges (contexto/aviso/
-// cobrança/captura de plano) e gate (deny/ask no Bash). Separados em dois grupos para
-// preservar a opção futura de gates opt-in; hoje o init wira TODOS por default.
-// preferLocal: alta frequência → invocação node-direta quando houver instalação local.
-export const CHANGE_NUDGE_HOOKS = [
-  { event: 'UserPromptSubmit', matcher: null, name: 'change-context', timeout: 15, order: 10, preferLocal: true, codex: true, statusMessage: 'wendkeep: change ping' },
-  // codex: reads tool_input.file_path, which Codex's apply_patch envelope does not carry.
-  { event: 'PostToolUse', matcher: 'Edit|Write|MultiEdit', name: 'change-warn', timeout: 10, order: 10, preferLocal: true, statusMessage: 'wendkeep: change warn' },
-  // codex: no ExitPlanMode equivalent — update_plan is the running TODO list, not an approval.
-  { event: 'PostToolUse', matcher: 'ExitPlanMode', name: 'plan-capture', timeout: 15, order: 10, preferLocal: true, statusMessage: 'wendkeep: capturing approved plan' },
-  { event: 'Stop', matcher: null, name: 'change-nag', timeout: 15, order: 10, preferLocal: true, codex: true, statusMessage: 'wendkeep: open tasks check' },
-];
-export const CHANGE_GATE_HOOKS = [
-  // codex: reads tool_input.command; Codex's exec sends a raw string and exec_command an argv,
-  // so the guard would silently fail OPEN — worse than absent, since the docs would promise it.
-  { event: 'PreToolUse', matcher: 'Bash', name: 'change-guard', timeout: 10, order: 10, preferLocal: true, statusMessage: 'wendkeep: change gate' },
-];
-
-// --- Codex projection ---------------------------------------------------------
-// Codex reads <project>/.codex/hooks.json (PascalCase event keys, same group shape as
-// Claude's settings.json). Only specs that opt in with `codex: true` are projected — the
-// rest carry a `// codex:` comment above them saying why. Three deltas from Claude, each
-// verified against codex-rs and each silent when wrong: the timeout key is `timeoutSec`
-// (`timeout` is not a field and falls through to a 600s default), there is no
-// ${CLAUDE_PROJECT_DIR} so `preferLocal` never applies, and matcher is only honoured on
-// SessionStart (UserPromptSubmit/Stop null it at discovery).
-export const CODEX_MATCHER_EVENTS = new Set(['SessionStart']);
-
-export function codexHookSpecs(specs) {
-  return specs.filter((h) => h.codex === true && !h.command);
-}
-
-export function codexHookEntry(spec) {
-  const entry = { type: 'command', command: hookCommand(spec.name), timeoutSec: spec.timeout };
-  if (spec.statusMessage) entry.statusMessage = spec.statusMessage;
-  return entry;
-}
 
 // --- companion plugins / MCP --------------------------------------------------
 // Optional tools wendkeep init can pin alongside the vault. Each is wired through

--- a/tests/hook-input-salvage.test.mjs
+++ b/tests/hook-input-salvage.test.mjs
@@ -4,12 +4,20 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { salvageTruncatedJson } from '../hooks/obsidian-common.mjs';
+import {
+  salvageTruncatedJson,
+  parseHookInput,
+} from '../packages/integrations/src/hook-envelope.mjs';
+import { salvageTruncatedJson as legacySalvageTruncatedJson } from '../hooks/obsidian-common.mjs';
 
 // Field order mirrors StopCommandInput in codex-rs — last_assistant_message is final.
 const PREFIX = '{"session_id":"019f7764-7627-79a3-b609-65abaa36eedd","turn_id":"turn-abc",'
   + '"transcript_path":"C:\\\\Users\\\\x\\\\rollout.jsonl","cwd":"C:\\\\GitHub\\\\Vendiva",'
   + '"hook_event_name":"Stop","model":"gpt-5.6-sol","permission_mode":"default","stop_hook_active":false';
+
+test('[req:MOD-20] salvageTruncatedJson legado é o binding puro canônico', () => {
+  assert.strictEqual(legacySalvageTruncatedJson, salvageTruncatedJson);
+});
 
 // --- CODEX-8 -----------------------------------------------------------------
 
@@ -106,6 +114,14 @@ test('salvageTruncatedJson: objeto aninhado não fecha a fronteira cedo demais',
   assert.equal(out.transcript_path, '/x.jsonl');
 });
 
+test('[req:MOD-21] parseHookInput preserva array, null e escalares JSON válidos', () => {
+  assert.deepEqual(parseHookInput('[1,{"ok":true}]'), [1, { ok: true }]);
+  assert.equal(parseHookInput('null'), null);
+  assert.equal(parseHookInput('false'), false);
+  assert.equal(parseHookInput('0'), 0);
+  assert.equal(parseHookInput('"texto"'), 'texto');
+});
+
 // readHookInput reads fd 0, so exercise it through a child process. The module URL is derived
 // from this test file so the spawn works on Windows and on the Linux CI matrix alike.
 const COMMON_URL = new URL('../hooks/obsidian-common.mjs', import.meta.url).href;
@@ -122,6 +138,14 @@ test('readHookInput: payload íntegro não é marcado como salvo', () => {
   assert.equal(out.ok, true);
   assert.equal(out.value.session_id, 'abc');
   assert.ok(!('_wkSalvaged' in out.value), 'parse normal não marca salvamento');
+});
+
+test('[req:MOD-21] readHookInput legado preserva valores JSON que não são objetos', () => {
+  assert.deepEqual(runReadHookInput('[1,{"ok":true}]').value, [1, { ok: true }]);
+  assert.equal(runReadHookInput('null').value, null);
+  assert.equal(runReadHookInput('false').value, false);
+  assert.equal(runReadHookInput('0').value, 0);
+  assert.equal(runReadHookInput('"texto"').value, 'texto');
 });
 
 test('readHookInput: payload truncado é salvo e marcado', () => {

--- a/tests/integrations-hook-envelope.test.mjs
+++ b/tests/integrations-hook-envelope.test.mjs
@@ -1,0 +1,201 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { parse } from 'acorn';
+import {
+  salvageTruncatedJson,
+  parseHookInput,
+  stringifyHookOutput,
+  detectProvider,
+  providerMeta,
+  extractHookPrompt,
+} from '../packages/integrations/src/hook-envelope.mjs';
+import * as legacy from '../hooks/obsidian-common.mjs';
+
+const LEGACY_URL = new URL('../hooks/obsidian-common.mjs', import.meta.url).href;
+
+function memberPath(node) {
+  if (node?.type === 'Identifier') return node.name;
+  if (node?.type !== 'MemberExpression' || node.computed) return '';
+  const owner = memberPath(node.object);
+  const property = memberPath(node.property);
+  return owner && property ? `${owner}.${property}` : '';
+}
+
+function callsFrom(fn) {
+  const calls = [];
+  const walk = (node) => {
+    if (!node || typeof node !== 'object') return;
+    if (node.type === 'CallExpression') calls.push(memberPath(node.callee));
+    for (const value of Object.values(node)) {
+      if (Array.isArray(value)) value.forEach(walk);
+      else if (value && typeof value === 'object') walk(value);
+    }
+  };
+  walk(parse(`(${fn.toString()})`, { ecmaVersion: 'latest' }));
+  return calls.sort();
+}
+
+for (const [label, raw, expected] of [
+  ['objeto', ' {"session_id":"abc"} ', { session_id: 'abc' }],
+  ['array', '[1,{"nested":true}]', [1, { nested: true }]],
+  ['null', 'null', null],
+  ['booleano', 'false', false],
+  ['número', '0', 0],
+  ['string', '"prompt"', 'prompt'],
+]) {
+  test(`[req:MOD-21] parseHookInput preserva JSON válido: ${label}`, () => {
+    assert.deepEqual(parseHookInput(raw), expected);
+  });
+}
+
+test('[req:MOD-21] parseHookInput preserva stdin vazio como objeto vazio', () => {
+  assert.deepEqual(parseHookInput(' \r\n\t '), {});
+});
+
+test('[req:MOD-21] parseHookInput marca apenas o prefixo truncado recuperável', () => {
+  const raw = '{"session_id":"abc","meta":{"nested":true},'
+    + '"last_assistant_message":"cortou, ainda dentro da string';
+
+  assert.deepEqual(salvageTruncatedJson(raw), {
+    session_id: 'abc',
+    meta: { nested: true },
+  });
+  assert.deepEqual(parseHookInput(raw), {
+    session_id: 'abc',
+    meta: { nested: true },
+    _wkSalvaged: true,
+  });
+});
+
+test('[req:MOD-21] parseHookInput relança o mesmo SyntaxError quando o JSON é irrecuperável', () => {
+  const originalParse = JSON.parse;
+  const sentinel = new SyntaxError('erro original do parser');
+  JSON.parse = () => { throw sentinel; };
+  try {
+    assert.throws(() => parseHookInput('isso não é JSON'), (error) => error === sentinel);
+  } finally {
+    JSON.parse = originalParse;
+  }
+});
+
+for (const [label, payload, expected] of [
+  ['default', undefined, '{}'],
+  ['objeto', { ok: true, nested: { n: 1 } }, '{"ok":true,"nested":{"n":1}}'],
+  ['array', [1, 'x'], '[1,"x"]'],
+  ['null', null, 'null'],
+  ['booleano', false, 'false'],
+  ['número', 0, '0'],
+  ['string', 'x', '"x"'],
+]) {
+  test(`[req:MOD-21] stringifyHookOutput emite JSON exato sem newline: ${label}`, () => {
+    const output = stringifyHookOutput(payload);
+    assert.equal(output, expected);
+    assert.equal(output.endsWith('\n'), false);
+  });
+}
+
+for (const [label, environment] of [
+  ['CLAUDECODE', { CLAUDECODE: '1' }],
+  ['CLAUDE_CODE_SESSION_ID', { CLAUDE_CODE_SESSION_ID: 'session-1' }],
+  ['CLAUDE_PROJECT_DIR', { CLAUDE_PROJECT_DIR: 'C:\\repo' }],
+]) {
+  test(`[req:MOD-21] detectProvider reconhece marcador Claude: ${label}`, () => {
+    assert.equal(detectProvider(environment), 'claude');
+  });
+}
+
+test('[req:MOD-21] detectProvider usa fallback Codex sem marcador Claude', () => {
+  assert.equal(detectProvider({}), 'codex');
+  assert.equal(detectProvider({ CLAUDECODE: '0', CLAUDE_CODE_SESSION_ID: '', CLAUDE_PROJECT_DIR: '' }), 'codex');
+});
+
+test('[req:MOD-21] providerMeta preserva os metadados Claude e o fallback Codex', () => {
+  assert.deepEqual(providerMeta('claude'), {
+    id: 'claude', label: 'Claude Code', tag: 'claude', source: 'claude-hook',
+  });
+  const codex = { id: 'codex', label: 'Codex', tag: 'codex', source: 'codex-hook' };
+  assert.deepEqual(providerMeta('codex'), codex);
+  assert.deepEqual(providerMeta(), codex);
+  assert.deepEqual(providerMeta('unknown-provider'), codex);
+});
+
+for (const [alias, value] of [
+  ['prompt', 'prompt direto'],
+  ['user_prompt', 'snake case'],
+  ['userPrompt', 'camel case'],
+  ['message', 'mensagem'],
+  ['input', 'entrada'],
+]) {
+  test(`[req:MOD-21] extractHookPrompt normaliza alias ${alias}`, () => {
+    assert.equal(extractHookPrompt({ [alias]: `  ${value}  ` }), value);
+  });
+}
+
+test('[req:MOD-21] extractHookPrompt respeita precedência e agrega mensagens textuais', () => {
+  assert.equal(extractHookPrompt({ prompt: ' primeiro ', user_prompt: 'segundo' }), 'primeiro');
+  assert.equal(extractHookPrompt({
+    prompt: '   ',
+    messages: [
+      { content: ' um ' },
+      { text: 'dois' },
+      { content: { type: 'text', text: 'ignorado' } },
+      null,
+    ],
+  }), 'um \ndois');
+  assert.equal(extractHookPrompt({}), '');
+});
+
+test('[req:MOD-20] obsidian-common reexporta os helpers puros por identidade', () => {
+  assert.strictEqual(legacy.salvageTruncatedJson, salvageTruncatedJson);
+  assert.strictEqual(legacy.extractHookPrompt, extractHookPrompt);
+});
+
+test('[req:MOD-21] reexport puro continua disponível aos consumidores internos legados', () => {
+  assert.equal(legacy.sessionSummaryFromInput({ prompt: '  duas palavras  ' }), 'Duas palavras');
+});
+
+test('[req:MOD-20] wrappers legados compõem somente I/O/ambiente com o kernel canônico', () => {
+  assert.deepEqual(callsFrom(legacy.readHookInput), ['parseHookInput', 'readFileSync']);
+  assert.deepEqual(callsFrom(legacy.writeHookOutput), ['process.stdout.write', 'stringifyHookOutput']);
+  assert.deepEqual(callsFrom(legacy.detectProvider), ['detectProviderFromEnvironment']);
+  assert.deepEqual(callsFrom(legacy.providerMeta), ['detectProvider', 'providerMetaFromProvider']);
+});
+
+test('[req:MOD-21] wrappers legados detectam provider no process.env a cada chamada', () => {
+  for (const marker of ['CLAUDECODE', 'CLAUDE_CODE_SESSION_ID', 'CLAUDE_PROJECT_DIR']) {
+    const env = { ...process.env };
+    delete env.CLAUDECODE;
+    delete env.CLAUDE_CODE_SESSION_ID;
+    delete env.CLAUDE_PROJECT_DIR;
+    const code = `import{detectProvider,providerMeta}from${JSON.stringify(LEGACY_URL)};`
+      + `const marker=${JSON.stringify(marker)};const value=marker==='CLAUDECODE'?'1':'present';`
+      + 'const states=[];const capture=()=>states.push({provider:detectProvider(),meta:providerMeta()});'
+      + 'capture();process.env[marker]=value;capture();delete process.env[marker];capture();'
+      + 'process.stdout.write(JSON.stringify(states))';
+    const result = spawnSync(process.execPath, ['--input-type=module', '-e', code], {
+      encoding: 'utf8', env,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const codex = {
+      provider: 'codex',
+      meta: { id: 'codex', label: 'Codex', tag: 'codex', source: 'codex-hook' },
+    };
+    const claude = {
+      provider: 'claude',
+      meta: { id: 'claude', label: 'Claude Code', tag: 'claude', source: 'claude-hook' },
+    };
+    assert.deepEqual(JSON.parse(result.stdout), [codex, claude, codex]);
+  }
+});
+
+test('[req:MOD-21] writeHookOutput legado escreve somente o JSON canônico', () => {
+  const code = `import{writeHookOutput}from${JSON.stringify(LEGACY_URL)};`
+    + 'writeHookOutput({ok:true,nested:[1,"x"]})';
+  const result = spawnSync(process.execPath, ['--input-type=module', '-e', code], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, '{"ok":true,"nested":[1,"x"]}');
+  assert.equal(result.stderr, '');
+});

--- a/tests/integrations-host-hooks.test.mjs
+++ b/tests/integrations-host-hooks.test.mjs
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const HOST_HOOKS_PATH = resolve(ROOT, 'packages', 'integrations', 'src', 'host-hooks.mjs');
+const HOST_HOOK_EXPORTS = [
+  'CHANGE_GATE_HOOKS',
+  'CHANGE_NUDGE_HOOKS',
+  'CODEX_MATCHER_EVENTS',
+  'SESSION_HOOKS',
+  'codexHookEntry',
+  'codexHookSpecs',
+  'hookCommand',
+  'hookCommandLocal',
+  'hookCommandLocalLegacy',
+];
+
+test('[req:MOD-20] [req:MOD-21] Integrations owns host-hook rules while taxonomy remains identity-compatible', async () => {
+  assert.ok(existsSync(HOST_HOOKS_PATH), 'missing canonical Integrations host-hook catalog');
+
+  const [canonical, taxonomy] = await Promise.all([
+    import('../packages/integrations/src/host-hooks.mjs'),
+    import('../src/taxonomy.mjs'),
+  ]);
+
+  assert.deepEqual(Object.keys(canonical).sort(), [...HOST_HOOK_EXPORTS].sort());
+  for (const name of HOST_HOOK_EXPORTS) {
+    assert.equal(taxonomy[name], canonical[name], `taxonomy must preserve identity for ${name}`);
+  }
+
+  assert.deepEqual(canonical.CODEX_MATCHER_EVENTS, new Set(['SessionStart']));
+  assert.equal(canonical.hookCommand('session-stop'), 'npx wendkeep hook session-stop');
+  assert.equal(
+    canonical.hookCommandLocal('change-context'),
+    'node "${CLAUDE_PROJECT_DIR}/node_modules/wendkeep/hooks/change-context.mjs"',
+  );
+  assert.equal(
+    canonical.hookCommandLocalLegacy('change-context'),
+    'node node_modules/wendkeep/hooks/change-context.mjs',
+  );
+  assert.deepEqual(
+    canonical.codexHookSpecs([
+      { name: 'session-start', codex: true },
+      { name: 'custom-command', codex: true, command: 'echo custom' },
+      { name: 'claude-only' },
+    ]),
+    [{ name: 'session-start', codex: true }],
+  );
+  assert.deepEqual(
+    canonical.codexHookEntry({ name: 'session-stop', timeout: 60, statusMessage: 'checkpoint' }),
+    {
+      type: 'command',
+      command: 'npx wendkeep hook session-stop',
+      timeoutSec: 60,
+      statusMessage: 'checkpoint',
+    },
+  );
+
+  for (const excluded of [
+    'HOOK_FILES',
+    'RUNNABLE_HOOKS',
+    'VAULT_FOLDERS',
+    'COMPANIONS',
+    'companionHookSpecs',
+    'MCP_SERVER_KEY',
+  ]) {
+    assert.equal(excluded in canonical, false, `${excluded} must remain outside host-hooks.mjs`);
+    assert.ok(excluded in taxonomy, `${excluded} must remain available from taxonomy.mjs`);
+  }
+});

--- a/tests/integrations-kernel-boundary.test.mjs
+++ b/tests/integrations-kernel-boundary.test.mjs
@@ -1,0 +1,244 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parse } from 'acorn';
+import { importSpecifiersFromSource } from './helpers/import-specifiers.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const INTEGRATIONS = resolve(ROOT, 'packages', 'integrations');
+const INTEGRATIONS_PACKAGE = resolve(INTEGRATIONS, 'package.json');
+const CANONICAL_MODULES = [
+  'src/host-hooks.mjs',
+  'src/hook-envelope.mjs',
+  'src/prompt-content.mjs',
+  'src/transcript-usage.mjs',
+  'src/transcripts.mjs',
+  'src/session-identity.mjs',
+  'src/index.mjs',
+];
+const OWNED_BINDINGS = new Map([
+  ['src/host-hooks.mjs', [
+    'SESSION_HOOKS', 'CHANGE_NUDGE_HOOKS', 'CHANGE_GATE_HOOKS',
+    'CODEX_MATCHER_EVENTS', 'hookCommand', 'hookCommandLocal',
+    'hookCommandLocalLegacy', 'codexHookSpecs', 'codexHookEntry',
+  ]],
+  ['src/hook-envelope.mjs', [
+    'salvageTruncatedJson', 'parseHookInput', 'stringifyHookOutput',
+    'detectProvider', 'providerMeta', 'extractHookPrompt',
+  ]],
+  ['src/prompt-content.mjs', ['isBootstrapPrompt', 'redactSecrets']],
+  ['src/transcript-usage.mjs', [
+    'emptyTokenUsage', 'normalizeCodexUsage', 'normalizeClaudeUsage', 'addUsage',
+  ]],
+  ['src/transcripts.mjs', [
+    'parseCodexTranscriptContent', 'parseClaudeTranscriptContent',
+    'parseTranscriptContent', 'resolveTurnIdentity',
+  ]],
+  ['src/session-identity.mjs', [
+    'inspectTranscriptIdentityContent', 'resolveSessionIdentitySnapshot',
+    'transcriptsMatch',
+  ]],
+]);
+const EFFECTFUL_BUILTINS = /^(?:node:)?(?:fs|fs\/promises|child_process|cluster|dgram|dns|http|https|net|readline|tls|worker_threads)$/;
+
+function json(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function walk(node, visit) {
+  if (!node || typeof node !== 'object') return;
+  if (typeof node.type === 'string') visit(node);
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) value.forEach((item) => walk(item, visit));
+    else if (value && typeof value === 'object') walk(value, visit);
+  }
+}
+
+function ast(source) {
+  return parse(source, { ecmaVersion: 'latest', sourceType: 'module' });
+}
+
+function staticMemberName(node) {
+  if (node?.type !== 'MemberExpression') return null;
+  if (!node.computed && node.property?.type === 'Identifier') return node.property.name;
+  if (node.computed && node.property?.type === 'Literal') return node.property.value;
+  return null;
+}
+
+function declarationNames(source) {
+  const names = [];
+  for (const statement of ast(source).body) {
+    const node = statement.type === 'ExportNamedDeclaration' ? statement.declaration : statement;
+    if (node?.type === 'FunctionDeclaration' || node?.type === 'ClassDeclaration') {
+      if (node.id?.name) names.push(node.id.name);
+    } else if (node?.type === 'VariableDeclaration') {
+      for (const declaration of node.declarations) {
+        if (declaration.id?.type === 'Identifier') names.push(declaration.id.name);
+      }
+    }
+  }
+  return names;
+}
+
+function insideWorkspace(path) {
+  const rel = relative(INTEGRATIONS, path);
+  return rel === '' || (!rel.startsWith('..') && !resolve(rel).startsWith('..'));
+}
+
+function assertAllowedImports(source, absolute = resolve(INTEGRATIONS, 'src', 'mutant.mjs')) {
+  const violations = importSpecifiersFromSource(source).filter((specifier) => {
+    if (specifier.startsWith('<dynamic:')) return true;
+    if (specifier.startsWith('.')) return !insideWorkspace(resolve(dirname(absolute), specifier));
+    if (specifier === 'node:path' || specifier === 'path') return false;
+    return true;
+  });
+  assert.deepEqual(violations, []);
+}
+
+function assertImportInertSource(source) {
+  const tree = ast(source);
+  const violations = [];
+  walk(tree, (node) => {
+    if (node.type === 'ImportDeclaration' && EFFECTFUL_BUILTINS.test(String(node.source?.value || ''))) {
+      violations.push(String(node.source.value));
+    }
+    if (node.type === 'Identifier' && node.name === 'process') violations.push('process');
+    if (node.type === 'MemberExpression'
+      && node.object?.type === 'Identifier'
+      && ['global', 'globalThis'].includes(node.object.name)
+      && ['process', 'fetch', 'eval', 'Function'].includes(staticMemberName(node))) {
+      violations.push(`${node.object.name}.${staticMemberName(node)}`);
+    }
+    if (node.type === 'CallExpression' && node.callee?.type === 'Identifier'
+      && ['eval', 'fetch', 'Function'].includes(node.callee.name)) violations.push(node.callee.name);
+    if (node.type === 'NewExpression' && node.callee?.type === 'Identifier'
+      && node.callee.name === 'Function') violations.push('Function');
+  });
+  assert.deepEqual(violations, []);
+}
+
+function assertSingleOwnership(sources) {
+  const owners = new Map();
+  for (const [file, source] of sources) {
+    for (const name of declarationNames(source)) {
+      if (!owners.has(name)) owners.set(name, []);
+      owners.get(name).push(file);
+    }
+  }
+  for (const [file, names] of OWNED_BINDINGS) {
+    for (const name of names) assert.deepEqual(owners.get(name), [file], `${name} must have one canonical owner`);
+  }
+}
+
+function assertCheckCoversIntegrations(root) {
+  for (const path of CANONICAL_MODULES) {
+    assert.ok(
+      root.scripts?.check?.includes(`node --check packages/integrations/${path}`),
+      `root check omits packages/integrations/${path}`,
+    );
+  }
+}
+
+test('[req:MOD-20] Integrations workspace declares and owns its private host kernel', () => {
+  const workspace = json(INTEGRATIONS_PACKAGE);
+  const root = json(resolve(ROOT, 'package.json'));
+
+  assert.equal(workspace.private, true);
+  assert.equal(workspace.exports, './src/index.mjs');
+  for (const path of CANONICAL_MODULES) {
+    assert.ok(existsSync(resolve(INTEGRATIONS, path)), `missing Integrations module: ${path}`);
+  }
+  assertCheckCoversIntegrations(root);
+  assert.equal(Object.hasOwn(root.exports || {}, './integrations'), false, 'wendkeep/integrations must remain absent');
+  assert.equal(Object.hasOwn(root.exports || {}, './*'), false, 'root wildcard would expose private workspaces');
+  const publicPackageTargets = new Set([
+    './packages/harness/src/index.mjs',
+    './packages/vault/src/index.mjs',
+  ]);
+  assert.equal(
+    Object.entries(root.exports || {}).some(([key, target]) => (
+      key.startsWith('./packages')
+      || (String(target).startsWith('./packages') && !publicPackageTargets.has(target))
+    )),
+    false,
+    'private workspace paths must not be exported',
+  );
+});
+
+test('[req:MOD-20] Integrations kernel is import-inert and adapter-independent', () => {
+  const sources = CANONICAL_MODULES.map((path) => {
+    const absolute = resolve(INTEGRATIONS, path);
+    assert.ok(existsSync(absolute), `missing Integrations module: ${path}`);
+    const source = readFileSync(absolute, 'utf8');
+    assertAllowedImports(source, absolute);
+    assertImportInertSource(source);
+    return [path, source];
+  });
+  assertSingleOwnership(sources);
+
+  const imported = spawnSync(process.execPath, [
+    '--input-type=module',
+    '-e',
+    `await import(${JSON.stringify(pathToFileURL(resolve(INTEGRATIONS, 'src/index.mjs')).href)})`,
+  ], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDECODE: '1', CLAUDE_CODE_SESSION_ID: 'poisoned' },
+  });
+  assert.equal(imported.status, 0, imported.stderr);
+  assert.equal(imported.stdout, '');
+  assert.equal(imported.stderr, '');
+});
+
+test('[req:MOD-20] legacy paths no longer own pure Integrations rules', () => {
+  const legacy = new Map([
+    ['src/taxonomy.mjs', [
+      'SESSION_HOOKS', 'CHANGE_NUDGE_HOOKS', 'CHANGE_GATE_HOOKS',
+      'CODEX_MATCHER_EVENTS', 'hookCommand', 'hookCommandLocal',
+      'hookCommandLocalLegacy', 'codexHookSpecs', 'codexHookEntry',
+    ]],
+    ['hooks/obsidian-common.mjs', [
+      'salvageTruncatedJson', 'extractHookPrompt', 'isBootstrapPrompt',
+      'redactSecrets', 'transcriptsMatch',
+    ]],
+    ['hooks/token-usage.mjs', [
+      'emptyTokenUsage', 'normalizeCodexUsage', 'normalizeClaudeUsage', 'addUsage',
+    ]],
+  ]);
+  for (const [path, forbidden] of legacy) {
+    const source = readFileSync(resolve(ROOT, path), 'utf8');
+    const declarations = new Set(declarationNames(source));
+    for (const name of forbidden) assert.equal(declarations.has(name), false, `${path} still owns ${name}`);
+    assert.match(source, /packages\/integrations\/src\//, `${path} must consume the canonical kernel`);
+  }
+});
+
+test('[req:MOD-20] [req:MOD-21] boundary gates reject cross-adapter and side-effect mutants', () => {
+  assert.throws(() => assertAllowedImports("import '../../mcp/src/index.mjs';"));
+  assert.throws(() => assertAllowedImports("import '../../../hooks/session-stop.mjs';"));
+  assert.throws(() => assertAllowedImports("const req = globalThis['require']; req('../../vault/src/index.mjs');"));
+  assert.throws(() => assertImportInertSource("import { readFileSync } from 'node:fs'; export const x = readFileSync(0);"));
+  assert.throws(() => assertImportInertSource("export function x() { process.stdout.write('x'); }"));
+  assert.throws(() => assertImportInertSource("export function x() { globalThis['process']['stdout'].write('x'); }"));
+  assert.throws(() => assertImportInertSource("export function x() { global['process'].env.SECRET; }"));
+  assert.throws(() => assertImportInertSource("export const x = Function('return process')();"));
+
+  const root = json(resolve(ROOT, 'package.json'));
+  const missingCheck = structuredClone(root);
+  missingCheck.scripts.check = missingCheck.scripts.check.replace(
+    'node --check packages/integrations/src/transcripts.mjs && ',
+    '',
+  );
+  assert.throws(() => assertCheckCoversIntegrations(missingCheck), /transcripts\.mjs/);
+
+  const valid = new Map([...OWNED_BINDINGS].map(([file, names]) => [
+    file,
+    names.map((name) => `export const ${name} = 1;`).join('\n'),
+  ]));
+  assert.doesNotThrow(() => assertSingleOwnership(valid));
+  valid.set('src/rogue.mjs', 'export const detectProvider = 1;');
+  assert.throws(() => assertSingleOwnership(valid));
+});

--- a/tests/integrations-session-identity.test.mjs
+++ b/tests/integrations-session-identity.test.mjs
@@ -1,0 +1,301 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  inspectTranscriptIdentityContent,
+  resolveSessionIdentitySnapshot,
+  transcriptsMatch,
+} from '../packages/integrations/src/session-identity.mjs';
+
+const CODEX_CANONICAL = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const CODEX_OTHER = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const TRANSCRIPT_PATH = 'C:\\Users\\tester\\.codex\\sessions\\rollout-current.jsonl';
+const jsonl = (events) => events.map((event) => (
+  typeof event === 'string' ? event : JSON.stringify(event)
+)).join('\n');
+
+function inspectedCodex(overrides = {}) {
+  return {
+    transcriptProvider: 'openai',
+    provider: 'codex',
+    canonicalConversationId: CODEX_CANONICAL,
+    transcriptId: 'rollout-current',
+    parentConversationId: '',
+    ...overrides,
+  };
+}
+
+function snapshot(overrides = {}) {
+  return {
+    input: { session_id: 'hook-ephemeral' },
+    provider: 'codex',
+    codexThreadId: '',
+    transcriptPath: TRANSCRIPT_PATH,
+    inspected: inspectedCodex(),
+    registry: { version: 2, sessions: {} },
+    ...overrides,
+  };
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  for (const nested of Object.values(value)) deepFreeze(nested);
+  return Object.freeze(value);
+}
+
+test('[req:MOD-21] inspectTranscriptIdentityContent ignora JSONL inválido e separa conversa, rollout e parent', () => {
+  const content = jsonl([
+    'linha invalida antes do meta',
+    {
+      type: 'session_meta',
+      payload: {
+        id: 'rollout-child',
+        session_id: CODEX_CANONICAL,
+        parent_thread_id: 'parent-preferido',
+        forked_from_id: 'fork-secundario',
+        model_provider: 'openai',
+      },
+    },
+  ]);
+
+  assert.deepEqual(inspectTranscriptIdentityContent(content, { fallbackTranscriptId: 'fallback' }), {
+    transcriptProvider: 'openai',
+    provider: 'codex',
+    canonicalConversationId: CODEX_CANONICAL,
+    transcriptId: 'rollout-child',
+    parentConversationId: 'parent-preferido',
+  });
+});
+
+test('[req:MOD-21] inspeção Codex preserva precedência session_id > id e parent_thread_id > forked_from_id', () => {
+  const preferred = inspectTranscriptIdentityContent(jsonl([{
+    type: 'session_meta',
+    payload: {
+      session_id: 'conversation', id: 'rollout',
+      parent_thread_id: 'parent', forked_from_id: 'fork',
+    },
+  }]), { fallbackTranscriptId: 'fallback' });
+  assert.equal(preferred.canonicalConversationId, 'conversation');
+  assert.equal(preferred.transcriptId, 'rollout');
+  assert.equal(preferred.parentConversationId, 'parent');
+
+  const fallbacks = inspectTranscriptIdentityContent(jsonl([{
+    type: 'session_meta', payload: { id: 'rollout-only', forked_from_id: 'fork-only' },
+  }]), { fallbackTranscriptId: 'filename-id' });
+  assert.equal(fallbacks.canonicalConversationId, 'rollout-only');
+  assert.equal(fallbacks.transcriptId, 'rollout-only');
+  assert.equal(fallbacks.parentConversationId, 'fork-only');
+});
+
+test('[req:MOD-21] inspeção Claude usa sessionId embutido e fallback explícito do transcript', () => {
+  const content = jsonl([
+    '{quebrada',
+    { type: 'user', sessionId: 'claude-session', message: { role: 'user', content: 'oi' } },
+  ]);
+  assert.deepEqual(inspectTranscriptIdentityContent(content, { fallbackTranscriptId: 'claude-file' }), {
+    transcriptProvider: 'anthropic',
+    provider: 'claude',
+    canonicalConversationId: 'claude-session',
+    transcriptId: 'claude-file',
+    parentConversationId: '',
+  });
+});
+
+test('[req:MOD-21] inspeção vazia ou desconhecida falha fechada sem inventar identidade', () => {
+  const expected = {
+    transcriptProvider: 'unknown',
+    provider: 'unknown',
+    canonicalConversationId: '',
+    transcriptId: '',
+    parentConversationId: '',
+  };
+  assert.deepEqual(inspectTranscriptIdentityContent(''), expected);
+  assert.deepEqual(inspectTranscriptIdentityContent('inválida\n{"type":"progress"}'), expected);
+});
+
+test('[req:MOD-21] resolveSessionIdentitySnapshot bloqueia conflito entre CODEX_THREAD_ID e session_id do transcript', () => {
+  const resolved = resolveSessionIdentitySnapshot(snapshot({ codexThreadId: CODEX_OTHER }));
+  assert.equal(resolved.state, 'deferred');
+  assert.equal(resolved.provider, 'codex');
+  assert.equal(resolved.transcriptPath, TRANSCRIPT_PATH);
+  assert.match(resolved.diagnostics.join(' '), /diverge/i);
+});
+
+test('[req:MOD-21] Codex sem transcript resolve somente por thread canônico válido', () => {
+  const noTranscript = {
+    input: { sessionId: 'hook-camel' },
+    provider: 'codex',
+    transcriptPath: '',
+    inspected: inspectedCodex({
+      transcriptProvider: 'unknown', provider: 'unknown', canonicalConversationId: '',
+      transcriptId: '', parentConversationId: '',
+    }),
+    registry: { version: 2, sessions: {} },
+  };
+  const resolved = resolveSessionIdentitySnapshot({ ...noTranscript, codexThreadId: CODEX_CANONICAL });
+  assert.deepEqual(resolved, {
+    state: 'resolved',
+    provider: 'codex',
+    canonicalConversationId: CODEX_CANONICAL,
+    hookSessionId: 'hook-camel',
+    transcriptPath: '',
+    transcriptId: CODEX_CANONICAL,
+    parentConversationId: '',
+    diagnostics: [],
+  });
+  assert.equal(resolveSessionIdentitySnapshot({
+    ...noTranscript, codexThreadId: 'resume-efemero-invalido',
+  }).state, 'deferred');
+});
+
+test('[req:MOD-21] aliases snake_case e camelCase do payload mantêm a mesma identidade', () => {
+  const common = snapshot({ input: {} });
+  const snake = resolveSessionIdentitySnapshot({
+    ...common,
+    input: { session_id: 'hook-alias', transcript_path: 'C:\\ignorado\\snake.jsonl' },
+  });
+  const camel = resolveSessionIdentitySnapshot({
+    ...common,
+    input: { sessionId: 'hook-alias', transcriptPath: 'C:\\ignorado\\camel.jsonl' },
+  });
+  assert.deepEqual(camel, snake);
+  assert.equal(camel.hookSessionId, 'hook-alias');
+  assert.equal(camel.transcriptPath, TRANSCRIPT_PATH, 'transcriptPath explícito prevalece sobre aliases do input');
+});
+
+test('[req:MOD-21] Claude novo sem transcript materializado resolve pelo sessionId do hook', () => {
+  const resolved = resolveSessionIdentitySnapshot({
+    input: { sessionId: 'claude-new-session' },
+    provider: 'claude',
+    codexThreadId: '',
+    transcriptPath: 'C:\\logs\\claude-new-session.jsonl',
+    inspected: {
+      transcriptProvider: 'unknown', provider: 'unknown', canonicalConversationId: '',
+      transcriptId: '', parentConversationId: '',
+    },
+    registry: { version: 2, sessions: {} },
+  });
+  assert.deepEqual(resolved, {
+    state: 'resolved',
+    provider: 'claude',
+    canonicalConversationId: 'claude-new-session',
+    hookSessionId: 'claude-new-session',
+    transcriptPath: 'C:\\logs\\claude-new-session.jsonl',
+    transcriptId: 'claude-new-session',
+    parentConversationId: '',
+    diagnostics: [],
+  });
+});
+
+test('[req:MOD-21] fallback pelo session_id consulta somente entrada do mesmo provider', () => {
+  const registryEntry = {
+    provider: 'codex',
+    transcript_path: 'C:\\logs\\known-rollout.jsonl',
+    transcript_id: 'known-rollout',
+  };
+  const base = {
+    input: { session_id: CODEX_CANONICAL },
+    provider: 'codex',
+    codexThreadId: '',
+    transcriptPath: '',
+    inspected: {
+      transcriptProvider: 'unknown', provider: 'unknown', canonicalConversationId: '',
+      transcriptId: '', parentConversationId: '',
+    },
+  };
+  const resolved = resolveSessionIdentitySnapshot({
+    ...base,
+    registry: { version: 2, sessions: { [CODEX_CANONICAL]: registryEntry } },
+  });
+  assert.equal(resolved.state, 'resolved');
+  assert.equal(resolved.transcriptPath, registryEntry.transcript_path);
+  assert.equal(resolved.transcriptId, registryEntry.transcript_id);
+
+  const mismatch = resolveSessionIdentitySnapshot({
+    ...base,
+    registry: {
+      version: 2,
+      sessions: { [CODEX_CANONICAL]: { ...registryEntry, provider: 'claude' } },
+    },
+  });
+  assert.equal(mismatch.state, 'deferred');
+});
+
+test('[req:MOD-21] transcript de provider incompatível permanece deferred', () => {
+  const resolved = resolveSessionIdentitySnapshot(snapshot({
+    inspected: {
+      transcriptProvider: 'anthropic',
+      provider: 'claude',
+      canonicalConversationId: 'claude-session',
+      transcriptId: 'claude-rollout',
+      parentConversationId: '',
+    },
+  }));
+  assert.equal(resolved.state, 'deferred');
+  assert.match(resolved.diagnostics.join(' '), /incompatível|incompativel/i);
+});
+
+test('[req:MOD-21] lookup registry por transcript ignora entrada de outro provider', () => {
+  const resolved = resolveSessionIdentitySnapshot(snapshot({
+    registry: {
+      version: 2,
+      sessions: {
+        'claude-nao-pode-roubar': {
+          provider: 'claude',
+          transcript_path: TRANSCRIPT_PATH,
+          transcript_paths: [TRANSCRIPT_PATH],
+        },
+      },
+    },
+  }));
+  assert.equal(resolved.state, 'resolved');
+  assert.equal(resolved.canonicalConversationId, CODEX_CANONICAL);
+  assert.notEqual(resolved.canonicalConversationId, 'claude-nao-pode-roubar');
+});
+
+test('[req:MOD-21] lookup registry por transcript reconecta somente entrada compatível', () => {
+  const resolved = resolveSessionIdentitySnapshot(snapshot({
+    registry: {
+      version: 2,
+      sessions: {
+        'conversa-ja-registrada': {
+          provider: 'codex',
+          transcript_paths: ['c:/users/tester/.codex/sessions/ROLLOUT-CURRENT.JSONL'],
+        },
+      },
+    },
+  }));
+  assert.equal(resolved.state, 'resolved');
+  assert.equal(resolved.canonicalConversationId, 'conversa-ja-registrada');
+});
+
+test('[req:MOD-21] transcriptsMatch normaliza separador/caixa, aceita basename e rejeita vazios', () => {
+  assert.equal(transcriptsMatch(
+    'C:\\Users\\Me\\.claude\\projects\\A\\SESSION.JSONL',
+    'c:/users/me/.claude/projects/a/session.jsonl',
+  ), true);
+  assert.equal(transcriptsMatch('/mnt/c/elsewhere/session.jsonl', 'C:\\logs\\SESSION.JSONL'), true);
+  assert.equal(transcriptsMatch('/a/one.jsonl', '/a/two.jsonl'), false);
+  assert.equal(transcriptsMatch('', '/a/two.jsonl'), false);
+  assert.equal(transcriptsMatch('/a/two.jsonl', null), false);
+});
+
+test('[req:MOD-20] [req:MOD-21] resolução é determinística e não muta input, inspeção ou registry', () => {
+  const argumentsSnapshot = deepFreeze(snapshot({
+    input: { session_id: 'hook-immutable', transcript_path: TRANSCRIPT_PATH },
+    registry: {
+      version: 2,
+      sessions: {
+        [CODEX_CANONICAL]: {
+          provider: 'codex',
+          transcript_path: TRANSCRIPT_PATH,
+          transcript_paths: [TRANSCRIPT_PATH],
+        },
+      },
+    },
+  }));
+  const before = JSON.stringify(argumentsSnapshot);
+  const first = resolveSessionIdentitySnapshot(argumentsSnapshot);
+  const second = resolveSessionIdentitySnapshot(argumentsSnapshot);
+  assert.deepEqual(second, first);
+  assert.equal(JSON.stringify(argumentsSnapshot), before);
+});

--- a/tests/integrations-transcripts.test.mjs
+++ b/tests/integrations-transcripts.test.mjs
@@ -1,0 +1,429 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseClaudeTranscriptContent,
+  parseCodexTranscriptContent,
+  parseTranscriptContent,
+  resolveTurnIdentity,
+} from '../packages/integrations/src/transcripts.mjs';
+
+const REPO_ROOT = 'C:\\work\\demo';
+const VAULT_ROOT = 'C:\\work\\demo\\.WendKeep-vault';
+const PARSE_OPTIONS = Object.freeze({ repoRoot: REPO_ROOT, vaultRoot: VAULT_ROOT });
+const emptyUsage = () => ({
+  input: 0,
+  cached: 0,
+  cacheWrite: 0,
+  cacheWrite1h: 0,
+  output: 0,
+  reasoning: 0,
+  total: 0,
+});
+const jsonl = (events) => events.map((event) => (
+  typeof event === 'string' ? event : JSON.stringify(event)
+)).join('\n');
+
+const CODEX_EVENTS = [
+  {
+    type: 'session_meta',
+    timestamp: '2026-07-29T10:00:00.000Z',
+    payload: {
+      id: 'rollout-codex-42',
+      session_id: 'conversation-codex-42',
+      model: 'gpt-5.6-sol',
+      model_provider: 'openai',
+    },
+  },
+  '{linha jsonl deliberadamente invalida',
+  {
+    type: 'turn_context',
+    timestamp: '2026-07-29T10:00:01.000Z',
+    payload: { turn_id: 'codex-turn-1', model: 'gpt-5.6-sol' },
+  },
+  {
+    type: 'event_msg',
+    timestamp: '2026-07-29T10:00:02.000Z',
+    payload: {
+      type: 'user_message',
+      turn_id: 'codex-turn-1',
+      message: '<recommended_plugins>catalogo injetado</recommended_plugins>',
+    },
+  },
+  {
+    type: 'event_msg',
+    timestamp: '2026-07-29T10:00:03.000Z',
+    payload: {
+      type: 'user_message',
+      turn_id: 'codex-turn-1',
+      message: 'Quais recommended_plugins devo instalar no projeto?',
+    },
+  },
+  {
+    type: 'response_item',
+    timestamp: '2026-07-29T10:00:04.000Z',
+    payload: {
+      type: 'message',
+      role: 'user',
+      turn_id: 'codex-turn-1',
+      content: [{ type: 'input_text', text: 'Leia src/app.mjs antes de responder.' }],
+    },
+  },
+  {
+    type: 'event_msg',
+    timestamp: '2026-07-29T10:00:05.000Z',
+    payload: {
+      type: 'agent_message',
+      turn_id: 'codex-turn-1',
+      message: 'Vou inspecionar os arquivos.',
+    },
+  },
+  {
+    type: 'response_item',
+    timestamp: '2026-07-29T10:00:06.000Z',
+    payload: {
+      type: 'message',
+      role: 'assistant',
+      turn_id: 'codex-turn-1',
+      content: [{ type: 'output_text', text: 'A inspeção confirmou o contrato.' }],
+    },
+  },
+  {
+    type: 'response_item',
+    timestamp: '2026-07-29T10:00:07.000Z',
+    payload: {
+      type: 'function_call',
+      turn_id: 'codex-turn-1',
+      name: 'Read',
+      arguments: JSON.stringify({ file_path: 'src/helper.mjs' }),
+    },
+  },
+  {
+    type: 'response_item',
+    timestamp: '2026-07-29T10:00:08.000Z',
+    payload: {
+      type: 'function_call',
+      turn_id: 'codex-turn-1',
+      name: 'apply_patch',
+      arguments: '*** Update File: src/app.mjs\n@@\n-old\n+new',
+    },
+  },
+  {
+    type: 'response_item',
+    timestamp: '2026-07-29T10:00:09.000Z',
+    payload: { type: 'tool_search_call', turn_id: 'codex-turn-1' },
+  },
+  {
+    type: 'response_item',
+    timestamp: '2026-07-29T10:00:10.000Z',
+    payload: { type: 'web_search_call', turn_id: 'codex-turn-1' },
+  },
+  {
+    type: 'event_msg',
+    timestamp: '2026-07-29T10:00:11.000Z',
+    payload: {
+      type: 'token_count',
+      turn_id: 'codex-turn-1',
+      info: {
+        model: 'gpt-5.6-sol',
+        last_token_usage: {
+          input_tokens: 120,
+          cached_input_tokens: 20,
+          output_tokens: 50,
+          reasoning_output_tokens: 10,
+          total_tokens: 170,
+        },
+      },
+    },
+  },
+  {
+    type: 'event_msg',
+    timestamp: '2026-07-29T10:05:00.000Z',
+    payload: { type: 'task_started', turn_id: 'codex-turn-2' },
+  },
+  {
+    type: 'event_msg',
+    timestamp: '2026-07-29T10:05:01.000Z',
+    payload: { type: 'user_message', turn_id: 'codex-turn-2', message: 'Continue para o segundo turno.' },
+  },
+  {
+    type: 'event_msg',
+    timestamp: '2026-07-29T10:05:02.000Z',
+    payload: { type: 'agent_message', turn_id: 'codex-turn-2', text: 'Segundo turno concluído.' },
+  },
+];
+
+const CODEX_CONTENT = `${jsonl(CODEX_EVENTS)}\n`;
+
+const EXPECTED_CODEX = {
+  provider: 'codex',
+  sessionId: 'rollout-codex-42',
+  model: 'gpt-5.6-sol',
+  latestTurnId: 'codex-turn-2',
+  latestUserPrompt: 'Continue para o segundo turno.',
+  latestAssistantMessage: 'Segundo turno concluído.',
+  userPrompts: [
+    'Quais recommended_plugins devo instalar no projeto?',
+    'Leia src/app.mjs antes de responder.',
+    'Continue para o segundo turno.',
+  ],
+  assistantMessages: [
+    'Vou inspecionar os arquivos.',
+    'A inspeção confirmou o contrato.',
+    'Segundo turno concluído.',
+  ],
+  tools: ['Read', 'apply_patch', 'tool_search', 'web_search'],
+  consultedFiles: ['src/helper.mjs', 'src/app.mjs'],
+  changedFiles: ['src/app.mjs'],
+  turns: [
+    {
+      turnId: 'codex-turn-1',
+      timestamp: '2026-07-29T10:00:01.000Z',
+      userPrompts: [
+        'Quais recommended_plugins devo instalar no projeto?',
+        'Leia src/app.mjs antes de responder.',
+      ],
+      assistantMessages: ['Vou inspecionar os arquivos.', 'A inspeção confirmou o contrato.'],
+      tools: ['Read', 'apply_patch', 'tool_search', 'web_search'],
+      consultedFiles: ['src/helper.mjs', 'src/app.mjs'],
+      changedFiles: ['src/app.mjs'],
+      conversation: [
+        { role: 'Usuário', text: 'Quais recommended_plugins devo instalar no projeto?' },
+        { role: 'Usuário', text: 'Leia src/app.mjs antes de responder.' },
+        { role: 'Assistente', text: 'Vou inspecionar os arquivos.' },
+        { role: 'Assistente', text: 'A inspeção confirmou o contrato.' },
+      ],
+      usage: {
+        input: 100,
+        cached: 20,
+        cacheWrite: 0,
+        cacheWrite1h: 0,
+        output: 50,
+        reasoning: 10,
+        total: 170,
+      },
+      model: 'gpt-5.6-sol',
+    },
+    {
+      turnId: 'codex-turn-2',
+      timestamp: '2026-07-29T10:05:00.000Z',
+      userPrompts: ['Continue para o segundo turno.'],
+      assistantMessages: ['Segundo turno concluído.'],
+      tools: [],
+      consultedFiles: [],
+      changedFiles: [],
+      conversation: [
+        { role: 'Usuário', text: 'Continue para o segundo turno.' },
+        { role: 'Assistente', text: 'Segundo turno concluído.' },
+      ],
+      usage: emptyUsage(),
+      model: '',
+    },
+  ],
+  rawTextForDetection: [
+    'Quais recommended_plugins devo instalar no projeto?',
+    'Leia src/app.mjs antes de responder.',
+    'Continue para o segundo turno.',
+    'Vou inspecionar os arquivos.',
+    'A inspeção confirmou o contrato.',
+    'Segundo turno concluído.',
+  ].join('\n\n'),
+};
+
+const CLAUDE_EVENTS = [
+  {
+    type: 'user',
+    uuid: 'claude-turn-1',
+    timestamp: '2026-07-29T11:00:00.000Z',
+    sessionId: 'claude-conversation-7',
+    message: {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Analise src/auth.mjs.' },
+        { type: 'tool_result', content: 'resultado interno' },
+        { type: 'text', text: '<system-reminder>contexto injetado</system-reminder>' },
+      ],
+    },
+  },
+  'nao-json entre eventos validos',
+  {
+    type: 'assistant',
+    uuid: 'claude-answer-1',
+    timestamp: '2026-07-29T11:00:01.000Z',
+    sessionId: 'claude-conversation-7',
+    message: {
+      role: 'assistant',
+      model: 'claude-opus-4-8',
+      usage: {
+        input_tokens: 10,
+        cache_read_input_tokens: 3,
+        cache_creation_input_tokens: 2,
+        cache_creation: { ephemeral_1h_input_tokens: 1 },
+        output_tokens: 5,
+      },
+      content: [
+        { type: 'thinking', thinking: 'não entra na conversa' },
+        { type: 'text', text: 'A autenticação está isolada.' },
+        { type: 'tool_use', name: 'Read', input: { file_path: 'src/auth.mjs' } },
+      ],
+    },
+  },
+  {
+    type: 'user',
+    uuid: 'claude-meta',
+    timestamp: '2026-07-29T11:04:00.000Z',
+    sessionId: 'claude-conversation-7',
+    message: { role: 'user', content: 'Generate a concise UI title for this task.' },
+  },
+  {
+    type: 'user',
+    uuid: 'claude-turn-2',
+    timestamp: '2026-07-29T11:05:00.000Z',
+    sessionId: 'claude-conversation-7',
+    message: { role: 'user', content: 'Quais recommended_plugins são opcionais?' },
+  },
+  {
+    type: 'assistant',
+    uuid: 'claude-answer-2',
+    timestamp: '2026-07-29T11:05:01.000Z',
+    sessionId: 'claude-conversation-7',
+    message: {
+      role: 'assistant',
+      model: 'claude-sonnet-5',
+      usage: { input_tokens: 7, output_tokens: 4 },
+      content: [
+        { type: 'text', text: 'Todos são opcionais.' },
+        { type: 'tool_use', name: 'Write', input: { file_path: 'src/result.mjs' } },
+      ],
+    },
+  },
+];
+
+const CLAUDE_CONTENT = `${jsonl(CLAUDE_EVENTS)}\n`;
+
+const EXPECTED_CLAUDE = {
+  provider: 'claude',
+  sessionId: 'claude-conversation-7',
+  model: 'claude-sonnet-5',
+  latestTurnId: 'claude-turn-2',
+  latestUserPrompt: 'Quais recommended_plugins são opcionais?',
+  latestAssistantMessage: 'Todos são opcionais.',
+  userPrompts: ['Analise src/auth.mjs.', 'Quais recommended_plugins são opcionais?'],
+  assistantMessages: ['A autenticação está isolada.', 'Todos são opcionais.'],
+  tools: ['Read', 'Write'],
+  consultedFiles: ['src/auth.mjs', 'src/result.mjs'],
+  changedFiles: ['src/result.mjs'],
+  turns: [
+    {
+      turnId: 'claude-turn-1',
+      timestamp: '2026-07-29T11:00:00.000Z',
+      userPrompts: ['Analise src/auth.mjs.'],
+      assistantMessages: ['A autenticação está isolada.'],
+      tools: ['Read'],
+      consultedFiles: ['src/auth.mjs'],
+      changedFiles: [],
+      conversation: [
+        { role: 'Usuário', text: 'Analise src/auth.mjs.' },
+        { role: 'Assistente', text: 'A autenticação está isolada.' },
+      ],
+      usage: {
+        input: 10,
+        cached: 3,
+        cacheWrite: 2,
+        cacheWrite1h: 1,
+        output: 5,
+        reasoning: 0,
+        total: 20,
+      },
+      model: 'claude-opus-4-8',
+    },
+    {
+      turnId: 'claude-turn-2',
+      timestamp: '2026-07-29T11:05:00.000Z',
+      userPrompts: ['Quais recommended_plugins são opcionais?'],
+      assistantMessages: ['Todos são opcionais.'],
+      tools: ['Write'],
+      consultedFiles: ['src/result.mjs'],
+      changedFiles: ['src/result.mjs'],
+      conversation: [
+        { role: 'Usuário', text: 'Quais recommended_plugins são opcionais?' },
+        { role: 'Assistente', text: 'Todos são opcionais.' },
+      ],
+      usage: {
+        input: 7,
+        cached: 0,
+        cacheWrite: 0,
+        cacheWrite1h: 0,
+        output: 4,
+        reasoning: 0,
+        total: 11,
+      },
+      model: 'claude-sonnet-5',
+    },
+  ],
+  rawTextForDetection: [
+    'Analise src/auth.mjs.',
+    'Quais recommended_plugins são opcionais?',
+    'A autenticação está isolada.',
+    'Todos são opcionais.',
+  ].join('\n\n'),
+};
+
+test('[req:MOD-21] parseCodexTranscriptContent preserva o formato completo sem filesystem', () => {
+  assert.deepEqual(parseCodexTranscriptContent(CODEX_CONTENT, PARSE_OPTIONS), EXPECTED_CODEX);
+});
+
+test('[req:MOD-21] parseClaudeTranscriptContent preserva o formato completo sem filesystem', () => {
+  assert.deepEqual(parseClaudeTranscriptContent(CLAUDE_CONTENT, PARSE_OPTIONS), EXPECTED_CLAUDE);
+});
+
+test('[req:MOD-21] parseTranscriptContent ignora JSONL inválido e despacha pelo primeiro evento reconhecível', () => {
+  assert.deepEqual(parseTranscriptContent(`invalida\n${CODEX_CONTENT}`, PARSE_OPTIONS), EXPECTED_CODEX);
+  assert.deepEqual(parseTranscriptContent(`invalida\n${CLAUDE_CONTENT}`, PARSE_OPTIONS), EXPECTED_CLAUDE);
+});
+
+test('[req:MOD-21] filtro de meta-prompt é ancorado e não engole menção humana a recommended_plugins', () => {
+  const parsed = parseCodexTranscriptContent(CODEX_CONTENT, PARSE_OPTIONS);
+  assert.doesNotMatch(parsed.rawTextForDetection, /catalogo injetado/);
+  assert.ok(parsed.userPrompts.includes('Quais recommended_plugins devo instalar no projeto?'));
+  assert.deepEqual(parsed.turns.map((turn) => turn.turnId), ['codex-turn-1', 'codex-turn-2']);
+});
+
+test('[req:MOD-21] roots explícitos normalizam paths do repositório e excluem paths do Vault', () => {
+  const content = jsonl([
+    { type: 'turn_context', payload: { turn_id: 'path-turn' } },
+    {
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        turn_id: 'path-turn',
+        name: 'Read',
+        arguments: JSON.stringify({
+          source: 'C:\\work\\demo\\src\\feature.mjs',
+          privateNote: 'C:\\work\\demo\\.WendKeep-vault\\02-Sessões\\private.md',
+        }),
+      },
+    },
+  ]);
+  const parsed = parseCodexTranscriptContent(content, PARSE_OPTIONS);
+  assert.deepEqual(parsed.consultedFiles, ['src/feature.mjs']);
+  assert.deepEqual(parsed.changedFiles, []);
+});
+
+test('[req:MOD-21] resolveTurnIdentity usa id solicitado, latest e ordem observada sem inventar turno', () => {
+  assert.deepEqual(resolveTurnIdentity(EXPECTED_CODEX, 'codex-turn-1'), {
+    id: 'codex-turn-1', order: 1, observedAt: '2026-07-29T10:00:01.000Z',
+  });
+  assert.deepEqual(resolveTurnIdentity(EXPECTED_CODEX), {
+    id: 'codex-turn-2', order: 2, observedAt: '2026-07-29T10:05:00.000Z',
+  });
+  assert.equal(resolveTurnIdentity(EXPECTED_CODEX, 'turno-ausente'), null);
+  assert.equal(resolveTurnIdentity({ turns: [] }), null);
+});
+
+test('[req:MOD-20] [req:MOD-21] parsers por conteúdo são determinísticos e não mutam opções', () => {
+  const before = JSON.stringify(PARSE_OPTIONS);
+  const first = parseTranscriptContent(CLAUDE_CONTENT, PARSE_OPTIONS);
+  const second = parseTranscriptContent(CLAUDE_CONTENT, PARSE_OPTIONS);
+  assert.deepEqual(second, first);
+  assert.equal(JSON.stringify(PARSE_OPTIONS), before);
+});

--- a/tests/modular-package-boundaries.test.mjs
+++ b/tests/modular-package-boundaries.test.mjs
@@ -8,6 +8,7 @@ import { importSpecifiers } from './helpers/import-specifiers.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const SURFACES = ['cli', 'harness', 'vault', 'mcp', 'integrations', 'pi'];
+const ADAPTERS = new Set(['cli', 'mcp', 'integrations', 'pi']);
 const INITIAL_MEMORY_KERNEL = [
   { module: 'memory-schema.mjs', legacy: '../hooks/memory-schema.mjs' },
   { module: 'memory-mode.mjs', legacy: '../hooks/memory-mode.mjs' },
@@ -19,6 +20,16 @@ const HARNESS_POLICY_KERNEL = [
   { module: 'operating-profile.mjs', legacy: '../src/operating-profile.mjs' },
   { module: 'sensors-core.mjs', legacy: '../hooks/sensors-core.mjs' },
 ];
+const INTEGRATIONS_KERNEL = [
+  'index.mjs',
+  'host-hooks.mjs',
+  'hook-envelope.mjs',
+  'prompt-content.mjs',
+  'transcript-usage.mjs',
+  'transcripts.mjs',
+  'session-identity.mjs',
+];
+const EFFECTFUL_BUILTINS = /^(?:node:)?(?:child_process|cluster|dgram|dns|fs|fs\/promises|http|https|net|readline|tls|worker_threads)$/;
 
 function json(path) {
   return JSON.parse(readFileSync(path, 'utf8'));
@@ -41,6 +52,60 @@ function assertSameBindings(canonical, publicSurface, legacy, label) {
     assert.equal(legacy[name], value, `${label}: legacy identity differs for ${name}`);
   }
   assert.deepEqual(Object.keys(legacy).sort(), Object.keys(canonical).sort());
+}
+
+function moduleFilesUnder(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return moduleFilesUnder(path);
+    return /\.(?:cjs|js|mjs)$/.test(entry.name) ? [path] : [];
+  });
+}
+
+function normalizedRelative(from, to) {
+  return relative(from, to).replaceAll('\\', '/');
+}
+
+function packageDependency(owner, file, specifier) {
+  if (specifier.startsWith('<dynamic:') || specifier.startsWith('node:')) return null;
+  const internal = specifier.match(/^@wendkeep\/([^/]+)(?:\/|$)/)
+    || specifier.match(/^wendkeep\/(?:packages\/)?([^/]+)(?:\/|$)/);
+  if (internal) return internal[1];
+  if (!specifier.startsWith('.')) return null;
+
+  let target;
+  try {
+    target = resolve(dirname(file), decodeURIComponent(specifier));
+  } catch {
+    return '<invalid>';
+  }
+  const match = normalizedRelative(join(ROOT, 'packages'), target).match(/^([^/]+)(?:\/|$)/);
+  return match && !match[1].startsWith('.') && match[1] !== owner ? match[1] : null;
+}
+
+function assertAcyclic(graph) {
+  const visiting = new Set();
+  const visited = new Set();
+  function visit(node, trail = []) {
+    if (visiting.has(node)) assert.fail(`package dependency cycle: ${[...trail, node].join(' -> ')}`);
+    if (visited.has(node)) return;
+    visiting.add(node);
+    for (const dependency of graph.get(node) || []) visit(dependency, [...trail, node]);
+    visiting.delete(node);
+    visited.add(node);
+  }
+  for (const node of graph.keys()) visit(node);
+}
+
+function assertAdapterSiblings(graph) {
+  for (const owner of ADAPTERS) {
+    for (const dependency of graph.get(owner) || []) {
+      if (ADAPTERS.has(dependency)) {
+        assert.fail(`adapter dependency forbidden: ${owner} -> ${dependency}`);
+      }
+    }
+  }
 }
 
 test('[req:MOD-1] root declares all six internal workspaces exactly once', () => {
@@ -181,4 +246,110 @@ test('[req:MOD-3] Vault imports only Node built-ins or modules inside its worksp
     }
   }
   assert.deepEqual(violations, []);
+});
+
+test('[req:MOD-20] [req:MOD-21] Integrations is a private, inert adapter sibling of MCP', () => {
+  const workspace = json(join(ROOT, 'packages', 'integrations', 'package.json'));
+  const root = json(join(ROOT, 'package.json'));
+  assert.equal(workspace.private, true);
+  assert.equal(workspace.exports, './src/index.mjs');
+  assert.equal(Object.hasOwn(root.exports, './integrations'), false);
+  assert.equal(Object.hasOwn(root.exports, './*'), false);
+  const publicPackageTargets = new Set([
+    './packages/harness/src/index.mjs',
+    './packages/vault/src/index.mjs',
+  ]);
+  assert.equal(
+    Object.entries(root.exports).some(([key, target]) => (
+      key.startsWith('./packages')
+      || (String(target).startsWith('./packages') && !publicPackageTargets.has(target))
+    )),
+    false,
+  );
+
+  const integrationsRoot = join(ROOT, 'packages', 'integrations');
+  const srcRoot = join(integrationsRoot, 'src');
+  for (const module of INTEGRATIONS_KERNEL) {
+    assert.ok(existsSync(join(srcRoot, module)), `missing Integrations kernel module: ${module}`);
+  }
+
+  const violations = [];
+  for (const file of moduleFilesUnder(srcRoot)) {
+    for (const specifier of importSpecifiers(file)) {
+      if (specifier.startsWith('<dynamic:') || EFFECTFUL_BUILTINS.test(specifier)) {
+        violations.push(`${normalizedRelative(integrationsRoot, file)} -> ${specifier}`);
+        continue;
+      }
+      if (specifier.startsWith('node:')) continue;
+      if (!specifier.startsWith('.')) {
+        violations.push(`${normalizedRelative(integrationsRoot, file)} -> ${specifier}`);
+        continue;
+      }
+      let target;
+      try {
+        target = resolve(dirname(file), decodeURIComponent(specifier));
+      } catch {
+        violations.push(`${normalizedRelative(integrationsRoot, file)} -> ${specifier}`);
+        continue;
+      }
+      const escaped = normalizedRelative(integrationsRoot, target);
+      if (escaped === '..' || escaped.startsWith('../')) {
+        violations.push(`${normalizedRelative(integrationsRoot, file)} -> ${specifier}`);
+      }
+    }
+  }
+
+  for (const file of moduleFilesUnder(join(ROOT, 'packages', 'mcp', 'src'))) {
+    for (const specifier of importSpecifiers(file)) {
+      if (packageDependency('mcp', file, specifier) === 'integrations') {
+        violations.push(`${normalizedRelative(ROOT, file)} -> ${specifier}`);
+      }
+    }
+  }
+  assert.deepEqual(violations, []);
+});
+
+test('[req:MOD-21] package dependency direction is acyclic', () => {
+  const graph = new Map(SURFACES.map((surface) => [surface, new Set()]));
+  for (const surface of SURFACES) {
+    const src = join(ROOT, 'packages', surface, 'src');
+    for (const file of moduleFilesUnder(src)) {
+      for (const specifier of importSpecifiers(file)) {
+        const dependency = packageDependency(surface, file, specifier);
+        if (graph.has(dependency)) graph.get(surface).add(dependency);
+      }
+    }
+  }
+  assertAcyclic(graph);
+  assertAdapterSiblings(graph);
+
+  assert.throws(
+    () => assertAcyclic(new Map([
+      ['mcp', new Set(['integrations'])],
+      ['integrations', new Set(['mcp'])],
+    ])),
+    /dependency cycle/,
+  );
+  assert.equal(
+    packageDependency(
+      'integrations',
+      join(ROOT, 'packages', 'integrations', 'src', 'index.mjs'),
+      '../../mcp/src/index.mjs',
+    ),
+    'mcp',
+  );
+  assert.throws(
+    () => assertAdapterSiblings(new Map([
+      ['cli', new Set(['integrations'])],
+      ['integrations', new Set()],
+    ])),
+    /adapter dependency forbidden: cli -> integrations/,
+  );
+  assert.throws(
+    () => assertAdapterSiblings(new Map([
+      ['pi', new Set(['mcp'])],
+      ['mcp', new Set()],
+    ])),
+    /adapter dependency forbidden: pi -> mcp/,
+  );
 });

--- a/tests/session-stop-migration-lifecycle.test.mjs
+++ b/tests/session-stop-migration-lifecycle.test.mjs
@@ -233,6 +233,11 @@ test('[req:MEM-STOP-1] [req:MEM-STOP-7] removing lifecycle staging makes the ful
       join(mutantRoot, 'packages', 'vault'),
       { recursive: true },
     );
+    cpSync(
+      join(ROOT, 'packages', 'integrations'),
+      join(mutantRoot, 'packages', 'integrations'),
+      { recursive: true },
+    );
 
     assert.doesNotThrow(() => runMigrationLifecycle(mutantRoot));
 

--- a/tests/tarball-smoke.test.mjs
+++ b/tests/tarball-smoke.test.mjs
@@ -4,7 +4,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, posix } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -73,7 +76,7 @@ test('every published hook passes node --check (no broken syntax shipped)', () =
   }
 });
 
-test('[req:MOD-4] [req:MOD-8] [req:MOD-10] [req:MOD-11] [req:MOD-12] [req:MOD-13] [req:MOD-16] [req:MOD-19] published tarball contains the modular surfaces', () => {
+test('[req:MOD-4] [req:MOD-8] [req:MOD-10] [req:MOD-11] [req:MOD-12] [req:MOD-13] [req:MOD-16] [req:MOD-19] [req:MOD-20] [req:MOD-22] published tarball contains the modular surfaces', () => {
   const published = publishedFiles();
   for (const path of [
     'packages/cli/package.json',
@@ -87,6 +90,13 @@ test('[req:MOD-4] [req:MOD-8] [req:MOD-10] [req:MOD-11] [req:MOD-12] [req:MOD-13
     'packages/mcp/src/config.mjs',
     'packages/mcp/src/index.mjs',
     'packages/integrations/package.json',
+    'packages/integrations/src/hook-envelope.mjs',
+    'packages/integrations/src/host-hooks.mjs',
+    'packages/integrations/src/index.mjs',
+    'packages/integrations/src/prompt-content.mjs',
+    'packages/integrations/src/session-identity.mjs',
+    'packages/integrations/src/transcript-usage.mjs',
+    'packages/integrations/src/transcripts.mjs',
     'packages/pi/package.json',
     'packages/vault/package.json',
     'packages/vault/src/index.mjs',
@@ -124,7 +134,32 @@ test('[req:MOD-17] [req:MOD-19] MCP workspace declares its private kernel withou
   assert.match(root.scripts.check, /node --check packages\/mcp\/src\/index\.mjs/);
 });
 
-test('[req:MOD-4] [req:MOD-6] [req:MOD-9] [req:MOD-10] [req:MOD-11] [req:MOD-12] [req:MOD-13] [req:MOD-16] [req:MOD-18] [req:MOD-19] installed tarball exposes strict canonical, public, and legacy identities', () => {
+test('[req:MOD-20] [req:MOD-22] Integrations workspace is packaged privately without a public subpath', () => {
+  const root = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8'));
+  const integrations = JSON.parse(readFileSync(
+    join(pkgRoot, 'packages', 'integrations', 'package.json'),
+    'utf8',
+  ));
+
+  assert.equal(integrations.name, '@wendkeep/integrations');
+  assert.equal(integrations.private, true);
+  assert.equal(integrations.exports, './src/index.mjs');
+  assert.equal(Object.hasOwn(root.exports, './integrations'), false);
+  assert.equal(Object.hasOwn(root.exports, './*'), false);
+  const publicPackageTargets = new Set([
+    './packages/harness/src/index.mjs',
+    './packages/vault/src/index.mjs',
+  ]);
+  assert.equal(
+    Object.entries(root.exports).some(([key, target]) => (
+      key.startsWith('./packages')
+      || (String(target).startsWith('./packages') && !publicPackageTargets.has(target))
+    )),
+    false,
+  );
+});
+
+test('[req:MOD-4] [req:MOD-6] [req:MOD-9] [req:MOD-10] [req:MOD-11] [req:MOD-12] [req:MOD-13] [req:MOD-16] [req:MOD-18] [req:MOD-19] [req:MOD-20] [req:MOD-21] [req:MOD-22] installed tarball exposes strict canonical, public, and legacy identities', () => {
   const temp = mkdtempSync(join(tmpdir(), 'wendkeep-installed-tarball-'));
   try {
     const packed = spawnSync(`npm pack --json --pack-destination "${temp}"`, {
@@ -151,9 +186,14 @@ test('[req:MOD-4] [req:MOD-6] [req:MOD-9] [req:MOD-10] [req:MOD-11] [req:MOD-12]
     const imported = spawnSync(process.execPath, ['--input-type=module', '--eval', [
       "const vault = await import('wendkeep/vault');",
       "const harness = await import('wendkeep/harness');",
-      "const canonicalMcp = await import('wendkeep/packages/mcp/src/index.mjs');",
-      "const canonicalLocale = await import('wendkeep/packages/vault/src/locale.mjs');",
-      "const canonicalFlowStore = await import('wendkeep/packages/harness/src/flow-store.mjs');",
+      "const path = await import('node:path');",
+      "const { pathToFileURL } = await import('node:url');",
+      "const installedRoot = path.join(process.cwd(), 'node_modules', 'wendkeep');",
+      "const internal = (...parts) => import(pathToFileURL(path.join(installedRoot, ...parts)).href);",
+      "const canonicalMcp = await internal('packages', 'mcp', 'src', 'index.mjs');",
+      "const canonicalIntegrations = await internal('packages', 'integrations', 'src', 'index.mjs');",
+      "const canonicalLocale = await internal('packages', 'vault', 'src', 'locale.mjs');",
+      "const canonicalFlowStore = await internal('packages', 'harness', 'src', 'flow-store.mjs');",
       "const legacyLocale = await import('wendkeep/hooks/locale.mjs');",
       "const legacy = await import('wendkeep/hooks/vault-path-safety.mjs');",
       "const legacyStore = await import('wendkeep/hooks/memory-store.mjs');",
@@ -161,6 +201,9 @@ test('[req:MOD-4] [req:MOD-6] [req:MOD-9] [req:MOD-10] [req:MOD-11] [req:MOD-12]
       "const legacyProfile = await import('wendkeep/src/operating-profile.mjs');",
       "const legacySensors = await import('wendkeep/hooks/sensors-core.mjs');",
       "const legacyTaxonomy = await import('wendkeep/src/taxonomy.mjs');",
+      "const legacyCommon = await import('wendkeep/hooks/obsidian-common.mjs');",
+      "const legacyUsage = await import('wendkeep/hooks/token-usage.mjs');",
+      "const legacySessionStop = await import('wendkeep/hooks/session-stop.mjs');",
       "if (typeof vault.resolveProjectVault !== 'function') process.exit(11);",
       "if (typeof legacy.assertVaultPathSafe !== 'function') process.exit(12);",
       "const shared = vault.renderSharedMemory({ updatedAt: '2026-07-28T00:00:00.000Z', reviewAfter: '2026-08-04T00:00:00.000Z' });",
@@ -237,9 +280,30 @@ test('[req:MOD-4] [req:MOD-6] [req:MOD-9] [req:MOD-10] [req:MOD-11] [req:MOD-12]
       "const mcpMerged = canonicalMcp.mergeMcpConfig({ mcpServers: { user: { command: 'user' } } }, { vaultPath: 'C:/vault' });",
       "if (mcpMerged.mcpServers.user.command !== 'user') process.exit(29);",
       "if (mcpMerged.mcpServers['wendkeep-vault'].args.at(-1) !== 'C:/vault') process.exit(30);",
-      "for (const specifier of ['wendkeep/mcp', '@wendkeep/mcp']) {",
-      "  try { await import(specifier); process.exit(31); } catch (error) {",
-      "    if (!['ERR_MODULE_NOT_FOUND', 'ERR_PACKAGE_PATH_NOT_EXPORTED'].includes(error.code)) process.exit(32);",
+      "const integrationsFacades = [",
+      "  [legacyTaxonomy, ['SESSION_HOOKS', 'CHANGE_NUDGE_HOOKS', 'CHANGE_GATE_HOOKS',",
+      "    'CODEX_MATCHER_EVENTS', 'hookCommand', 'hookCommandLocal',",
+      "    'hookCommandLocalLegacy', 'codexHookSpecs', 'codexHookEntry']],",
+      "  [legacyCommon, ['salvageTruncatedJson', 'extractHookPrompt', 'isBootstrapPrompt',",
+      "    'redactSecrets', 'transcriptsMatch']],",
+      "  [legacyUsage, ['emptyTokenUsage', 'normalizeCodexUsage', 'normalizeClaudeUsage', 'addUsage']],",
+      "  [legacySessionStop, ['resolveTurnIdentity']],",
+      "];",
+      "for (const [facade, names] of integrationsFacades) {",
+      "  for (const name of names) {",
+      "    if (!(name in canonicalIntegrations) || canonicalIntegrations[name] !== facade[name]) {",
+      "      throw new Error(`missing or non-identical installed Integrations facade: ${name}`);",
+      "    }",
+      "  }",
+      "}",
+      "for (const specifier of [",
+      "  'wendkeep/mcp', '@wendkeep/mcp', 'wendkeep/integrations', '@wendkeep/integrations',",
+      "  'wendkeep/packages/mcp/src/index.mjs', 'wendkeep/packages/harness/src/index.mjs',",
+      "  'wendkeep/packages/vault/src/index.mjs', 'wendkeep/packages/integrations',",
+      "  'wendkeep/packages/integrations/src/index.mjs', 'wendkeep/%70ackages/integrations/src/index.mjs',",
+      "]) {",
+      "  try { await import(specifier); process.exit(32); } catch (error) {",
+      "    if (!['ERR_MODULE_NOT_FOUND', 'ERR_PACKAGE_PATH_NOT_EXPORTED'].includes(error.code)) process.exit(33);",
       "  }",
       "}",
     ].join('\n')], { cwd: consumer, encoding: 'utf8' });
@@ -293,6 +357,156 @@ test('[req:MOD-4] [req:MOD-6] [req:MOD-9] [req:MOD-10] [req:MOD-11] [req:MOD-12]
       installedMcp.mcpServers['wendkeep-vault'].args,
       ['-y', '@bitbonsai/mcpvault@latest', installedVault],
     );
+
+    const installedHookProjection = spawnSync(process.execPath, ['--input-type=module', '--eval', [
+      "import assert from 'node:assert/strict';",
+      "import { readFileSync } from 'node:fs';",
+      "import { join } from 'node:path';",
+      "import { pathToFileURL } from 'node:url';",
+      `const project = ${JSON.stringify(installedProject)};`,
+      "const installedRoot = join(process.cwd(), 'node_modules', 'wendkeep');",
+      "const kernel = await import(pathToFileURL(join(installedRoot, 'packages', 'integrations', 'src', 'index.mjs')).href);",
+      "const specs = [...kernel.SESSION_HOOKS, ...kernel.CHANGE_NUDGE_HOOKS, ...kernel.CHANGE_GATE_HOOKS]",
+      "  .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));",
+      "const claude = JSON.parse(readFileSync(join(project, '.claude', 'settings.json'), 'utf8'));",
+      "const claudeManaged = Object.values(claude.hooks).flatMap((groups) => groups)",
+      "  .flatMap((group) => group.hooks || []).filter((entry) => entry.command?.startsWith('npx wendkeep hook '));",
+      "assert.equal(claudeManaged.length, specs.length);",
+      "for (const spec of specs) {",
+      "  const group = (claude.hooks[spec.event] || []).find((candidate) =>",
+      "    (candidate.hooks || []).some((entry) => entry.command === kernel.hookCommand(spec.name)));",
+      "  assert.ok(group, `missing installed Claude projection: ${spec.name}`);",
+      "  const entry = group.hooks.find((candidate) => candidate.command === kernel.hookCommand(spec.name));",
+      "  assert.equal(entry.timeout, spec.timeout);",
+      "  assert.equal(entry.statusMessage, spec.statusMessage);",
+      "  if (spec.matcher) assert.equal(group.matcher, spec.matcher);",
+      "}",
+      "const codex = JSON.parse(readFileSync(join(project, '.codex', 'hooks.json'), 'utf8'));",
+      "const codexSpecs = kernel.codexHookSpecs(specs).sort((a, b) => (a.order ?? 0) - (b.order ?? 0));",
+      "const codexManaged = Object.values(codex.hooks).flatMap((groups) => groups)",
+      "  .flatMap((group) => group.hooks || []).filter((entry) => entry.command?.startsWith('npx wendkeep hook '));",
+      "assert.equal(codexManaged.length, codexSpecs.length);",
+      "for (const spec of codexSpecs) {",
+      "  const expected = kernel.codexHookEntry(spec);",
+      "  const group = (codex.hooks[spec.event] || []).find((candidate) =>",
+      "    (candidate.hooks || []).some((entry) => entry.command === expected.command));",
+      "  assert.ok(group, `missing installed Codex projection: ${spec.name}`);",
+      "  assert.deepEqual(group.hooks.find((entry) => entry.command === expected.command), expected);",
+      "  if (kernel.CODEX_MATCHER_EVENTS.has(spec.event) && spec.matcher) assert.equal(group.matcher, spec.matcher);",
+      "  else assert.equal(Object.hasOwn(group, 'matcher'), false);",
+      "}",
+    ].join('\n')], { cwd: consumer, encoding: 'utf8' });
+    assert.equal(
+      installedHookProjection.status,
+      0,
+      `installed Claude/Codex hook projection failed:\n${installedHookProjection.stderr}`,
+    );
+
+    const installedBin = join(
+      consumer,
+      'node_modules',
+      'wendkeep',
+      'bin',
+      'wendkeep.mjs',
+    );
+    const installedSessionId = '019d0000-0000-7000-8000-000000000022';
+    const installedTranscript = join(installedProject, 'installed-hook.jsonl');
+    writeFileSync(installedTranscript, `${JSON.stringify({
+      type: 'session_meta',
+      payload: {
+        id: 'installed-hook-transcript',
+        session_id: installedSessionId,
+        model_provider: 'openai',
+      },
+    })}\n`);
+    const wrongGlobalVault = join(consumer, 'wrong-global-vault');
+    const installedHookEnv = {
+      ...process.env,
+      HOME: consumer,
+      USERPROFILE: consumer,
+      OBSIDIAN_VAULT_PATH: wrongGlobalVault,
+    };
+    for (const key of [
+      'CLAUDECODE',
+      'CLAUDE_CODE_SESSION_ID',
+      'CLAUDE_PROJECT_DIR',
+      'CODEX_THREAD_ID',
+      'NODE_PATH',
+      'WENDKEEP_DEBUG',
+    ]) delete installedHookEnv[key];
+    const installedHookInput = JSON.stringify({
+      hook_event_name: 'UserPromptSubmit',
+      session_id: installedSessionId,
+      transcript_path: installedTranscript,
+      prompt: 'installed hook runtime',
+    });
+    const installedHook = spawnSync(process.execPath, [
+      installedBin,
+      'hook',
+      'session-ensure',
+    ], {
+      cwd: installedProject,
+      env: installedHookEnv,
+      input: installedHookInput,
+      encoding: 'utf8',
+    });
+    assert.equal(
+      installedHook.status,
+      0,
+      `installed session-ensure hook failed:\n${installedHook.stderr}`,
+    );
+    const installedHookOutput = JSON.parse(installedHook.stdout);
+    assert.equal(installedHookOutput.hookSpecificOutput.hookEventName, 'UserPromptSubmit');
+    assert.match(installedHookOutput.hookSpecificOutput.additionalContext, /<obsidian_session>/);
+    assert.match(installedHookOutput.systemMessage, /Sessão Obsidian criada/);
+    const installedRegistry = JSON.parse(readFileSync(
+      join(installedVault, '.brain', 'SESSION_REGISTRY.json'),
+      'utf8',
+    ));
+    const installedEntry = installedRegistry.sessions[installedSessionId];
+    assert.equal(installedEntry.provider, 'codex');
+    assert.equal(installedEntry.transcript_path, installedTranscript);
+    assert.equal(installedEntry.transcript_id, 'installed-hook-transcript');
+    assert.equal(installedEntry.status, 'active');
+    assert.ok(installedEntry.session_file);
+    assert.ok(existsSync(join(installedVault, installedEntry.session_file)));
+    assert.match(
+      readFileSync(join(installedVault, installedEntry.session_file), 'utf8'),
+      /installed hook runtime/i,
+    );
+    assert.equal(existsSync(wrongGlobalVault), false);
+
+    const installedEnvelope = join(
+      consumer,
+      'node_modules',
+      'wendkeep',
+      'packages',
+      'integrations',
+      'src',
+      'hook-envelope.mjs',
+    );
+    const disabledEnvelope = `${installedEnvelope}.disabled`;
+    renameSync(installedEnvelope, disabledEnvelope);
+    try {
+      const brokenInstalledHook = spawnSync(process.execPath, [
+        installedBin,
+        'hook',
+        'session-ensure',
+      ], {
+        cwd: installedProject,
+        env: installedHookEnv,
+        input: installedHookInput,
+        encoding: 'utf8',
+      });
+      assert.notEqual(
+        brokenInstalledHook.status,
+        0,
+        'installed hook must not fall back to the source checkout when its kernel is absent',
+      );
+      assert.match(brokenInstalledHook.stderr, /hook-envelope\.mjs|ERR_MODULE_NOT_FOUND/);
+    } finally {
+      renameSync(disabledEnvelope, installedEnvelope);
+    }
   } finally {
     rmSync(temp, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
   }


### PR DESCRIPTION
## Summary

- adds the private canonical Integrations kernel for hook catalogs, envelopes/providers, prompt filtering, usage, transcript parsing, and session identity
- keeps filesystem, process environment, stdin/stdout, Vault, and registry effects in the legacy hook facades while preserving historical export identity
- hardens root package exports so private workspaces cannot be reached through package-name deep imports
- ships the complete kernel in the single `wendkeep` tarball without exposing `wendkeep/integrations` or publishing `@wendkeep/integrations`
- updates PT-BR/EN documentation, CHANGELOG, and package version to `0.66.0`

## Why

This is the Integrations phase of the modular migration. It establishes one internal authority for Claude Code and Codex integration behavior while preserving the existing Vault-first runtime, persisted paths, schemas, registries, locks, and consumer configuration.

## Validation

- `wendkeep verify --deep`: all 6 sensors green (`tests`, modular boundaries, installed tarball, bilingual docs, release checks, syntax check)
- full test sensor: 1,142/1,142 green
- installed tarball smoke: 8/8, including `init`, Claude/Codex projections, installed `session-ensure`, persisted registry/session note, and a missing-kernel mutant proving no checkout fallback
- independent `wk-verify`: MOD-20, MOD-21, and MOD-22 covered (3/3), current task/spec hashes, no notes
- `git diff --check`: green

## Changelog

### Added

- Private canonical Integrations kernel under `packages/integrations/src/`.
- Installed-tarball proof for initialization, projected hooks, and an executed session hook outside the checkout.

### Changed

- Legacy hook surfaces now delegate pure behavior to Integrations while retaining effects at the edges.
- Root exports use an explicit allowlist and the test runner caps file concurrency at 2 on Windows to avoid cross-file process starvation.