### PR TITLE
fix: preserve causal continuity in memory promotion (0.66.2)

### DIFF
--- a/.agents/skills/example-skill/.wendkeep-meta.json
+++ b/.agents/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.1",
+  "wendkeepVersion": "0.66.2",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.agents/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.agents/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.1",
+  "wendkeepVersion": "0.66.2",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.agents/skills/wk-debugging/.wendkeep-meta.json
+++ b/.agents/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.1",
+  "wendkeepVersion": "0.66.2",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.agents/skills/wk-planning/.wendkeep-meta.json
+++ b/.agents/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.1",
+  "wendkeepVersion": "0.66.2",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.agents/skills/wk-tdd/.wendkeep-meta.json
+++ b/.agents/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.1",
+  "wendkeepVersion": "0.66.2",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.agents/skills/wk-verify/.wendkeep-meta.json
+++ b/.agents/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.1",
+  "wendkeepVersion": "0.66.2",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.agents/skills/wk-workflow/.wendkeep-meta.json
+++ b/.agents/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.1",
+  "wendkeepVersion": "0.66.2",
   "sourceHash": "c3299e94ce34103fb599744eabec7aec581aefc6fd7c6b959e0350293ee5d8bf"
 }

--- a/.claude/skills/example-skill/.wendkeep-meta.json
+++ b/.claude/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.1",
+  "wendkeepVersion": "0.66.2",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.claude/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.claude/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.1",
+  "wendkeepVersion": "0.66.2",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.claude/skills/wk-debugging/.wendkeep-meta.json
+++ b/.claude/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.1",
+  "wendkeepVersion": "0.66.2",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.claude/skills/wk-planning/.wendkeep-meta.json
+++ b/.claude/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.1",
+  "wendkeepVersion": "0.66.2",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.claude/skills/wk-tdd/.wendkeep-meta.json
+++ b/.claude/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.1",
+  "wendkeepVersion": "0.66.2",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.claude/skills/wk-verify/.wendkeep-meta.json
+++ b/.claude/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.1",
+  "wendkeepVersion": "0.66.2",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.claude/skills/wk-workflow/.wendkeep-meta.json
+++ b/.claude/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.1",
+  "wendkeepVersion": "0.66.2",
   "sourceHash": "c3299e94ce34103fb599744eabec7aec581aefc6fd7c6b959e0350293ee5d8bf"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- wendkeep:skills:start -->
-<!-- wendkeep-version: 0.66.1; skills-sha256: 36ebe0728fe02c48230802722405c3179cb460f289429505e341db582542b82d -->
+<!-- wendkeep-version: 0.66.2; skills-sha256: 36ebe0728fe02c48230802722405c3179cb460f289429505e341db582542b82d -->
 ## wendkeep — Keep Core & operating profiles
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. **Keep Core is always active**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.66.2] — 2026-07-29
+
+### Fixed
+
+- **Promoção preserva valor e identidade causal do evento escolhido.** `memory promote` não
+  converte mais objetos/arrays JSON em texto e mantém sessão, activation/epoch, turno de origem e
+  sequência; o próximo `SessionStop` da mesma cadeia avança o handoff sem recriar candidate.
+- **A recuperação 0.66.1 cobre inversão física/temporal sem ampliar autoridade.** Quando uma
+  promoção legada projetada fica fora do candidate por `observed_at`, `memory promote` só a inclui
+  em `supersedes` sob prova de ancestralidade e mesma linhagem; fonte moderna ou alheia falha antes
+  de anexar. O E2E percorre o dispatcher público e prova Stop posterior e duplicado idempotentes.
+
 ## [0.66.1] — 2026-07-29
 
 ### Fixed

--- a/README.en.md
+++ b/README.en.md
@@ -256,7 +256,7 @@ Hot memory now separates human authorship, operational state, and evidence:
 - **`CORE.md` is canonical.** It is the short, hand-curated nucleus for durable preferences, active patterns, and open issues; no projector may infer or overwrite it.
 - **`SHARED_MEMORY.md` is generated operational state.** The `Stop` hook turns the session handoff into sanitized events; the projector deterministically reduces the ledger and publishes a verifiable revision, cursor, and hash. Facts are `verified` only with local evidence; unsupported reports remain `reported`, and disagreements become candidates for human judgment.
 - **`MEMORY_EVENTS.jsonl` is the append-only authority.** `Stop` makes events durable in the outbox before acknowledging the attempt; the projector runs outside the registry lock and retries reuse the same IDs. Repeating an identical `event_id`/payload is a no-op; reusing the ID with different bytes is observable corruption.
-- **`MEMORY_CANDIDATES.jsonl` is the curation queue.** Conflicts and legacy content are never silently promoted. `promote` and `reject` record the decision as a new event.
+- **`MEMORY_CANDIDATES.jsonl` is the curation queue.** Conflicts and legacy content are never silently promoted. `promote` and `reject` record the decision as a new event; promotion preserves the selected event's JSON type, session, activation/epoch, and source turn.
 
 Artifacts stay under `.brain/` only. Sanitization strips secrets, tokens, local paths, transcripts, and harness payloads both before persistence and before injection. Events carry a `project_id`, and one vault never accepts another project's events.
 
@@ -295,9 +295,15 @@ ambiguity uses `memory reconcile <session> --by-session <successor>
 --reason <reason>` as a dry run and requires `--apply`; the decision is backed up and audited
 without rewriting ledger, CORE, or notes. Run `status --gate` again afterwards. Conflicts require
 explicit, durable curation: `memory promote <id> --event <event-id>` selects one event from the
-candidate, while `memory reject <id>` keeps the current value. Decisions are idempotent and
-survive repair/replay; `blocked_by_core` cannot override CORE. Doctor only diagnoses. See
-[memory and curation](docs/en/commands/memory.md).
+candidate, while `memory reject <id>` keeps the current value. The decision is idempotent, and a
+new promotion accepts a later Stop from the same session/activation without recreating a conflict.
+A promotion written by 0.66.1 remains historical: if the next Stop forms a new candidate, update
+the package and explicitly promote the current event once; repair/reconcile do not choose causal
+lineage. If physical order and `observed_at` leave another projected 0.66.1 promotion outside the
+candidate, the command adds it to `supersedes` only after proving the same lineage, a later turn,
+and the temporal inversion; a modern or unrelated source fails before appending bytes. Decisions
+survive repair/replay; `blocked_by_core` cannot override CORE. Doctor only
+diagnoses. See [memory and curation](docs/en/commands/memory.md).
 
 Session notes use one live `## Agentes, tokens e custos` snapshot. Main-agent and subagent hooks recompose it atomically, with costs, token dimensions, reasoning tokens and effort per model/source. Every hook that rewrites a session note takes a per-file lock and writes through a temp file + rename, so the `SubagentStop` fan-out (one hook run per subagent) can never leave a note half-written; a note whose frontmatter reads back damaged is left untouched rather than patched.
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ A memória quente agora separa claramente autoria humana, estado operacional e e
 - **`CORE.md` é canônico.** É o núcleo curto, curado à mão, com preferências duráveis, padrões ativos e pendências que nenhum projetor pode inferir ou sobrescrever.
 - **`SHARED_MEMORY.md` é operacional e gerado.** O hook `Stop` transforma o handoff da sessão em eventos sanitizados; o projetor reduz o ledger de modo determinístico e publica revision, cursor e hash verificáveis. Fatos só entram como `verified` quando há evidência local; relatos sem prova ficam `reported`, e disputas viram candidates para decisão humana.
 - **`MEMORY_EVENTS.jsonl` é a autoridade append-only.** O `Stop` torna os eventos duráveis na outbox antes de reconhecer o attempt; o projector roda fora do lock do registry e retries reutilizam os mesmos IDs. Repetir o mesmo `event_id`/payload é no-op; reutilizar o ID com bytes diferentes é corrupção observável.
-- **`MEMORY_CANDIDATES.jsonl` é a fila de curadoria.** Conflitos e conteúdo legado não são promovidos silenciosamente. `promote` e `reject` registram a decisão como novo evento.
+- **`MEMORY_CANDIDATES.jsonl` é a fila de curadoria.** Conflitos e conteúdo legado não são promovidos silenciosamente. `promote` e `reject` registram a decisão como novo evento; a promoção preserva o tipo JSON, a sessão, a activation/epoch e o turno de origem do evento escolhido.
 
 Os artefatos ficam somente em `.brain/`; a sanitização remove secrets, tokens, paths locais, transcripts e payloads de harness tanto antes da persistência quanto antes da injeção. Eventos carregam `project_id`, e um vault nunca aceita eventos de outro projeto.
 
@@ -291,9 +291,15 @@ ambiguidade comprovadamente substituída usa `memory reconcile <sessão>
 --by-session <sucessora> --reason <motivo>` como dry-run e exige `--apply`; a decisão faz backup e
 auditoria sem reescrever ledger, CORE ou notas. Depois rode `status --gate` novamente. Conflitos
 exigem curadoria explícita e durável: `memory promote <id> --event <event-id>` escolhe um dos
-eventos do candidate; `memory reject <id>` mantém o valor atual. As decisões são idempotentes e
-sobrevivem a repair/replay; `blocked_by_core` não pode sobrescrever CORE. O doctor apenas
-diagnostica. Veja [memória e curadoria](docs/pt-BR/commands/memory.md).
+eventos do candidate; `memory reject <id>` mantém o valor atual. A decisão é idempotente, e uma
+promoção nova aceita um Stop posterior da mesma sessão/activation sem recriar conflito. Uma
+promoção gravada pela 0.66.1 permanece histórica: se o próximo Stop formar novo candidate,
+atualize o pacote e promova explicitamente o evento atual uma vez; repair/reconcile não escolhem
+causalidade. Se a ordem física e `observed_at` deixarem outra promoção 0.66.1 projetada fora do
+candidate, o comando só a inclui em `supersedes` após provar a mesma linhagem, turno maior e a
+inversão temporal; fonte moderna ou alheia falha antes de anexar bytes. Decisões sobrevivem a
+repair/replay; `blocked_by_core` não pode sobrescrever CORE.
+O doctor apenas diagnostica. Veja [memória e curadoria](docs/pt-BR/commands/memory.md).
 
 As notas de sessão usam um único snapshot vivo `## Agentes, tokens e custos`. Os hooks do agente principal e dos subagents recompõem o bloco atomicamente, incluindo custo, dimensões de tokens, reasoning e effort por modelo/origem.
 

--- a/docs/en/commands/memory.md
+++ b/docs/en/commands/memory.md
@@ -70,7 +70,15 @@ npx wendkeep validate-memory --vault <v2-vault>
   `blocked_by_core` candidate can only be rejected: promotion first requires canonical CORE
   curation. If the selected event still belongs to the matching latest `projected` attempt,
   promotion also refreshes its checkpoint and mirror causally; JSON reports
-  `checkpointRefreshed`, and a newer concurrent attempt remains untouched.
+  `checkpointRefreshed`, and a newer concurrent attempt remains untouched. The decision keeps
+  the already validated JSON value without string coercion and copies the selected event's
+  `canonical_session_id`, activation/epoch, `source_turn_id`, and `turn_sequence`. A later Stop
+  from the same session/activation therefore advances the value instead of opening another candidate.
+  When physical append order and `observed_at` leave a projected 0.66.1 promotion outside the
+  candidate, it is added to `supersedes` only if it has the exact legacy shape, shares a candidate
+  ancestor, and the selected event proves the same session/activation/epoch, a later turn, and the
+  temporal inversion. `candidate_decision.event_ids` remains exactly the choice shown to the
+  operator; a modern source, different lineage, or incomplete proof fails before appending an event.
 - `validate-memory <CORE.md>` checks the 25-line cap, required sections, and secrets.
 - `validate-memory --vault` requires a complete v2 bundle and is not the legacy-vault gate.
 
@@ -108,6 +116,11 @@ of a global projection that has already advanced with concurrent events.
 - `promote` reports that `--event` is required: inspect the candidate `event_ids`, compare their
   provenance/value, and name the winner explicitly. An ID outside the candidate fails without
   mutating the ledger or projections.
+- A promotion made by 0.66.1 followed by a new candidate: update to 0.66.2 or newer, inspect the
+  provenance, and explicitly promote the current event once. The old ledger is not reinterpreted;
+  `memory repair` and `memory reconcile` do not replace that human choice.
+- `promote` says that the candidate no longer matches the causal projection: no event was appended.
+  Run `memory status`, inspect the current candidate again, and do not force a different lineage.
 - Missing `event_cursor` or mismatched v2 hash: preserve the bundle and assess `memory repair`.
 - `validate-memory --vault` fails on legacy: validate CORE only or migrate first.
 

--- a/docs/pt-BR/commands/memory.md
+++ b/docs/pt-BR/commands/memory.md
@@ -68,6 +68,14 @@ npx wendkeep validate-memory --vault <cofre-v2>
   promover exige antes alterar CORE pela curadoria canônica. Se o evento escolhido ainda pertence
   ao último attempt `projected` correspondente, a promoção também atualiza causalmente checkpoint
   e espelho; o JSON retorna `checkpointRefreshed`, e um attempt concorrente mais novo não é tocado.
+  A decisão conserva, sem coerção para string, o valor JSON já validado e copia do evento escolhido
+  `canonical_session_id`, activation/epoch, `source_turn_id` e `turn_sequence`. Por isso, um Stop
+  posterior da mesma sessão/activation avança o valor em vez de abrir outro candidate. Quando
+  append físico e `observed_at` deixam uma promoção 0.66.1 projetada fora do candidate, ela só é
+  acrescentada a `supersedes` se tiver a forma legada exata, compartilhar ancestral no candidate e
+  o evento escolhido provar a mesma sessão/activation/epoch, turno maior e a inversão temporal.
+  `candidate_decision.event_ids` continua sendo exatamente a escolha mostrada ao operador; fonte
+  moderna, outra linhagem ou prova incompleta falha antes de anexar um evento.
 - `validate-memory <CORE.md>` valida cap de 25 linhas, seções e segredos.
 - `validate-memory --vault` exige bundle v2 completo; não é o gate correto para vault legado.
 
@@ -104,6 +112,11 @@ prefixo válido de uma projeção global que já avançou com eventos concorrent
 - `promote` informa que `--event` é obrigatório: leia os `event_ids` do candidate, compare a
   proveniência/valor e indique explicitamente o vencedor. ID que não pertence ao candidate falha
   sem mutar ledger ou projeções.
+- Promoção feita pela 0.66.1 seguida de novo candidate: atualize para 0.66.2 ou superior,
+  confira a proveniência e promova explicitamente o evento atual uma vez. O ledger antigo não é
+  reinterpretado; `memory repair` e `memory reconcile` não substituem essa escolha humana.
+- `promote` informa que o candidate não corresponde mais à projeção causal: nenhum evento foi
+  anexado. Rode `memory status`, releia o candidate atual e não force uma linhagem diferente.
 - `event_cursor` ausente ou hash divergente em v2: preserve o bundle e avalie `memory repair`.
 - `validate-memory --vault` falha no legado: valide apenas CORE ou migre primeiro.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.66.1",
+  "version": "0.66.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.66.1",
+      "version": "0.66.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.66.1",
+  "version": "0.66.2",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [

--- a/src/memory.mjs
+++ b/src/memory.mjs
@@ -263,6 +263,80 @@ function assertCompatibleDecision(prior, { action, eventId }) {
   }
 }
 
+function promotedMemoryValue(value) {
+  return typeof value === 'string' ? sanitizeMemoryText(value) : cloneJson(value);
+}
+
+function eventSupersedes(event) {
+  if (Array.isArray(event?.supersedes)) return event.supersedes;
+  return event?.supersedes_event_id ? [event.supersedes_event_id] : [];
+}
+
+function hasCompleteCausalIdentity(event) {
+  return Boolean(event?.canonical_session_id && event?.activation_id && event?.source_turn_id)
+    && Number.isInteger(event.activation_epoch)
+    && Number.isInteger(event.turn_sequence);
+}
+
+function sameCausalLineage(left, right) {
+  return hasCompleteCausalIdentity(left) && hasCompleteCausalIdentity(right)
+    && left.canonical_session_id === right.canonical_session_id
+    && left.activation_id === right.activation_id
+    && left.activation_epoch === right.activation_epoch;
+}
+
+function promotedSupersedes(vault, candidate, selected) {
+  const memberIds = new Set(Array.isArray(candidate.event_ids) ? candidate.event_ids : []);
+  const ledger = readMemoryLedger(vault);
+  if (ledger.status !== 'ok') throw new Error('Ledger de memória inválido durante a promoção.');
+  const current = deriveMemoryProjection(vault, ledger.events)
+    .records?.[candidate.memory_key]?.source;
+  if (!current?.event_id || memberIds.has(current.event_id)) return [...memberIds].sort();
+
+  const currentSelectedId = current.candidate_decision?.selected_event_id;
+  const currentSelected = currentSelectedId
+    ? ledger.events.find((event) => event.event_id === currentSelectedId)
+    : null;
+  const selectedLedger = ledger.events.find((event) => event.event_id === selected.event_id);
+  const currentAncestors = eventSupersedes(current);
+  const decisionMembers = Array.isArray(current.candidate_decision?.event_ids)
+    ? current.candidate_decision.event_ids
+    : [];
+  const canonicalAncestors = [...new Set(currentAncestors)].sort();
+  const canonicalDecisionMembers = [...new Set(decisionMembers)].sort();
+  const currentObserved = String(current.effective_at || current.observed_at || '');
+  const selectedObserved = String(selectedLedger?.effective_at || selectedLedger?.observed_at || '');
+  const currentPhysicalIndex = ledger.events.findIndex((event) => event.event_id === current.event_id);
+  const selectedPhysicalIndex = ledger.events.findIndex((event) => event.event_id === selected.event_id);
+  const bridgeChecks = {
+    legacyShape: current.operation === 'replace' && current.authority === 'verified'
+      && !current.canonical_session_id && !current.source_turn_id,
+    promotion: current.candidate_decision?.action === 'promote',
+    selectedPresent: Boolean(currentSelected),
+    selectedPersisted: Boolean(selectedLedger),
+    exactDecisionMembers: canonicalAncestors.length === currentAncestors.length
+      && canonicalDecisionMembers.length === decisionMembers.length
+      && canonicalAncestors.length === canonicalDecisionMembers.length
+      && canonicalAncestors.every((eventId, index) => eventId === canonicalDecisionMembers[index]),
+    selectedSuperseded: currentAncestors.includes(currentSelectedId)
+      && decisionMembers.includes(currentSelectedId),
+    candidateAncestor: currentAncestors.some((eventId) => memberIds.has(eventId)),
+    sameLineage: sameCausalLineage(currentSelected, selectedLedger),
+    laterTurn: selectedLedger?.turn_sequence > currentSelected?.turn_sequence,
+    appendedAfterCurrent: selectedPhysicalIndex > currentPhysicalIndex && currentPhysicalIndex >= 0,
+    observedBeforeCurrent: selectedObserved < currentObserved,
+  };
+  const bridgesObservedOrder = Object.values(bridgeChecks).every(Boolean);
+  if (!bridgesObservedOrder) {
+    throw new Error(
+      `Candidate ${candidate.candidate_id} não corresponde mais à projeção causal atual; `
+      + 'recarregue os candidates antes de promover.',
+    );
+  }
+  memberIds.add(current.event_id);
+  return [...memberIds].sort();
+}
+
 function matchesPromotedAttempt(attempt, selected) {
   if (attempt?.memory_mode !== 'v2' || attempt.state !== 'projected'
       || !Array.isArray(attempt.event_ids) || !attempt.event_ids.includes(selected.event_id)) return false;
@@ -378,6 +452,9 @@ export function decideMemoryCandidate(vault, {
   if (action === 'promote' && selectedValue === undefined) {
     throw new Error(`Candidate ${candidateId} não contém valor promovível.`);
   }
+  const supersedes = action === 'promote' && selected
+    ? promotedSupersedes(vault, candidate, selected)
+    : [];
   const now = new Date().toISOString();
   const decision = {
     candidate_id: candidateId,
@@ -391,15 +468,19 @@ export function decideMemoryCandidate(vault, {
     project_id: projectId(vault),
     memory_key: action === 'promote' ? candidate.memory_key : `candidate.decision.${candidateId}`,
     operation: action === 'promote' && selected ? 'replace' : 'assert',
-    value: sanitizeMemoryText(action === 'promote' ? selectedValue : 'rejected'),
+    value: action === 'promote' ? promotedMemoryValue(selectedValue) : 'rejected',
     authority: 'verified',
+    ...(selected?.canonical_session_id
+      ? { canonical_session_id: selected.canonical_session_id }
+      : {}),
     activation_id: selected?.activation_id || 'wendkeep-memory-cli',
     ...(Number.isInteger(selected?.activation_epoch) ? { activation_epoch: selected.activation_epoch } : {}),
     turn_sequence: selected?.turn_sequence ?? 0,
+    ...(selected?.source_turn_id ? { source_turn_id: selected.source_turn_id } : {}),
     observed_at: now,
     evidence: [`candidate:${candidateId}`],
     candidate_decision: decision,
-    ...(selected ? { supersedes: decision.event_ids } : {}),
+    ...(selected ? { supersedes } : {}),
   };
   enqueueMemoryEvent(vault, event);
   const projection = projectMemoryOutbox(vault);

--- a/tests/memory-cli.test.mjs
+++ b/tests/memory-cli.test.mjs
@@ -11,7 +11,8 @@ import { join } from 'node:path';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  canonicalMemoryJson, deriveMemoryProjection, prepareMemoryProjection, reduceMemoryEvents,
+  canonicalMemoryJson, deriveMemoryProjection, hashMemoryValue, prepareMemoryProjection,
+  reduceMemoryEvents,
 } from '../hooks/memory-store.mjs';
 import { renderSharedMemory } from '../hooks/memory-schema.mjs';
 import { renderCoreSkeleton } from '../src/validate-core.mjs';
@@ -59,6 +60,100 @@ function memoryEvent(eventId, value, turnSequence) {
     observed_at: `2026-07-26T12:0${turnSequence}:00.000Z`,
     evidence: [`turn:${turnSequence}`],
   };
+}
+
+function legacyPromotionEvent(eventId, candidate, selected, observedAt, overrides = {}) {
+  const eventIds = [...candidate.event_ids].sort();
+  return {
+    v: 1,
+    event_id: eventId,
+    project_id: selected.project_id,
+    memory_key: selected.memory_key,
+    operation: 'replace',
+    value: selected.value,
+    authority: 'verified',
+    activation_id: selected.activation_id,
+    activation_epoch: selected.activation_epoch,
+    turn_sequence: selected.turn_sequence,
+    observed_at: observedAt,
+    evidence: [`candidate:${candidate.candidate_id}`],
+    candidate_decision: {
+      candidate_id: candidate.candidate_id,
+      action: 'promote',
+      event_ids: eventIds,
+      selected_event_id: selected.event_id,
+    },
+    supersedes: eventIds,
+    ...overrides,
+  };
+}
+
+function seedOutOfOrderPromotionBridge(vault, {
+  currentOverrides = {}, selectedOverrides = {}, mutateCurrentPromotion = null,
+  selectedBeforeCurrent = false,
+} = {}) {
+  const base = {
+    ...memoryEvent('mem-bridge-base', 'bridge base', 0),
+    canonical_session_id: 'bridge-session',
+    activation_id: 'bridge-activation',
+    source_turn_id: 'bridge-turn-base',
+    observed_at: '2026-07-26T12:00:00.000Z',
+  };
+  const competing = {
+    ...base,
+    event_id: 'mem-bridge-competing',
+    value: 'bridge competing',
+    canonical_session_id: 'bridge-competing-session',
+    activation_id: 'bridge-competing-activation',
+    source_turn_id: 'bridge-competing-turn',
+    observed_at: '2026-07-26T12:01:00.000Z',
+  };
+  writeMemoryProjection(vault, [base, competing]);
+  const initial = readCandidates(vault).find((item) => item.event_ids.includes(base.event_id));
+  const firstPromotion = legacyPromotionEvent(
+    'mem-bridge-first-promotion', initial, base, '2026-07-26T12:02:00.000Z',
+  );
+  const prior = {
+    ...base,
+    event_id: 'mem-bridge-prior',
+    value: 'bridge prior',
+    turn_sequence: 1,
+    source_turn_id: 'bridge-turn-prior',
+    observed_at: '2026-07-26T12:03:00.000Z',
+  };
+  const prefix = [base, competing, firstPromotion, prior];
+  writeMemoryProjection(vault, prefix);
+  const priorCandidate = readCandidates(vault)
+    .find((item) => item.event_ids.includes(prior.event_id));
+  const prefixProjection = deriveMemoryProjection(vault, prefix);
+  let currentPromotion = legacyPromotionEvent(
+    'mem-bridge-current-promotion',
+    priorCandidate,
+    prior,
+    '2026-07-26T12:05:00.000Z',
+    currentOverrides,
+  );
+  const selected = {
+    ...base,
+    event_id: 'mem-bridge-selected',
+    value: 'bridge selected',
+    turn_sequence: 2,
+    source_turn_id: 'bridge-turn-selected',
+    observed_at: '2026-07-26T12:04:00.000Z',
+    ...selectedOverrides,
+  };
+  if (mutateCurrentPromotion) {
+    currentPromotion = mutateCurrentPromotion({
+      currentPromotion, prefixProjection, prior, priorCandidate,
+    });
+  }
+  const suffix = selectedBeforeCurrent
+    ? [selected, currentPromotion]
+    : [currentPromotion, selected];
+  writeMemoryProjection(vault, [...prefix, ...suffix]);
+  const candidate = readCandidates(vault)
+    .find((item) => item.event_ids.includes(selected.event_id));
+  return { candidate, currentPromotion, selected };
 }
 
 function checkpoint(reduced) {
@@ -518,6 +613,148 @@ test('[req:MEM-CUR-1] [req:MEM-CUR-2] [req:MEM-CUR-3] decisões sobre candidates
       action: 'reject', candidateId: promoted.candidate_id,
     }), /decisão incompatível|already.*promot|já.*promov/i);
   } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-CUR-2] promoção preserva valor JSON e identidade causal do evento escolhido', async () => {
+  const vault = fixture();
+  try {
+    const { decideMemoryCandidate } = await import('../src/memory.mjs');
+    const selected = {
+      ...memoryEvent('mem-typed-selected', { branch: 'main', commit: 'abc123' }, 2),
+      memory_key: 'git.local-head',
+      canonical_session_id: 'selected-session',
+      activation_id: 'selected-activation',
+      source_turn_id: 'selected-turn',
+    };
+    const competing = {
+      ...memoryEvent('mem-typed-competing', { branch: 'feature', commit: 'def456' }, 2),
+      memory_key: 'git.local-head',
+      canonical_session_id: 'competing-session',
+      activation_id: 'competing-activation',
+      source_turn_id: 'competing-turn',
+    };
+    writeMemoryProjection(vault, [selected, competing]);
+    const candidate = readCandidates(vault).find((item) => item.event_ids.includes(selected.event_id));
+    assert.ok(candidate);
+
+    const result = decideMemoryCandidate(vault, {
+      action: 'promote', candidateId: candidate.candidate_id, eventId: selected.event_id,
+    });
+    const ledger = readFileSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl'), 'utf8')
+      .trim().split('\n').map(JSON.parse);
+    const decision = ledger.find((event) => event.event_id === result.eventId);
+
+    assert.deepEqual(decision.value, selected.value);
+    assert.equal(decision.canonical_session_id, selected.canonical_session_id);
+    assert.equal(decision.activation_id, selected.activation_id);
+    assert.equal(decision.activation_epoch, selected.activation_epoch);
+    assert.equal(decision.source_turn_id, selected.source_turn_id);
+    assert.equal(decision.turn_sequence, selected.turn_sequence);
+
+    const later = {
+      ...selected,
+      event_id: 'mem-typed-later',
+      value: { branch: 'main', commit: 'fedcba' },
+      turn_sequence: selected.turn_sequence + 1,
+      source_turn_id: 'selected-turn-later',
+      observed_at: new Date(Date.parse(decision.observed_at) + 1_000).toISOString(),
+    };
+    const reduced = reduceMemoryEvents([...ledger, later]);
+    assert.equal(reduced.candidates.length, 0, JSON.stringify(reduced.candidates));
+    assert.deepEqual(reduced.state['git.local-head'], later.value);
+    assert.equal(reduced.records['git.local-head'].source.event_id, later.event_id);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-CUR-2] bridge temporal exige todas as provas legadas e causais', async () => {
+  const { decideMemoryCandidate } = await import('../src/memory.mjs');
+  const scenarios = [
+    {
+      name: 'promoção atual já possui identidade moderna',
+      options: {
+        currentOverrides: {
+          canonical_session_id: 'bridge-session',
+          source_turn_id: 'bridge-turn-prior',
+        },
+      },
+    },
+    {
+      name: 'evento escolhido pertence a outra linhagem causal',
+      options: {
+        selectedOverrides: {
+          canonical_session_id: 'bridge-other-session',
+          activation_id: 'bridge-other-activation',
+          source_turn_id: 'bridge-other-turn',
+        },
+      },
+    },
+    {
+      name: 'supersedes diverge dos membros auditados pela decisão legada',
+      options: {
+        mutateCurrentPromotion: ({ currentPromotion }) => ({
+          ...currentPromotion,
+          candidate_decision: {
+            ...currentPromotion.candidate_decision,
+            event_ids: [...currentPromotion.candidate_decision.event_ids, 'mem-bridge-base'].sort(),
+          },
+        }),
+      },
+    },
+    {
+      name: 'promoção atual não compartilha ancestral com o candidate posterior',
+      options: {
+        mutateCurrentPromotion: ({ currentPromotion, prefixProjection, prior }) => {
+          const current = prefixProjection.records['handoff.latest'];
+          return {
+            ...currentPromotion,
+            supersedes: [prior.event_id],
+            base_revision: current.revision,
+            base_value_hash: hashMemoryValue(current.value),
+            candidate_decision: {
+              ...currentPromotion.candidate_decision,
+              event_ids: [prior.event_id],
+            },
+          };
+        },
+      },
+    },
+    {
+      name: 'evento escolhido não possui turno maior',
+      options: { selectedOverrides: { turn_sequence: 1 } },
+    },
+    {
+      name: 'evento escolhido não foi anexado depois da promoção atual',
+      options: { selectedBeforeCurrent: true },
+    },
+    {
+      name: 'observed_at não está invertido em relação à ordem física',
+      options: {
+        selectedOverrides: { observed_at: '2026-07-26T12:06:00.000Z' },
+        mutateCurrentPromotion: ({ currentPromotion, prefixProjection }) => {
+          const current = prefixProjection.records['handoff.latest'];
+          return {
+            ...currentPromotion,
+            base_revision: current.revision,
+            base_value_hash: hashMemoryValue(current.value),
+          };
+        },
+      },
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const vault = fixture();
+    try {
+      const { candidate, selected } = seedOutOfOrderPromotionBridge(vault, scenario.options);
+      assert.ok(candidate, scenario.name);
+      const ledgerPath = join(vault, '.brain', 'MEMORY_EVENTS.jsonl');
+      const ledgerBefore = readFileSync(ledgerPath, 'utf8');
+      assert.throws(() => decideMemoryCandidate(vault, {
+        action: 'promote', candidateId: candidate.candidate_id, eventId: selected.event_id,
+      }), /não corresponde mais à projeção causal atual/i, scenario.name);
+      assert.equal(readFileSync(ledgerPath, 'utf8'), ledgerBefore, `${scenario.name}: ledger imutável`);
+    } finally { rmSync(vault, { recursive: true, force: true }); }
+  }
 });
 
 test('[req:MEM-CUR-2] CAS não atualiza attempt novo que ainda contém o evento promovido', async () => {

--- a/tests/memory-hybrid-e2e.test.mjs
+++ b/tests/memory-hybrid-e2e.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -11,8 +11,13 @@ import {
   cleanSyntheticHookEnv,
   seedSyntheticHybridLifecycle,
 } from './fixtures/synthetic-memory-lifecycle.mjs';
+import {
+  enqueueMemoryEvent, projectMemoryOutbox, readMemoryLedger,
+} from '../hooks/memory-store.mjs';
+import { decideMemoryCandidate } from '../src/memory.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const BIN = join(ROOT, 'bin', 'wendkeep.mjs');
 const STOP = join(ROOT, 'hooks', 'session-stop.mjs');
 const START = join(ROOT, 'hooks', 'session-start.mjs');
 const INJECT = join(ROOT, 'hooks', 'brain-inject.mjs');
@@ -36,6 +41,22 @@ function runHook(script, { project, vault, input }) {
     encoding: 'utf8',
     input: JSON.stringify(input),
   });
+}
+
+function runPublicHook(name, { project, vault, input }) {
+  const env = cleanSyntheticHookEnv(vault);
+  env.OBSIDIAN_VAULT_PATH = join(project, '.wk-fixture-wrong-global-vault');
+  return spawnSync(process.execPath, [BIN, 'hook', name], {
+    cwd: project,
+    env,
+    encoding: 'utf8',
+    input: JSON.stringify(input),
+  });
+}
+
+function readCandidates(brain) {
+  const content = readFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), 'utf8').trim();
+  return content ? content.split('\n').map(JSON.parse) : [];
 }
 
 function escapeRegExp(value) {
@@ -126,6 +147,216 @@ test('[req:MEM-STOP-7] synthetic Stop projects lifecycle memory and remains idem
       '[wk-fixture] injected context contains projected memory',
     );
   }
+});
+
+test('[req:MEM-CUR-2] recovery after a 0.66.1 promotion accepts the next public Stop', () => {
+  const { project, vault, brain, sessionPath, transcript } = seedSyntheticHybridLifecycle();
+  const legacyBase = Date.now() - 10_000;
+  const selected = {
+    v: 1,
+    event_id: 'wk-fixture-promoted-handoff',
+    project_id: SYNTHETIC_MEMORY.projectId,
+    memory_key: 'handoff.latest',
+    operation: 'assert',
+    value: '[wk-fixture] selected handoff before the next Stop.',
+    authority: 'reported',
+    canonical_session_id: SYNTHETIC_MEMORY.sessionId,
+    activation_id: SYNTHETIC_MEMORY.activationOne,
+    activation_epoch: 1,
+    turn_sequence: 0,
+    source_turn_id: 'wk-fixture-turn-before-stop',
+    observed_at: new Date(legacyBase).toISOString(),
+    evidence: ['wk-fixture:selected'],
+  };
+  const competing = {
+    ...selected,
+    event_id: 'wk-fixture-competing-handoff',
+    value: '[wk-fixture] competing handoff.',
+    canonical_session_id: 'wk-fixture-competing-session',
+    activation_id: 'wk-fixture-competing-activation',
+    source_turn_id: 'wk-fixture-competing-turn',
+    observed_at: new Date(legacyBase + 1_000).toISOString(),
+    evidence: ['wk-fixture:competing'],
+  };
+  enqueueMemoryEvent(vault, selected);
+  enqueueMemoryEvent(vault, competing);
+  projectMemoryOutbox(vault);
+  const candidate = readCandidates(brain).find((item) => item.event_ids.includes(selected.event_id));
+  assert.ok(candidate);
+
+  const legacyPromotion = {
+    v: 1,
+    event_id: 'wk-fixture-0661-promotion',
+    project_id: SYNTHETIC_MEMORY.projectId,
+    memory_key: selected.memory_key,
+    operation: 'replace',
+    value: selected.value,
+    authority: 'verified',
+    activation_id: selected.activation_id,
+    activation_epoch: selected.activation_epoch,
+    turn_sequence: selected.turn_sequence,
+    observed_at: new Date(legacyBase + 2_000).toISOString(),
+    evidence: [`candidate:${candidate.candidate_id}`],
+    candidate_decision: {
+      candidate_id: candidate.candidate_id,
+      action: 'promote',
+      event_ids: [...candidate.event_ids].sort(),
+      selected_event_id: selected.event_id,
+    },
+    supersedes: [...candidate.event_ids].sort(),
+  };
+  enqueueMemoryEvent(vault, legacyPromotion);
+  projectMemoryOutbox(vault);
+  assert.deepEqual(readCandidates(brain), []);
+
+  const priorContinuation = {
+    ...selected,
+    event_id: 'wk-fixture-prior-0661-continuation',
+    value: '[wk-fixture] prior continuation promoted by 0.66.1.',
+    source_turn_id: 'wk-fixture-turn-prior-0661',
+    observed_at: new Date(legacyBase + 3_000).toISOString(),
+    evidence: ['wk-fixture:prior-0661'],
+  };
+  enqueueMemoryEvent(vault, priorContinuation);
+  projectMemoryOutbox(vault);
+  const priorCandidate = readCandidates(brain).find(
+    (item) => item.event_ids.includes(priorContinuation.event_id),
+  );
+  assert.ok(priorCandidate);
+  const laterLegacyPromotion = {
+    ...legacyPromotion,
+    event_id: 'wk-fixture-later-0661-promotion',
+    value: priorContinuation.value,
+    observed_at: new Date(legacyBase + 5_000).toISOString(),
+    evidence: [`candidate:${priorCandidate.candidate_id}`],
+    candidate_decision: {
+      candidate_id: priorCandidate.candidate_id,
+      action: 'promote',
+      event_ids: [...priorCandidate.event_ids].sort(),
+      selected_event_id: priorContinuation.event_id,
+    },
+    supersedes: [...priorCandidate.event_ids].sort(),
+  };
+  enqueueMemoryEvent(vault, laterLegacyPromotion);
+  projectMemoryOutbox(vault);
+  assert.deepEqual(readCandidates(brain), []);
+
+  const postLegacyHandoff = {
+    ...selected,
+    event_id: 'wk-fixture-post-0661-handoff',
+    value: '[wk-fixture] handoff observed after the 0.66.1 decision.',
+    turn_sequence: 1,
+    source_turn_id: 'wk-fixture-turn-after-0661',
+    observed_at: new Date(legacyBase + 4_000).toISOString(),
+    evidence: ['wk-fixture:post-0661'],
+  };
+  enqueueMemoryEvent(vault, postLegacyHandoff);
+  projectMemoryOutbox(vault);
+  const recoveryCandidate = readCandidates(brain).find(
+    (item) => item.event_ids.includes(postLegacyHandoff.event_id),
+  );
+  assert.ok(recoveryCandidate, 'a decisão 0.66.1 sem sessão causal produz o candidate conhecido');
+  assert.ok(
+    recoveryCandidate.event_ids.includes(legacyPromotion.event_id),
+    'o candidate de recuperação é causado pela promoção 0.66.1 persistida',
+  );
+  assert.equal(
+    recoveryCandidate.event_ids.includes(laterLegacyPromotion.event_id),
+    false,
+    'a promoção projetada mais nova pode ficar fora do candidate por ordenação temporal',
+  );
+  const historicalPrefix = readFileSync(join(brain, 'MEMORY_EVENTS.jsonl'));
+
+  const promotion = decideMemoryCandidate(vault, {
+    action: 'promote',
+    candidateId: recoveryCandidate.candidate_id,
+    eventId: postLegacyHandoff.event_id,
+  });
+  assert.equal(promotion.status, 'promoted');
+  assert.deepEqual(readCandidates(brain), []);
+  assert.ok(
+    readFileSync(join(brain, 'MEMORY_EVENTS.jsonl')).subarray(0, historicalPrefix.length)
+      .equals(historicalPrefix),
+    'a recuperação acrescenta uma decisão sem reinterpretar o prefixo 0.66.1',
+  );
+
+  const decision = readMemoryLedger(vault).events.find((event) => event.event_id === promotion.eventId);
+  assert.ok(
+    decision.supersedes.includes(laterLegacyPromotion.event_id),
+    'a nova decisão cobre a promoção legada que avançou a projeção fora do candidate',
+  );
+  assert.deepEqual(
+    decision.candidate_decision.event_ids,
+    [...recoveryCandidate.event_ids].sort(),
+    'a auditoria da escolha continua descrevendo somente os membros do candidate',
+  );
+  const ledgerAfterPromotion = readFileSync(join(brain, 'MEMORY_EVENTS.jsonl'));
+  const promotionRetry = decideMemoryCandidate(vault, {
+    action: 'promote',
+    candidateId: recoveryCandidate.candidate_id,
+    eventId: postLegacyHandoff.event_id,
+  });
+  assert.equal(promotionRetry.alreadyApplied, true);
+  assert.deepEqual(
+    readFileSync(join(brain, 'MEMORY_EVENTS.jsonl')),
+    ledgerAfterPromotion,
+    'retry da recuperação temporal não duplica a decisão',
+  );
+  const baseInstant = Date.parse(decision.observed_at) + 1_000;
+  const transcriptEvents = readFileSync(transcript, 'utf8').trim().split('\n').map(JSON.parse);
+  const secondTurnId = 'wk-fixture-example-turn-two';
+  transcriptEvents.push(
+    {
+      type: 'event_msg',
+      payload: { type: 'task_started', turn_id: secondTurnId },
+    },
+    {
+      type: 'event_msg',
+      payload: {
+        type: 'user_message', turn_id: secondTurnId,
+        message: '[wk-fixture] second artificial lifecycle request.',
+      },
+    },
+    {
+      type: 'event_msg',
+      payload: {
+        type: 'agent_message', turn_id: secondTurnId,
+        message: '[wk-fixture] second artificial lifecycle response.',
+      },
+    },
+  );
+  transcriptEvents.forEach((event, index) => {
+    event.timestamp = new Date(baseInstant + (index * 1_000)).toISOString();
+  });
+  writeFileSync(transcript, `${transcriptEvents.map(JSON.stringify).join('\n')}\n`);
+
+  const input = {
+    ...stopInput(project, transcript), turn_id: secondTurnId, turn_sequence: 2,
+  };
+  const stop = runPublicHook('session-stop', { project, vault, input });
+  assert.equal(stop.status, 0, stop.stderr);
+  assert.equal(JSON.parse(stop.stdout || '{}').systemMessage, undefined);
+  assert.deepEqual(readCandidates(brain), []);
+  const ledgerAfterStop = readFileSync(join(brain, 'MEMORY_EVENTS.jsonl'));
+  const eventsAfterStop = readMemoryLedger(vault).events;
+  const latest = eventsAfterStop.find((event) => (
+    event.memory_key === 'handoff.latest' && event.source_turn_id === secondTurnId
+  ));
+  assert.ok(latest);
+  assert.equal(latest.canonical_session_id, SYNTHETIC_MEMORY.sessionId);
+  assert.equal(latest.activation_id, SYNTHETIC_MEMORY.activationOne);
+
+  const stable = {
+    shared: readFileSync(join(brain, 'SHARED_MEMORY.md')),
+    registry: readFileSync(join(brain, 'SESSION_REGISTRY.json')),
+    note: readFileSync(sessionPath),
+  };
+  const repeated = runPublicHook('session-stop', { project, vault, input });
+  assert.equal(repeated.status, 0, repeated.stderr);
+  assert.deepEqual(readFileSync(join(brain, 'MEMORY_EVENTS.jsonl')), ledgerAfterStop);
+  assert.deepEqual(readFileSync(join(brain, 'SHARED_MEMORY.md')), stable.shared);
+  assert.deepEqual(readFileSync(join(brain, 'SESSION_REGISTRY.json')), stable.registry);
+  assert.deepEqual(readFileSync(sessionPath), stable.note);
 });
 
 test('[req:MEM-STOP-7] synthetic busy projector preserves active session and durable outbox', () => {


### PR DESCRIPTION
## Resumo

- preserva valores JSON tipados e identidade causal ao promover um candidato de memória;
- adiciona uma ponte de compatibilidade estritamente guardada para a forma legada emitida pela 0.66.1;
- impede que linhagem divergente, decisão moderna, ancestralidade incompleta ou inversão causal inválida sejam publicadas;
- mantém retries e Stops duplicados idempotentes;
- atualiza a documentação PT-BR/EN e prepara a versão 0.66.2.

## Causa raiz

A promoção explícita legada podia conservar o valor selecionado sem carregar toda a identidade causal. Quando a ordem física do ledger e a ordem temporal projetada divergiam, uma promoção posterior válida podia encontrar a projeção atual fora do conjunto candidato e falhar antes de restabelecer a continuidade.

## Impacto

A recuperação permanece append-only e fail-closed. Somente o formato legado exato e auditável recebe a ponte temporal; eventos modernos ou causalmente incompatíveis continuam bloqueados antes do append.

## Validação

- suíte integral: 1149/1149;
- testes focados de memória e lifecycle: 43/43;
- seis sensores verdes em `verify` e `verify --deep`;
- verificação independente aprovada para `MEM-CUR-2`;
- `doctor`, `memory status --gate`, `validate-memory`, `sync-defs --check` e `git diff --check` verdes;
- varredura do diff sem dados privados, caminhos locais, identificadores reais ou segredos.

Closes #20