### PR TITLE
fix: make memory candidate decisions durable (0.66.1)

### DIFF
--- a/.agents/skills/example-skill/.wendkeep-meta.json
+++ b/.agents/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.59.0",
+  "wendkeepVersion": "0.66.1",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.agents/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.agents/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.59.0",
+  "wendkeepVersion": "0.66.1",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.agents/skills/wk-debugging/.wendkeep-meta.json
+++ b/.agents/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.59.0",
+  "wendkeepVersion": "0.66.1",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.agents/skills/wk-planning/.wendkeep-meta.json
+++ b/.agents/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.59.0",
+  "wendkeepVersion": "0.66.1",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.agents/skills/wk-tdd/.wendkeep-meta.json
+++ b/.agents/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.59.0",
+  "wendkeepVersion": "0.66.1",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.agents/skills/wk-verify/.wendkeep-meta.json
+++ b/.agents/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.59.0",
+  "wendkeepVersion": "0.66.1",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.agents/skills/wk-workflow/.wendkeep-meta.json
+++ b/.agents/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.59.0",
+  "wendkeepVersion": "0.66.1",
   "sourceHash": "c3299e94ce34103fb599744eabec7aec581aefc6fd7c6b959e0350293ee5d8bf"
 }

--- a/.claude/skills/example-skill/.wendkeep-meta.json
+++ b/.claude/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.59.0",
+  "wendkeepVersion": "0.66.1",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.claude/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.claude/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.59.0",
+  "wendkeepVersion": "0.66.1",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.claude/skills/wk-debugging/.wendkeep-meta.json
+++ b/.claude/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.59.0",
+  "wendkeepVersion": "0.66.1",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.claude/skills/wk-planning/.wendkeep-meta.json
+++ b/.claude/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.59.0",
+  "wendkeepVersion": "0.66.1",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.claude/skills/wk-tdd/.wendkeep-meta.json
+++ b/.claude/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.59.0",
+  "wendkeepVersion": "0.66.1",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.claude/skills/wk-verify/.wendkeep-meta.json
+++ b/.claude/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.59.0",
+  "wendkeepVersion": "0.66.1",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.claude/skills/wk-workflow/.wendkeep-meta.json
+++ b/.claude/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.59.0",
+  "wendkeepVersion": "0.66.1",
   "sourceHash": "c3299e94ce34103fb599744eabec7aec581aefc6fd7c6b959e0350293ee5d8bf"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- wendkeep:skills:start -->
-<!-- wendkeep-version: 0.59.0; skills-sha256: 36ebe0728fe02c48230802722405c3179cb460f289429505e341db582542b82d -->
+<!-- wendkeep-version: 0.66.1; skills-sha256: 36ebe0728fe02c48230802722405c3179cb460f289429505e341db582542b82d -->
 ## wendkeep — Keep Core & operating profiles
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. **Keep Core is always active**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.66.1] — 2026-07-29
+
+### Fixed
+
+- **A curadoria de candidates agora é durável e idempotente.** `memory promote` e
+  `memory reject` registram decisões causais no ledger; repair/replay não recriam o conflito
+  resolvido, retries não duplicam eventos, candidates sobrepostos permanecem isolados e a
+  promoção recupera o checkpoint divergente do attempt correspondente sem tocar attempt novo.
+- **Promoção de conflito exige escolha explícita.** `memory promote <candidate> --event
+  <event-id>` publica exatamente o evento escolhido, rejeita IDs externos ao candidate e não
+  permite que `blocked_by_core` sobrescreva a autoridade canônica de CORE.
+
 ## [0.66.0] — 2026-07-29
 
 ### Added

--- a/README.en.md
+++ b/README.en.md
@@ -294,7 +294,10 @@ backup/audit; divergent mirrors fail closed. A demonstrably superseded
 ambiguity uses `memory reconcile <session> --by-session <successor>
 --reason <reason>` as a dry run and requires `--apply`; the decision is backed up and audited
 without rewriting ledger, CORE, or notes. Run `status --gate` again afterwards. Conflicts require
-explicit curation with `memory promote <id>` or `memory reject <id>`; doctor only diagnoses.
+explicit, durable curation: `memory promote <id> --event <event-id>` selects one event from the
+candidate, while `memory reject <id>` keeps the current value. Decisions are idempotent and
+survive repair/replay; `blocked_by_core` cannot override CORE. Doctor only diagnoses. See
+[memory and curation](docs/en/commands/memory.md).
 
 Session notes use one live `## Agentes, tokens e custos` snapshot. Main-agent and subagent hooks recompose it atomically, with costs, token dimensions, reasoning tokens and effort per model/source. Every hook that rewrites a session note takes a per-file lock and writes through a temp file + rename, so the `SubagentStop` fan-out (one hook run per subagent) can never leave a note half-written; a note whose frontmatter reads back damaged is left untouched rather than patched.
 

--- a/README.md
+++ b/README.md
@@ -290,8 +290,10 @@ a fronteira física correta; espelhos divergentes falham fechados. Uma
 ambiguidade comprovadamente substituída usa `memory reconcile <sessão>
 --by-session <sucessora> --reason <motivo>` como dry-run e exige `--apply`; a decisão faz backup e
 auditoria sem reescrever ledger, CORE ou notas. Depois rode `status --gate` novamente. Conflitos
-exigem curadoria explícita com `memory promote <id>` ou `memory reject <id>`; o doctor apenas
-diagnostica.
+exigem curadoria explícita e durável: `memory promote <id> --event <event-id>` escolhe um dos
+eventos do candidate; `memory reject <id>` mantém o valor atual. As decisões são idempotentes e
+sobrevivem a repair/replay; `blocked_by_core` não pode sobrescrever CORE. O doctor apenas
+diagnostica. Veja [memória e curadoria](docs/pt-BR/commands/memory.md).
 
 As notas de sessão usam um único snapshot vivo `## Agentes, tokens e custos`. Os hooks do agente principal e dos subagents recompõem o bloco atomicamente, incluindo custo, dimensões de tokens, reasoning e effort por modelo/origem.
 

--- a/docs/en/commands/memory-migration.md
+++ b/docs/en/commands/memory-migration.md
@@ -64,7 +64,8 @@ to revision 1. Replaying that prompt or Stop does not duplicate the event/revisi
 - Partial/corrupt v2 bundle: use status and repair; migration is not a corruption tool.
 - First post-migration Stop is `ambiguous`: verify that its `turn_id` belongs to the transcript and
   that `UserPromptSubmit` opened/advanced the recovery activation.
-- Many candidates: curate gradually with `memory promote`/`memory reject`.
+- Many candidates: curate gradually with `memory promote`/`memory reject`; conflicts require
+  `memory promote <candidate> --event <event-id>` to choose the winner explicitly.
 - Legacy warning remains after apply: verify the selected vault and project binding.
 
 ## Next steps

--- a/docs/en/commands/memory.md
+++ b/docs/en/commands/memory.md
@@ -26,7 +26,7 @@ Pass the vault explicitly in automation. Preserve backups and evidence before re
 npx wendkeep memory status [--gate] --vault <vault>
 npx wendkeep memory repair --vault <vault>
 npx wendkeep memory reconcile <ambiguous-session> --by-session <successor-session> --reason <reason> [--apply] --vault <vault>
-npx wendkeep memory promote <candidate> --vault <vault>
+npx wendkeep memory promote <candidate> [--event <event-id>] --vault <vault>
 npx wendkeep memory reject <candidate> --vault <vault>
 npx wendkeep validate-memory [CORE-path]
 npx wendkeep validate-memory --vault <v2-vault>
@@ -63,7 +63,14 @@ npx wendkeep validate-memory --vault <v2-vault>
   Junctions, symlinks, reparse points, or hardlinks fail closed without touching external bytes.
   Locks publish owner and lease atomically, never reap a live PID by age alone, and release only
   the lease they acquired.
-- `promote`/`reject` append auditable decisions and never rewrite the ledger in place.
+- `promote`/`reject` append an auditable, idempotent decision to the ledger. Replay and repair
+  preserve that decision and do not recreate the resolved candidate. For a `conflict` candidate,
+  `promote` requires an `--event <event-id>` that belongs to the candidate; date or random ID
+  never picks an implicit winner. `reject` preserves the current operational value. A
+  `blocked_by_core` candidate can only be rejected: promotion first requires canonical CORE
+  curation. If the selected event still belongs to the matching latest `projected` attempt,
+  promotion also refreshes its checkpoint and mirror causally; JSON reports
+  `checkpointRefreshed`, and a newer concurrent attempt remains untouched.
 - `validate-memory <CORE.md>` checks the 25-line cap, required sections, and secrets.
 - `validate-memory --vault` requires a complete v2 bundle and is not the legacy-vault gate.
 
@@ -74,7 +81,8 @@ npx wendkeep memory status --gate --vault .MyApp-vault
 npx wendkeep memory reconcile old --by-session current --reason "delivery continued" --vault .MyApp-vault
 npx wendkeep memory reconcile old --by-session current --reason "delivery continued" --apply --vault .MyApp-vault
 npx wendkeep validate-memory .MyApp-vault/.brain/CORE.md
-npx wendkeep memory promote candidate-123 --vault .MyApp-vault
+npx wendkeep memory promote candidate-123 --event mem-selected --vault .MyApp-vault
+npx wendkeep memory reject candidate-456 --vault .MyApp-vault
 ```
 
 ## Expected result
@@ -97,6 +105,9 @@ of a global projection that has already advanced with concurrent events.
   `memory reconcile` dry run before authorizing `--apply`; the command fails when the ambiguous
   attempt already contains event IDs.
 - Ordinary pending candidate: recoverable warning, requiring human choice when appropriate.
+- `promote` reports that `--event` is required: inspect the candidate `event_ids`, compare their
+  provenance/value, and name the winner explicitly. An ID outside the candidate fails without
+  mutating the ledger or projections.
 - Missing `event_cursor` or mismatched v2 hash: preserve the bundle and assess `memory repair`.
 - `validate-memory --vault` fails on legacy: validate CORE only or migrate first.
 

--- a/docs/pt-BR/commands/memory-migration.md
+++ b/docs/pt-BR/commands/memory-migration.md
@@ -64,7 +64,8 @@ revision 1. Repetir esse prompt ou Stop não duplica evento/revision.
 - Bundle v2 parcial/corrompido: use status e repair; migração não é ferramenta de corrupção.
 - Primeiro Stop pós-migração fica `ambiguous`: confirme que o `turn_id` pertence ao transcript e
   que `UserPromptSubmit` abriu/avançou a activation de recuperação.
-- Candidates numerosos: curate gradualmente com `memory promote`/`memory reject`.
+- Candidates numerosos: curate gradualmente com `memory promote`/`memory reject`; conflitos
+  exigem `memory promote <candidate> --event <event-id>` para escolher o vencedor explicitamente.
 - Warning legado após apply: confirme o vault efetivamente selecionado e o vínculo do projeto.
 
 ## Próximos passos

--- a/docs/pt-BR/commands/memory.md
+++ b/docs/pt-BR/commands/memory.md
@@ -26,7 +26,7 @@ Informe o vault explicitamente em automações. Preserve backups e evidências a
 npx wendkeep memory status [--gate] --vault <cofre>
 npx wendkeep memory repair --vault <cofre>
 npx wendkeep memory reconcile <sessão-ambígua> --by-session <sessão-sucessora> --reason <motivo> [--apply] --vault <cofre>
-npx wendkeep memory promote <candidate> --vault <cofre>
+npx wendkeep memory promote <candidate> [--event <event-id>] --vault <cofre>
 npx wendkeep memory reject <candidate> --vault <cofre>
 npx wendkeep validate-memory [caminho-do-CORE]
 npx wendkeep validate-memory --vault <cofre-v2>
@@ -61,7 +61,13 @@ npx wendkeep validate-memory --vault <cofre-v2>
   candidates, registry, notas, backups, temporários e sidecars antes de ler ou escrever. Junction,
   symlink, reparse point ou hardlink falham fechados sem tocar bytes externos. Locks publicam owner
   e lease atomicamente, não colhem PID vivo apenas por idade e só liberam a lease adquirida.
-- `promote`/`reject` acrescentam decisão auditável; nunca reescrevem o ledger no lugar.
+- `promote`/`reject` acrescentam uma decisão auditável e idempotente ao ledger. Replay e repair
+  preservam a decisão e não recriam o candidate resolvido. Para candidate `conflict`, `promote`
+  exige `--event <event-id>` pertencente ao candidate; não há vencedor implícito por data ou ID.
+  `reject` preserva o valor operacional atual. Candidate `blocked_by_core` só pode ser rejeitado:
+  promover exige antes alterar CORE pela curadoria canônica. Se o evento escolhido ainda pertence
+  ao último attempt `projected` correspondente, a promoção também atualiza causalmente checkpoint
+  e espelho; o JSON retorna `checkpointRefreshed`, e um attempt concorrente mais novo não é tocado.
 - `validate-memory <CORE.md>` valida cap de 25 linhas, seções e segredos.
 - `validate-memory --vault` exige bundle v2 completo; não é o gate correto para vault legado.
 
@@ -72,7 +78,8 @@ npx wendkeep memory status --gate --vault .MeuApp-vault
 npx wendkeep memory reconcile antiga --by-session atual --reason "entrega continuada" --vault .MeuApp-vault
 npx wendkeep memory reconcile antiga --by-session atual --reason "entrega continuada" --apply --vault .MeuApp-vault
 npx wendkeep validate-memory .MeuApp-vault/.brain/CORE.md
-npx wendkeep memory promote candidate-123 --vault .MeuApp-vault
+npx wendkeep memory promote candidate-123 --event mem-escolhido --vault .MeuApp-vault
+npx wendkeep memory reject candidate-456 --vault .MeuApp-vault
 ```
 
 ## Resultado esperado
@@ -94,6 +101,9 @@ prefixo válido de uma projeção global que já avançou com eventos concorrent
   ambiguidade for comprovadamente substituída por uma sessão sucessora, revise o dry-run de
   `memory reconcile` antes de autorizar `--apply`; o comando falha se o attempt ambíguo tiver IDs.
 - Candidate pendente comum: warning recuperável, exige decisão humana quando apropriado.
+- `promote` informa que `--event` é obrigatório: leia os `event_ids` do candidate, compare a
+  proveniência/valor e indique explicitamente o vencedor. ID que não pertence ao candidate falha
+  sem mutar ledger ou projeções.
 - `event_cursor` ausente ou hash divergente em v2: preserve o bundle e avalie `memory repair`.
 - `validate-memory --vault` falha no legado: valide apenas CORE ou migre primeiro.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.66.0",
+  "version": "0.66.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.66.0",
+      "version": "0.66.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.66.0",
+  "version": "0.66.1",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -101,7 +101,7 @@ Usage:
   wendkeep lesson add "t" "l"   Record a project-local lesson (injected at SessionStart).
   wendkeep memory <sub>          Shared memory v2: status | migrate [--apply] | repair |
                            reconcile <session> --by-session <session> --reason <text> [--apply] |
-                           promote <candidate> | reject <candidate>. --vault P.
+                           promote <candidate> [--event <event-id>] | reject <candidate>. --vault P.
                            Reconcile is dry-run by default; the original attempt remains audited.
   wendkeep validate-memory [path]  Validate .brain/CORE.md against the compaction
                            protocol (cap 25, 3 sections, no secrets/PII).

--- a/packages/vault/src/memory-schema.mjs
+++ b/packages/vault/src/memory-schema.mjs
@@ -108,6 +108,31 @@ export function validateMemoryEvent(event, { projectId } = {}) {
     errors.push(`project_id não pertence ao vault esperado (${projectId}).`);
   }
 
+  if (event.candidate_decision !== undefined) {
+    const decision = event.candidate_decision;
+    if (!decision || typeof decision !== 'object' || Array.isArray(decision)) {
+      errors.push('candidate_decision deve ser objeto.');
+    } else {
+      if (typeof decision.candidate_id !== 'string' || !decision.candidate_id) {
+        errors.push('candidate_decision.candidate_id deve ser string não vazia.');
+      }
+      if (!['promote', 'reject'].includes(decision.action)) {
+        errors.push('candidate_decision.action deve ser promote ou reject.');
+      }
+      if (!Array.isArray(decision.event_ids)
+          || decision.event_ids.some((item) => typeof item !== 'string' || !item)) {
+        errors.push('candidate_decision.event_ids deve ser array de strings não vazias.');
+      }
+      if (decision.action === 'promote' && decision.selected_event_id !== undefined
+          && (typeof decision.selected_event_id !== 'string' || !decision.selected_event_id)) {
+        errors.push('candidate_decision.selected_event_id deve ser string não vazia.');
+      }
+      if (decision.action === 'reject' && decision.selected_event_id !== undefined) {
+        errors.push('candidate_decision.selected_event_id não é permitido em reject.');
+      }
+    }
+  }
+
   for (const field of ['value', 'evidence']) sanitizedField(event, field, errors);
   return { ok: errors.length === 0, errors, warnings };
 }

--- a/packages/vault/src/memory-store.mjs
+++ b/packages/vault/src/memory-store.mjs
@@ -461,6 +461,19 @@ export function reduceMemoryEvents(inputEvents = [], { coreInvariants = new Map(
     if (!existing) unique.set(event.event_id, event);
   }
   const events = [...unique.values()].sort(eventOrder);
+  const candidateDecisions = new Map();
+  for (const item of events) {
+    const decision = item.candidate_decision;
+    if (!decision) continue;
+    const existing = candidateDecisions.get(decision.candidate_id);
+    if (existing && canonicalMemoryJson(existing.decision) !== canonicalMemoryJson(decision)) {
+      throw new MemoryEventCollision(
+        decision.candidate_id,
+        `Ledger contains incompatible decisions for candidate ${decision.candidate_id}`,
+      );
+    }
+    if (!existing) candidateDecisions.set(decision.candidate_id, { decision, event: item });
+  }
 
   const peerGroups = new Map();
   for (const item of events) {
@@ -488,6 +501,11 @@ export function reduceMemoryEvents(inputEvents = [], { coreInvariants = new Map(
   let revision = 0;
 
   for (const item of events) {
+    if (item.candidate_decision && item.candidate_decision.action === 'reject') {
+      appliedEventIds.push(item.event_id);
+      continue;
+    }
+
     if (protectedValues.has(item.memory_key)) {
       const coreValue = protectedValues.get(item.memory_key);
       const agreesWithCore = item.operation === 'assert'
@@ -604,7 +622,9 @@ export function reduceMemoryEvents(inputEvents = [], { coreInvariants = new Map(
   const state = sortedObject(stateEntries);
   const recordObject = sortedObject(recordEntries);
   const tombstoneObject = sortedObject(tombstoneEntries);
-  candidates.sort((left, right) => left.candidate_id.localeCompare(right.candidate_id));
+  const unresolvedCandidates = candidates
+    .filter((item) => !candidateDecisions.has(item.candidate_id));
+  unresolvedCandidates.sort((left, right) => left.candidate_id.localeCompare(right.candidate_id));
   superseded.sort((left, right) => left.event_id.localeCompare(right.event_id));
   const activeEvents = Object.entries(recordObject).map(([memoryKey, record]) => ({
     ...record.source,
@@ -618,7 +638,7 @@ export function reduceMemoryEvents(inputEvents = [], { coreInvariants = new Map(
   return {
     state,
     records: recordObject,
-    candidates,
+    candidates: unresolvedCandidates,
     tombstones: tombstoneObject,
     superseded,
     appliedEventIds,

--- a/src/memory.mjs
+++ b/src/memory.mjs
@@ -237,37 +237,191 @@ function readCandidates(vault) {
     .split('\n').filter(Boolean).map((line) => JSON.parse(line));
 }
 
-export function decideMemoryCandidate(vault, { action, candidateId, value } = {}) {
+function priorCandidateDecision(vault, candidateId) {
+  return readMemoryLedger(vault).events.find(
+    (event) => event.candidate_decision?.candidate_id === candidateId,
+  ) || null;
+}
+
+function candidateEvent(candidate, eventId) {
+  const events = Array.isArray(candidate.events) ? candidate.events : [];
+  if (candidate.reason === 'conflict' && !eventId) {
+    throw new Error('Candidate de conflito exige eventId (--event na CLI).');
+  }
+  if (!eventId) return events.length === 1 ? events[0] : null;
+  const selected = events.find((event) => event.event_id === eventId);
+  if (!selected) throw new Error(`event_id ${eventId} não pertence ao candidate ${candidate.candidate_id}.`);
+  return selected;
+}
+
+function assertCompatibleDecision(prior, { action, eventId }) {
+  const decision = prior.candidate_decision;
+  const sameSelection = action !== 'promote'
+    || (decision.selected_event_id || null) === (eventId || null);
+  if (decision.action !== action || !sameSelection) {
+    throw new Error(`Candidate ${decision.candidate_id} já possui decisão incompatível (${decision.action}).`);
+  }
+}
+
+function matchesPromotedAttempt(attempt, selected) {
+  if (attempt?.memory_mode !== 'v2' || attempt.state !== 'projected'
+      || !Array.isArray(attempt.event_ids) || !attempt.event_ids.includes(selected.event_id)) return false;
+  if (attempt.activation_id && selected.activation_id
+      && attempt.activation_id !== selected.activation_id) return false;
+  if (Number.isInteger(attempt.activation_epoch) && Number.isInteger(selected.activation_epoch)
+      && attempt.activation_epoch !== selected.activation_epoch) return false;
+  if (Number.isInteger(attempt.turn_sequence) && Number.isInteger(selected.turn_sequence)
+      && attempt.turn_sequence !== selected.turn_sequence) return false;
+  if (attempt.canonical_session_id && selected.canonical_session_id
+      && attempt.canonical_session_id !== selected.canonical_session_id) return false;
+  return true;
+}
+
+function snapshotPromotedAttemptCheckpoints(vault, selected) {
+  if (!selected) return new Map();
+  const registry = readSessionRegistry(vault);
+  return new Map(Object.entries(registry.sessions || {})
+    .filter(([, entry]) => matchesPromotedAttempt(entry?.last_memory_attempt, selected))
+    .map(([sessionId, entry]) => [sessionId, {
+      attempt: attemptFingerprint(entry.last_memory_attempt),
+      checkpoint: memoryCheckpointFingerprint(entry),
+    }]));
+}
+
+function refreshPromotedAttemptCheckpoint(vault, {
+  candidateId, decisionEventId, selected, checkpoint, decidedAt, expectedAttempts,
+}) {
+  if (!selected || !checkpoint || !expectedAttempts?.size) return 0;
+  return mutateSessionRegistry(vault, (registry) => {
+    let refreshed = 0;
+    for (const [sessionId, entry] of Object.entries(registry.sessions || {})) {
+      const expected = expectedAttempts.get(sessionId);
+      if (!expected) continue;
+      const attempt = entry?.last_memory_attempt;
+      if (attemptFingerprint(attempt) !== expected.attempt
+          || memoryCheckpointFingerprint(entry) !== expected.checkpoint) continue;
+
+      const alreadyAudited = (entry.memory_candidate_decisions || [])
+        .some((audit) => audit.decision_event_id === decisionEventId);
+      if (alreadyAudited && sameCheckpoint(attempt.checkpoint, checkpoint)
+          && sameCheckpoint(entry.memory_checkpoint, checkpoint)) continue;
+      const originalCheckpoint = cloneJson(attempt.checkpoint || entry.memory_checkpoint || null);
+      attempt.checkpoint = cloneJson(checkpoint);
+      entry.memory_checkpoint = cloneJson(checkpoint);
+      entry.memory_status = 'projected';
+      if (!alreadyAudited) {
+        entry.memory_candidate_decisions = [
+          ...(Array.isArray(entry.memory_candidate_decisions) ? entry.memory_candidate_decisions : []),
+          {
+            v: 1,
+            type: 'candidate_checkpoint_refreshed',
+            candidate_id: candidateId,
+            decision_event_id: decisionEventId,
+            selected_event_id: selected.event_id,
+            decided_at: decidedAt,
+            original_checkpoint: originalCheckpoint,
+            checkpoint: cloneJson(checkpoint),
+          },
+        ];
+      }
+      refreshed += 1;
+    }
+    return refreshed;
+  });
+}
+
+export function decideMemoryCandidate(vault, {
+  action, candidateId, value, eventId, beforeCheckpointRefresh,
+} = {}) {
   if (!['promote', 'reject'].includes(action)) throw new TypeError('action deve ser promote ou reject.');
   if (!candidateId) throw new TypeError('candidateId é obrigatório.');
+  const preflight = projectMemoryOutbox(vault);
+  if (preflight.status === 'busy') return { status: 'busy', candidateId };
+  const prior = priorCandidateDecision(vault, candidateId);
+  if (prior) {
+    assertCompatibleDecision(prior, { action, eventId });
+    const selected = action === 'promote' && prior.candidate_decision.selected_event_id
+      ? readMemoryLedger(vault).events.find(
+        (event) => event.event_id === prior.candidate_decision.selected_event_id,
+      )
+      : null;
+    const expectedAttempts = snapshotPromotedAttemptCheckpoints(vault, selected);
+    beforeCheckpointRefresh?.();
+    const checkpointRefreshed = action === 'promote'
+      ? refreshPromotedAttemptCheckpoint(vault, {
+        candidateId,
+        decisionEventId: prior.event_id,
+        selected,
+        checkpoint: preflight.checkpoint,
+        decidedAt: prior.observed_at,
+        expectedAttempts,
+      })
+      : 0;
+    return {
+      status: action === 'promote' ? 'promoted' : 'rejected',
+      candidateId,
+      eventId: prior.event_id,
+      alreadyApplied: true,
+      checkpointRefreshed,
+      projection: preflight,
+    };
+  }
   const candidates = readCandidates(vault);
   const candidate = candidates.find((item) => item.candidate_id === candidateId);
   if (!candidate) throw new Error(`Candidate não encontrado: ${candidateId}`);
+  if (action === 'promote' && candidate.reason === 'blocked_by_core') {
+    throw new Error(`Candidate ${candidateId} está blocked_by_core; edite CORE ou rejeite o candidate.`);
+  }
+  const selected = action === 'promote' ? candidateEvent(candidate, eventId) : null;
+  const expectedAttempts = snapshotPromotedAttemptCheckpoints(vault, selected);
+  const selectedValue = selected?.value ?? value ?? candidate.value ?? candidate.proposed_value;
+  if (action === 'promote' && selectedValue === undefined) {
+    throw new Error(`Candidate ${candidateId} não contém valor promovível.`);
+  }
   const now = new Date().toISOString();
+  const decision = {
+    candidate_id: candidateId,
+    action,
+    event_ids: Array.isArray(candidate.event_ids) ? [...candidate.event_ids].sort() : [],
+    ...(selected ? { selected_event_id: selected.event_id } : {}),
+  };
   const event = {
     v: 1,
-    event_id: `cli-${action}-${hash(candidateId).slice(0, 20)}`,
+    event_id: `cli-${action}-${hash(`${candidateId}\0${selected?.event_id || ''}`).slice(0, 20)}`,
     project_id: projectId(vault),
-    memory_key: action === 'promote' ? candidate.memory_key : `candidate.rejected.${candidateId}`,
-    operation: 'assert',
-    value: sanitizeMemoryText(action === 'promote' ? (value ?? candidate.value ?? candidate.values?.[0] ?? '') : 'rejected'),
+    memory_key: action === 'promote' ? candidate.memory_key : `candidate.decision.${candidateId}`,
+    operation: action === 'promote' && selected ? 'replace' : 'assert',
+    value: sanitizeMemoryText(action === 'promote' ? selectedValue : 'rejected'),
     authority: 'verified',
-    activation_id: 'wendkeep-memory-cli',
-    turn_sequence: 0,
+    activation_id: selected?.activation_id || 'wendkeep-memory-cli',
+    ...(Number.isInteger(selected?.activation_epoch) ? { activation_epoch: selected.activation_epoch } : {}),
+    turn_sequence: selected?.turn_sequence ?? 0,
     observed_at: now,
     evidence: [`candidate:${candidateId}`],
+    candidate_decision: decision,
+    ...(selected ? { supersedes: decision.event_ids } : {}),
   };
   enqueueMemoryEvent(vault, event);
   const projection = projectMemoryOutbox(vault);
   if (projection.status === 'busy') return { status: 'busy', candidateId };
-  const remaining = candidates.filter((item) => item.candidate_id !== candidateId);
-  const projected = readCandidates(vault);
-  const merged = new Map([...remaining, ...projected].map((item) => [item.candidate_id, item]));
-  writeVaultFileAtomic(
-    vault, brainPath(vault, CANDIDATES), candidateText([...merged.values()]), 'utf8',
-    { label: 'candidates após decisão humana' },
-  );
-  return { status: action === 'promote' ? 'promoted' : 'rejected', candidateId, eventId: event.event_id, projection };
+  beforeCheckpointRefresh?.();
+  const checkpointRefreshed = action === 'promote'
+    ? refreshPromotedAttemptCheckpoint(vault, {
+      candidateId,
+      decisionEventId: event.event_id,
+      selected,
+      checkpoint: projection.checkpoint,
+      decidedAt: now,
+      expectedAttempts,
+    })
+    : 0;
+  return {
+    status: action === 'promote' ? 'promoted' : 'rejected',
+    candidateId,
+    eventId: event.event_id,
+    checkpointRefreshed,
+    projection,
+  };
 }
 
 function cloneJson(value) {
@@ -1038,8 +1192,14 @@ export function runMemory(argv) {
         apply: reconcileArgs.apply,
       });
     }
-    else if (sub === 'promote' || sub === 'reject') result = decideMemoryCandidate(vault, { action: sub, candidateId: positional });
-    else { process.stderr.write('wendkeep memory: use status | migrate [--apply] | repair | reconcile <session> --by-session <session> --reason <text> [--apply] | promote <candidate> | reject <candidate>.\n'); process.exitCode = 2; return; }
+    else if (sub === 'promote' || sub === 'reject') {
+      const eventId = option(argv, '--event');
+      if (sub === 'reject' && eventId) throw memoryUsageError('--event é permitido somente em memory promote.');
+      result = decideMemoryCandidate(vault, {
+        action: sub, candidateId: positional, ...(eventId ? { eventId } : {}),
+      });
+    }
+    else { process.stderr.write('wendkeep memory: use status | migrate [--apply] | repair | reconcile <session> --by-session <session> --reason <text> [--apply] | promote <candidate> [--event <event-id>] | reject <candidate>.\n'); process.exitCode = 2; return; }
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     if (sub === 'status' && argv.includes('--gate')) process.exitCode = result.status === 'blocked' ? 1 : 0;
     else if (sub === 'reconcile' && reconcileArgs.apply) process.exitCode = result.health?.status === 'blocked' ? 1 : 0;

--- a/tests/memory-cli.test.mjs
+++ b/tests/memory-cli.test.mjs
@@ -10,7 +10,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { canonicalMemoryJson, deriveMemoryProjection, reduceMemoryEvents } from '../hooks/memory-store.mjs';
+import {
+  canonicalMemoryJson, deriveMemoryProjection, prepareMemoryProjection, reduceMemoryEvents,
+} from '../hooks/memory-store.mjs';
 import { renderSharedMemory } from '../hooks/memory-schema.mjs';
 import { renderCoreSkeleton } from '../src/validate-core.mjs';
 
@@ -65,6 +67,20 @@ function checkpoint(reduced) {
     event_cursor: reduced.eventCursor,
     state_hash: reduced.stateHash,
   };
+}
+
+function writeMemoryProjection(vault, events) {
+  const brain = join(vault, '.brain');
+  const projection = prepareMemoryProjection(vault, events);
+  writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), `${events.map(canonicalMemoryJson).join('\n')}\n`);
+  writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), projection.candidatesContent);
+  writeFileSync(join(brain, 'SHARED_MEMORY.md'), projection.sharedContent);
+  return projection;
+}
+
+function readCandidates(vault) {
+  const content = readFileSync(join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl'), 'utf8').trim();
+  return content ? content.split('\n').map(JSON.parse) : [];
 }
 
 function projectedAttempt(sessionId, event, checkpointValue = null, overrides = {}) {
@@ -405,20 +421,218 @@ test('falha durante publish restaura todos os paths finais e mantém backup', as
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
 
-test('promote e reject referenciam candidate e apenas acrescentam eventos ao ledger', async () => {
+test('[req:MEM-CUR-1] [req:MEM-CUR-2] [req:MEM-CUR-3] decisões sobre candidates sobrepostos sobrevivem a repair e retry', async () => {
   const vault = fixture();
   try {
-    const { migrateMemory, decideMemoryCandidate } = await import('../src/memory.mjs');
-    migrateMemory(vault, { apply: true });
-    const candidates = readFileSync(join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl'), 'utf8').trim().split('\n').map(JSON.parse);
-    assert.ok(candidates.length >= 2);
-    const first = decideMemoryCandidate(vault, { action: 'promote', candidateId: candidates[0].candidate_id });
-    const second = decideMemoryCandidate(vault, { action: 'reject', candidateId: candidates[1].candidate_id });
-    assert.equal(first.status, 'promoted');
-    assert.equal(second.status, 'rejected');
-    const ledger = readFileSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl'), 'utf8').trim().split('\n').map(JSON.parse);
-    assert.ok(ledger.some((event) => event.evidence.includes(`candidate:${candidates[0].candidate_id}`)));
-    assert.ok(ledger.some((event) => event.evidence.includes(`candidate:${candidates[1].candidate_id}`)));
+    const { decideMemoryCandidate, repairMemory } = await import('../src/memory.mjs');
+    const base = { ...memoryEvent('mem-base', 'base handoff', 1), activation_id: 'activation-base' };
+    const discarded = { ...memoryEvent('mem-discarded', 'discarded handoff', 2), activation_id: 'activation-a' };
+    const winner = {
+      ...memoryEvent('mem-winner', 'winning handoff', 3),
+      activation_id: 'activation-b',
+      canonical_session_id: 'current',
+    };
+    writeMemoryProjection(vault, [base, discarded, winner]);
+    const historicalLedger = readFileSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl'), 'utf8');
+    const staleCheckpoint = { revision: 0, event_cursor: winner.event_id, state_hash: 'stale' };
+    const newerCheckpoint = { revision: 9, event_cursor: 'mem-newer', state_hash: 'newer' };
+    const newerAttemptEvent = {
+      ...memoryEvent('mem-newer', 'newer handoff', 4),
+      activation_id: 'activation-newer',
+      canonical_session_id: 'newer',
+    };
+    writeFileSync(join(vault, '.brain', 'SESSION_REGISTRY.json'), `${JSON.stringify({
+      version: 2,
+      sessions: {
+        current: {
+          memory_status: 'projected',
+          memory_checkpoint: staleCheckpoint,
+          last_memory_attempt: projectedAttempt('current', winner, staleCheckpoint),
+        },
+        newer: {
+          memory_status: 'projected',
+          memory_checkpoint: newerCheckpoint,
+          last_memory_attempt: projectedAttempt('newer', newerAttemptEvent, newerCheckpoint),
+        },
+      },
+    }, null, 2)}\n`);
+    const candidates = readCandidates(vault);
+    const rejected = candidates.find((item) => item.event_ids.includes(discarded.event_id));
+    const promoted = candidates.find((item) => item.event_ids.includes(winner.event_id));
+    assert.ok(rejected);
+    assert.ok(promoted);
+
+    assert.equal(decideMemoryCandidate(vault, {
+      action: 'reject', candidateId: rejected.candidate_id,
+    }).status, 'rejected');
+    assert.deepEqual(readCandidates(vault).map((item) => item.candidate_id), [promoted.candidate_id]);
+
+    const promotedResult = decideMemoryCandidate(vault, {
+      action: 'promote',
+      candidateId: promoted.candidate_id,
+      eventId: winner.event_id,
+      value: 'override que não pode vencer o evento escolhido',
+    });
+    assert.equal(promotedResult.status, 'promoted');
+    assert.deepEqual(readCandidates(vault), []);
+    const refreshed = JSON.parse(readFileSync(join(vault, '.brain', 'SESSION_REGISTRY.json'), 'utf8'))
+      .sessions.current;
+    assert.deepEqual(refreshed.last_memory_attempt.checkpoint, promotedResult.projection.checkpoint);
+    assert.deepEqual(refreshed.memory_checkpoint, promotedResult.projection.checkpoint);
+    assert.equal(refreshed.memory_candidate_decisions.length, 1);
+    const concurrent = JSON.parse(readFileSync(join(vault, '.brain', 'SESSION_REGISTRY.json'), 'utf8'))
+      .sessions.newer;
+    assert.deepEqual(concurrent.last_memory_attempt.checkpoint, newerCheckpoint);
+    assert.deepEqual(concurrent.memory_checkpoint, newerCheckpoint);
+
+    repairMemory(vault);
+    assert.deepEqual(readCandidates(vault), [], 'repair/replay não recria decisões concluídas');
+    const ledgerPath = join(vault, '.brain', 'MEMORY_EVENTS.jsonl');
+    const ledgerAfterDecisions = readFileSync(ledgerPath, 'utf8');
+    assert.ok(ledgerAfterDecisions.startsWith(historicalLedger), 'decisões somente acrescentam ao ledger histórico');
+    const ledger = ledgerAfterDecisions.trim().split('\n').map(JSON.parse);
+    assert.deepEqual(
+      ledger.filter((event) => event.candidate_decision).map((event) => event.candidate_decision.action).sort(),
+      ['promote', 'reject'],
+      'promote e reject permanecem auditáveis no ledger',
+    );
+    const reduced = reduceMemoryEvents(ledger);
+    assert.equal(reduced.state['handoff.latest'], winner.value);
+    assert.equal(Object.keys(reduced.state).some((key) => key.startsWith('candidate.')), false);
+    assert.equal(reduced.records['handoff.latest'].source.candidate_decision.selected_event_id, winner.event_id);
+    assert.equal(reduced.records['handoff.latest'].source.activation_id, winner.activation_id);
+    assert.ok(reduced.records['handoff.latest'].source.supersedes.includes(winner.event_id));
+
+    const beforeRetry = readFileSync(ledgerPath, 'utf8');
+    const sharedBeforeRetry = readFileSync(join(vault, '.brain', 'SHARED_MEMORY.md'), 'utf8');
+    const retry = decideMemoryCandidate(vault, {
+      action: 'promote', candidateId: promoted.candidate_id, eventId: winner.event_id,
+    });
+    assert.equal(retry.status, 'promoted');
+    assert.equal(retry.alreadyApplied, true);
+    assert.equal(readFileSync(ledgerPath, 'utf8'), beforeRetry, 'retry não duplica evento');
+    assert.equal(readFileSync(join(vault, '.brain', 'SHARED_MEMORY.md'), 'utf8'), sharedBeforeRetry);
+    assert.equal(retry.projection.revision, promotedResult.projection.revision);
+    assert.equal(retry.projection.stateHash, promotedResult.projection.stateHash);
+    assert.throws(() => decideMemoryCandidate(vault, {
+      action: 'reject', candidateId: promoted.candidate_id,
+    }), /decisão incompatível|already.*promot|já.*promov/i);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-CUR-2] CAS não atualiza attempt novo que ainda contém o evento promovido', async () => {
+  const vault = fixture();
+  try {
+    const { decideMemoryCandidate } = await import('../src/memory.mjs');
+    const base = { ...memoryEvent('mem-cas-base', 'base', 1), activation_id: 'activation-base' };
+    const winner = {
+      ...memoryEvent('mem-cas-winner', 'winner', 2),
+      activation_id: 'activation-winner',
+      canonical_session_id: 'current',
+    };
+    writeMemoryProjection(vault, [base, winner]);
+    const [candidate] = readCandidates(vault);
+    const staleCheckpoint = { revision: 0, event_cursor: winner.event_id, state_hash: 'stale' };
+    const newerCheckpoint = { revision: 77, event_cursor: 'mem-same-turn-newer', state_hash: 'newer' };
+    const registryPath = join(vault, '.brain', 'SESSION_REGISTRY.json');
+    writeFileSync(registryPath, `${JSON.stringify({
+      version: 2,
+      sessions: {
+        current: {
+          memory_status: 'projected',
+          memory_checkpoint: staleCheckpoint,
+          last_memory_attempt: projectedAttempt('current', winner, staleCheckpoint),
+        },
+      },
+    }, null, 2)}\n`);
+
+    const result = decideMemoryCandidate(vault, {
+      action: 'promote',
+      candidateId: candidate.candidate_id,
+      eventId: winner.event_id,
+      beforeCheckpointRefresh: () => {
+        const registry = JSON.parse(readFileSync(registryPath, 'utf8'));
+        registry.sessions.current.last_memory_attempt = {
+          ...registry.sessions.current.last_memory_attempt,
+          event_ids: [winner.event_id, 'mem-same-turn-newer'],
+          checkpoint: newerCheckpoint,
+        };
+        registry.sessions.current.memory_checkpoint = newerCheckpoint;
+        writeFileSync(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+      },
+    });
+
+    assert.equal(result.status, 'promoted');
+    assert.equal(result.checkpointRefreshed, 0);
+    const current = JSON.parse(readFileSync(registryPath, 'utf8')).sessions.current;
+    assert.deepEqual(current.last_memory_attempt.checkpoint, newerCheckpoint);
+    assert.deepEqual(current.memory_checkpoint, newerCheckpoint);
+    assert.deepEqual(current.last_memory_attempt.event_ids, [winner.event_id, 'mem-same-turn-newer']);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-CUR-2] promoção de conflito exige event_id pertencente ao candidate', async () => {
+  const vault = fixture();
+  try {
+    const { decideMemoryCandidate } = await import('../src/memory.mjs');
+    const base = { ...memoryEvent('mem-choice-base', 'base', 1), activation_id: 'activation-base' };
+    const proposal = { ...memoryEvent('mem-choice-proposal', 'proposal', 2), activation_id: 'activation-proposal' };
+    writeMemoryProjection(vault, [base, proposal]);
+    const [candidate] = readCandidates(vault);
+    const ledgerBefore = readFileSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl'), 'utf8');
+
+    assert.throws(() => decideMemoryCandidate(vault, {
+      action: 'promote', candidateId: candidate.candidate_id,
+    }), /event_id|eventId|--event/i);
+    assert.throws(() => decideMemoryCandidate(vault, {
+      action: 'promote', candidateId: candidate.candidate_id, eventId: 'mem-not-a-member',
+    }), /não pertence|not.*candidate/i);
+    assert.equal(readFileSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl'), 'utf8'), ledgerBefore);
+    assert.equal(readCandidates(vault).length, 1);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-CUR-2] CLI promote encaminha --event e falha fechado sem a escolha', () => {
+  const vault = fixture();
+  try {
+    const base = { ...memoryEvent('mem-cli-choice-base', 'base', 1), activation_id: 'activation-base' };
+    const proposal = { ...memoryEvent('mem-cli-choice-proposal', 'proposal', 2), activation_id: 'activation-proposal' };
+    writeMemoryProjection(vault, [base, proposal]);
+    const [candidate] = readCandidates(vault);
+    const args = ['memory', 'promote', candidate.candidate_id, '--vault', vault];
+
+    const missing = spawnSync(process.execPath, [BIN, ...args], { encoding: 'utf8' });
+    assert.equal(missing.status, 1);
+    assert.match(missing.stderr, /--event|eventId/i);
+
+    const applied = spawnSync(process.execPath, [BIN, ...args, '--event', proposal.event_id], { encoding: 'utf8' });
+    assert.equal(applied.status, 0, applied.stderr);
+    assert.equal(JSON.parse(applied.stdout).status, 'promoted');
+    assert.deepEqual(readCandidates(vault), []);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-CUR-2] blocked_by_core não pode ser promovido e pode ser rejeitado durablemente', async () => {
+  const vault = fixture();
+  try {
+    const { decideMemoryCandidate, repairMemory } = await import('../src/memory.mjs');
+    const corePath = join(vault, '.brain', 'CORE.md');
+    writeFileSync(corePath, `${readFileSync(corePath, 'utf8')}\n<!-- wk-memory: release.push="manual-only" -->\n`);
+    const proposal = {
+      ...memoryEvent('mem-core-conflict', 'automatic', 1),
+      memory_key: 'release.push',
+    };
+    writeMemoryProjection(vault, [proposal]);
+    const [candidate] = readCandidates(vault);
+    assert.equal(candidate.reason, 'blocked_by_core');
+    assert.throws(() => decideMemoryCandidate(vault, {
+      action: 'promote', candidateId: candidate.candidate_id, eventId: proposal.event_id,
+    }), /CORE|blocked_by_core/i);
+    assert.equal(decideMemoryCandidate(vault, {
+      action: 'reject', candidateId: candidate.candidate_id,
+    }).status, 'rejected');
+    repairMemory(vault);
+    assert.deepEqual(readCandidates(vault), []);
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
## Resumo

- torna `memory promote` e `memory reject` decisões duráveis no ledger, preservadas por `memory repair`
- exige seleção explícita de evento para conflitos e mantém a proveniência exata do valor promovido
- torna retries idempotentes e protege checkpoints com CAS causal contra attempts mais novos
- atualiza CLI, documentação PT-BR/EN e prepara a versão patch `0.66.1`

## Causa raiz

A curadoria alterava apenas a projeção derivada de candidates. Uma nova projeção podia recriar o conflito e a promoção podia escolher um valor sem seleção explícita. Além disso, a atualização do checkpoint aceitava correspondência inclusiva e podia alcançar um attempt que tivesse mudado concorrentemente.

Esta é uma correção de endurecimento descoberta durante a validação pós-migração da issue #20; não reabre nem altera os dados usados naquela investigação.

## Impacto

- decisões de promote/reject sobrevivem a repair e retries
- conflitos falham fechados sem `--event`
- retry não duplica ledger nem avança revision/state hash
- attempts concorrentes mais novos permanecem intactos
- nenhuma fixture contém dados de projetos consumidores

## Validação

- `node --test --test-name-pattern "MEM-CUR" tests/memory-cli.test.mjs`: 5/5
- `node --test tests/memory-cli.test.mjs`: 37/37
- `npm test`: 1146/1146
- `wendkeep verify`: 4/4 sensores
- `wendkeep verify --deep`: 4/4 sensores
- verificação independente: `ok:true`, 3/3 requisitos
- `wendkeep doctor`: 0 erros, 0 avisos
- `wendkeep validate-memory`: bundle v2 válido
- `wendkeep sync-defs --check`: 0.66.1 alinhado

## Release

`package.json`, lockfile e `CHANGELOG.md` estão alinhados em `0.66.1`. O npm deve ser publicado somente após revisão e merge na `main`.