### PR TITLE
fix: reconcile deferred memory replay (0.66.3)

### DIFF
--- a/.agents/skills/example-skill/.wendkeep-meta.json
+++ b/.agents/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.2",
+  "wendkeepVersion": "0.66.3",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.agents/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.agents/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.2",
+  "wendkeepVersion": "0.66.3",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.agents/skills/wk-debugging/.wendkeep-meta.json
+++ b/.agents/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.2",
+  "wendkeepVersion": "0.66.3",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.agents/skills/wk-planning/.wendkeep-meta.json
+++ b/.agents/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.2",
+  "wendkeepVersion": "0.66.3",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.agents/skills/wk-tdd/.wendkeep-meta.json
+++ b/.agents/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.2",
+  "wendkeepVersion": "0.66.3",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.agents/skills/wk-verify/.wendkeep-meta.json
+++ b/.agents/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.2",
+  "wendkeepVersion": "0.66.3",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.agents/skills/wk-workflow/.wendkeep-meta.json
+++ b/.agents/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.2",
+  "wendkeepVersion": "0.66.3",
   "sourceHash": "c3299e94ce34103fb599744eabec7aec581aefc6fd7c6b959e0350293ee5d8bf"
 }

--- a/.claude/skills/example-skill/.wendkeep-meta.json
+++ b/.claude/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.2",
+  "wendkeepVersion": "0.66.3",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.claude/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.claude/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.2",
+  "wendkeepVersion": "0.66.3",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.claude/skills/wk-debugging/.wendkeep-meta.json
+++ b/.claude/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.2",
+  "wendkeepVersion": "0.66.3",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.claude/skills/wk-planning/.wendkeep-meta.json
+++ b/.claude/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.2",
+  "wendkeepVersion": "0.66.3",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.claude/skills/wk-tdd/.wendkeep-meta.json
+++ b/.claude/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.2",
+  "wendkeepVersion": "0.66.3",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.claude/skills/wk-verify/.wendkeep-meta.json
+++ b/.claude/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.2",
+  "wendkeepVersion": "0.66.3",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.claude/skills/wk-workflow/.wendkeep-meta.json
+++ b/.claude/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.2",
+  "wendkeepVersion": "0.66.3",
   "sourceHash": "c3299e94ce34103fb599744eabec7aec581aefc6fd7c6b959e0350293ee5d8bf"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- wendkeep:skills:start -->
-<!-- wendkeep-version: 0.66.2; skills-sha256: 36ebe0728fe02c48230802722405c3179cb460f289429505e341db582542b82d -->
+<!-- wendkeep-version: 0.66.3; skills-sha256: 36ebe0728fe02c48230802722405c3179cb460f289429505e341db582542b82d -->
 ## wendkeep — Keep Core & operating profiles
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. **Keep Core is always active**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.66.3] — 2026-07-30
+
+### Fixed
+
+- **O replay reavalia candidates transitórios contra a fonte moderna final.** Um Stop da mesma
+  sessão/activation/epoch e turno maior agora avança depois que a correção causal já presente se
+  torna ativa; turno menor fica superseded e divergências reais continuam para curadoria.
+- **`memory repair` migra o checkpoint antigo somente com prova e CAS.** O repair compara a
+  semântica anterior e a atual, faz backup, atualiza attempt e espelho e registra auditoria sem
+  reordenar, reescrever ou acrescentar evento ao ledger. Prova incompleta continua bloqueada. A
+  0.66.2 não deve ser publicada no npm; publique e instale a 0.66.3.
+
 ## [0.66.2] — 2026-07-29
 
 ### Fixed

--- a/README.en.md
+++ b/README.en.md
@@ -298,11 +298,13 @@ explicit, durable curation: `memory promote <id> --event <event-id>` selects one
 candidate, while `memory reject <id>` keeps the current value. The decision is idempotent, and a
 new promotion accepts a later Stop from the same session/activation without recreating a conflict.
 A promotion written by 0.66.1 remains historical: if the next Stop forms a new candidate, update
-the package and explicitly promote the current event once; repair/reconcile do not choose causal
-lineage. If physical order and `observed_at` leave another projected 0.66.1 promotion outside the
-candidate, the command adds it to `supersedes` only after proving the same lineage, a later turn,
-and the temporal inversion; a modern or unrelated source fails before appending bytes. Decisions
-survive repair/replay; `blocked_by_core` cannot override CORE. Doctor only
+to 0.66.3 and run `memory repair`. During replay, a transient candidate is re-evaluated against the
+final modern source: the same session/activation/epoch and a higher turn advances; a lower turn is
+superseded. Repair migrates the checkpoint and mirror only when it proves the exact previous
+replay, attempt identity, and absence of a real conflict; it creates a backup and audit without
+appending or rewriting events. Ambiguity stays queued for explicit curation. Do not publish or
+install 0.66.2; use 0.66.3. Decisions survive repair/replay;
+`blocked_by_core` cannot override CORE. Doctor only
 diagnoses. See [memory and curation](docs/en/commands/memory.md).
 
 Session notes use one live `## Agentes, tokens e custos` snapshot. Main-agent and subagent hooks recompose it atomically, with costs, token dimensions, reasoning tokens and effort per model/source. Every hook that rewrites a session note takes a per-file lock and writes through a temp file + rename, so the `SubagentStop` fan-out (one hook run per subagent) can never leave a note half-written; a note whose frontmatter reads back damaged is left untouched rather than patched.

--- a/README.md
+++ b/README.md
@@ -294,11 +294,13 @@ exigem curadoria explícita e durável: `memory promote <id> --event <event-id>`
 eventos do candidate; `memory reject <id>` mantém o valor atual. A decisão é idempotente, e uma
 promoção nova aceita um Stop posterior da mesma sessão/activation sem recriar conflito. Uma
 promoção gravada pela 0.66.1 permanece histórica: se o próximo Stop formar novo candidate,
-atualize o pacote e promova explicitamente o evento atual uma vez; repair/reconcile não escolhem
-causalidade. Se a ordem física e `observed_at` deixarem outra promoção 0.66.1 projetada fora do
-candidate, o comando só a inclui em `supersedes` após provar a mesma linhagem, turno maior e a
-inversão temporal; fonte moderna ou alheia falha antes de anexar bytes. Decisões sobrevivem a
-repair/replay; `blocked_by_core` não pode sobrescrever CORE.
+atualize para a 0.66.3 e rode `memory repair`. Durante o replay, um candidate transitório é
+reavaliado contra a fonte moderna final: mesma sessão/activation/epoch e turno maior avança;
+turno menor fica superseded. O repair só migra checkpoint e espelho quando prova exatamente o
+replay anterior, a identidade do attempt e a ausência de conflito real; faz backup, registra audit
+e não acrescenta nem reescreve eventos. Ambiguidade continua na fila para curadoria explícita.
+Não publique nem instale a 0.66.2; use a 0.66.3. Decisões sobrevivem a repair/replay;
+`blocked_by_core` não pode sobrescrever CORE.
 O doctor apenas diagnostica. Veja [memória e curadoria](docs/pt-BR/commands/memory.md).
 
 As notas de sessão usam um único snapshot vivo `## Agentes, tokens e custos`. Os hooks do agente principal e dos subagents recompõem o bloco atomicamente, incluindo custo, dimensões de tokens, reasoning e effort por modelo/origem.

--- a/docs/en/commands/memory.md
+++ b/docs/en/commands/memory.md
@@ -74,11 +74,11 @@ npx wendkeep validate-memory --vault <v2-vault>
   the already validated JSON value without string coercion and copies the selected event's
   `canonical_session_id`, activation/epoch, `source_turn_id`, and `turn_sequence`. A later Stop
   from the same session/activation therefore advances the value instead of opening another candidate.
-  When physical append order and `observed_at` leave a projected 0.66.1 promotion outside the
-  candidate, it is added to `supersedes` only if it has the exact legacy shape, shares a candidate
-  ancestor, and the selected event proves the same session/activation/epoch, a later turn, and the
-  temporal inversion. `candidate_decision.event_ids` remains exactly the choice shown to the
-  operator; a modern source, different lineage, or incomplete proof fails before appending an event.
+  During replay, a transient candidate is re-evaluated against the final modern source. The same
+  session/activation/epoch and a higher turn applies the Stop; a lower turn is superseded. A
+  different, incomplete, or ambiguous identity keeps the candidate queued for curation. `memory
+  repair` compares the old and current replay and migrates checkpoint+mirror only with exact
+  identity, backup, audit, and CAS; it does not reorder, rewrite, or append a ledger event.
 - `validate-memory <CORE.md>` checks the 25-line cap, required sections, and secrets.
 - `validate-memory --vault` requires a complete v2 bundle and is not the legacy-vault gate.
 
@@ -116,9 +116,10 @@ of a global projection that has already advanced with concurrent events.
 - `promote` reports that `--event` is required: inspect the candidate `event_ids`, compare their
   provenance/value, and name the winner explicitly. An ID outside the candidate fails without
   mutating the ledger or projections.
-- A promotion made by 0.66.1 followed by a new candidate: update to 0.66.2 or newer, inspect the
-  provenance, and explicitly promote the current event once. The old ledger is not reinterpreted;
-  `memory repair` and `memory reconcile` do not replace that human choice.
+- A promotion made by 0.66.1 followed by a transient candidate: update to 0.66.3, preserve a backup,
+  and run `memory repair`. Do not publish or install 0.66.2. Repair migrates the checkpoint only
+  when the old replay, attempt identity, and new event match exactly; a real conflict stays blocked
+  for a human `promote`/`reject` choice.
 - `promote` says that the candidate no longer matches the causal projection: no event was appended.
   Run `memory status`, inspect the current candidate again, and do not force a different lineage.
 - Missing `event_cursor` or mismatched v2 hash: preserve the bundle and assess `memory repair`.

--- a/docs/pt-BR/commands/memory.md
+++ b/docs/pt-BR/commands/memory.md
@@ -70,12 +70,12 @@ npx wendkeep validate-memory --vault <cofre-v2>
   e espelho; o JSON retorna `checkpointRefreshed`, e um attempt concorrente mais novo não é tocado.
   A decisão conserva, sem coerção para string, o valor JSON já validado e copia do evento escolhido
   `canonical_session_id`, activation/epoch, `source_turn_id` e `turn_sequence`. Por isso, um Stop
-  posterior da mesma sessão/activation avança o valor em vez de abrir outro candidate. Quando
-  append físico e `observed_at` deixam uma promoção 0.66.1 projetada fora do candidate, ela só é
-  acrescentada a `supersedes` se tiver a forma legada exata, compartilhar ancestral no candidate e
-  o evento escolhido provar a mesma sessão/activation/epoch, turno maior e a inversão temporal.
-  `candidate_decision.event_ids` continua sendo exatamente a escolha mostrada ao operador; fonte
-  moderna, outra linhagem ou prova incompleta falha antes de anexar um evento.
+  posterior da mesma sessão/activation avança o valor em vez de abrir outro candidate. Durante o
+  replay, um candidate transitório é reavaliado contra a fonte moderna final. Mesma
+  sessão/activation/epoch e turno maior aplica o Stop; turno menor fica superseded. Identidade
+  divergente, incompleta ou ambígua mantém o candidate para curadoria. `memory repair` compara o
+  replay anterior e o atual e só migra checkpoint+espelho com identidade exata, backup, audit e
+  CAS; ele não reordena, reescreve nem acrescenta evento ao ledger.
 - `validate-memory <CORE.md>` valida cap de 25 linhas, seções e segredos.
 - `validate-memory --vault` exige bundle v2 completo; não é o gate correto para vault legado.
 
@@ -112,9 +112,10 @@ prefixo válido de uma projeção global que já avançou com eventos concorrent
 - `promote` informa que `--event` é obrigatório: leia os `event_ids` do candidate, compare a
   proveniência/valor e indique explicitamente o vencedor. ID que não pertence ao candidate falha
   sem mutar ledger ou projeções.
-- Promoção feita pela 0.66.1 seguida de novo candidate: atualize para 0.66.2 ou superior,
-  confira a proveniência e promova explicitamente o evento atual uma vez. O ledger antigo não é
-  reinterpretado; `memory repair` e `memory reconcile` não substituem essa escolha humana.
+- Promoção feita pela 0.66.1 seguida de candidate transitório: atualize para a 0.66.3, preserve um
+  backup e rode `memory repair`. Não publique nem instale a 0.66.2. O repair só migra o checkpoint
+  quando o replay anterior, a identidade do attempt e o evento novo coincidem exatamente; conflito
+  real continua bloqueado para escolha humana com `promote`/`reject`.
 - `promote` informa que o candidate não corresponde mais à projeção causal: nenhum evento foi
   anexado. Rode `memory status`, releia o candidate atual e não force uma linhagem diferente.
 - `event_cursor` ausente ou hash divergente em v2: preserve o bundle e avalie `memory repair`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.66.2",
+  "version": "0.66.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.66.2",
+      "version": "0.66.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.66.2",
+  "version": "0.66.3",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [

--- a/packages/vault/src/memory-store.mjs
+++ b/packages/vault/src/memory-store.mjs
@@ -344,6 +344,22 @@ function sameCausalActivation(left, right) {
     && left.activation_id === right?.activation_id;
 }
 
+function hasCompleteCausalIdentity(event) {
+  return Boolean(event?.canonical_session_id)
+    && Boolean(event?.activation_id)
+    && Boolean(event?.source_turn_id)
+    && Number.isInteger(event?.activation_epoch)
+    && Number.isInteger(event?.turn_sequence);
+}
+
+function sameCompleteCausalLineage(left, right) {
+  return hasCompleteCausalIdentity(left)
+    && hasCompleteCausalIdentity(right)
+    && left.canonical_session_id === right.canonical_session_id
+    && left.activation_id === right.activation_id
+    && left.activation_epoch === right.activation_epoch;
+}
+
 function comparable(left, right) {
   if (sameCausalActivation(left, right)) return true;
   const leftSupersedes = left.supersedes_event_id || left.supersedes;
@@ -447,7 +463,9 @@ function isCausallyOlder(event, current) {
  * Pure deterministic reducer. It pre-detects incomparable scalar siblings so replay order
  * never turns one concurrent writer into an accidental winner.
  */
-export function reduceMemoryEvents(inputEvents = [], { coreInvariants = new Map() } = {}) {
+export function reduceMemoryEvents(inputEvents = [], {
+  coreInvariants = new Map(), resolveDeferredAsserts = true,
+} = {}) {
   const protectedValues = coreInvariants instanceof Map
     ? coreInvariants
     : new Map(Object.entries(coreInvariants || {}));
@@ -495,6 +513,8 @@ export function reduceMemoryEvents(inputEvents = [], { coreInvariants = new Map(
   const records = new Map();
   const tombstones = new Map();
   const candidates = [];
+  const pendingAssertConflicts = [];
+  const resolvedCandidateIds = new Set();
   const emittedGroups = new Set();
   const appliedEventIds = [];
   const superseded = [];
@@ -543,7 +563,9 @@ export function reduceMemoryEvents(inputEvents = [], { coreInvariants = new Map(
           appliedEventIds.push(item.event_id);
           continue;
         }
-        candidates.push(conflictCandidate(item.memory_key, [currentEventFromRecord(current), item]));
+        const candidate = conflictCandidate(item.memory_key, [currentEventFromRecord(current), item]);
+        candidates.push(candidate);
+        pendingAssertConflicts.push({ candidate, event: item });
         continue;
       }
       if (!current) {
@@ -616,6 +638,46 @@ export function reduceMemoryEvents(inputEvents = [], { coreInvariants = new Map(
     appliedEventIds.push(item.event_id);
   }
 
+  if (resolveDeferredAsserts) {
+    // A physically late assert can sort before a corrective promotion because effective time
+    // precedes CLI decision time. Revisit only scalar assert conflicts left without an explicit
+    // decision, against the final complete causal source; the ledger and global ordering stay put.
+    const deferredAsserts = pendingAssertConflicts
+      .filter((pending) => !candidateDecisions.has(pending.candidate.candidate_id))
+      .sort((left, right) => String(left.event.memory_key).localeCompare(String(right.event.memory_key))
+        || String(left.event.canonical_session_id || '').localeCompare(String(right.event.canonical_session_id || ''))
+        || String(left.event.activation_id || '').localeCompare(String(right.event.activation_id || ''))
+        || Number(left.event.activation_epoch ?? -1) - Number(right.event.activation_epoch ?? -1)
+        || Number(left.event.turn_sequence ?? -1) - Number(right.event.turn_sequence ?? -1)
+        || eventOrder(left.event, right.event));
+    let advanced = true;
+    while (advanced) {
+      advanced = false;
+      for (const pending of deferredAsserts) {
+        if (resolvedCandidateIds.has(pending.candidate.candidate_id)) continue;
+        const current = records.get(pending.event.memory_key);
+        const currentSource = current?.source;
+        if (!sameCompleteCausalLineage(pending.event, currentSource)) continue;
+        if (pending.event.turn_sequence > currentSource.turn_sequence) {
+          records.set(pending.event.memory_key, {
+            value: pending.event.value,
+            revision: current.revision + 1,
+            source: pending.event,
+          });
+          tombstones.delete(pending.event.memory_key);
+          superseded.push({ event_id: currentSource.event_id, by_event_id: pending.event.event_id });
+          revision += 1;
+          appliedEventIds.push(pending.event.event_id);
+          resolvedCandidateIds.add(pending.candidate.candidate_id);
+          advanced = true;
+        } else if (pending.event.turn_sequence < currentSource.turn_sequence) {
+          superseded.push({ event_id: pending.event.event_id, by_event_id: currentSource.event_id });
+          resolvedCandidateIds.add(pending.candidate.candidate_id);
+        }
+      }
+    }
+  }
+
   const stateEntries = [...records].map(([key, record]) => [key, record.value]);
   const recordEntries = [...records].map(([key, record]) => [key, record]);
   const tombstoneEntries = [...tombstones];
@@ -623,7 +685,8 @@ export function reduceMemoryEvents(inputEvents = [], { coreInvariants = new Map(
   const recordObject = sortedObject(recordEntries);
   const tombstoneObject = sortedObject(tombstoneEntries);
   const unresolvedCandidates = candidates
-    .filter((item) => !candidateDecisions.has(item.candidate_id));
+    .filter((item) => !candidateDecisions.has(item.candidate_id)
+      && !resolvedCandidateIds.has(item.candidate_id));
   unresolvedCandidates.sort((left, right) => left.candidate_id.localeCompare(right.candidate_id));
   superseded.sort((left, right) => left.event_id.localeCompare(right.event_id));
   const activeEvents = Object.entries(recordObject).map(([memoryKey, record]) => ({
@@ -655,8 +718,12 @@ export function reduceMemoryEvents(inputEvents = [], { coreInvariants = new Map(
  * `eventCursor` is the reducer's deterministic causal cursor; `ledgerCursor` is the
  * physical prefix boundary used by durable checkpoints.
  */
-export function deriveMemoryProjection(vaultBase, inputEvents = []) {
-  const reduced = reduceMemoryEvents(inputEvents, { coreInvariants: readCoreInvariants(vaultBase) });
+export function deriveMemoryProjection(vaultBase, inputEvents = [], {
+  resolveDeferredAsserts = true,
+} = {}) {
+  const reduced = reduceMemoryEvents(inputEvents, {
+    coreInvariants: readCoreInvariants(vaultBase), resolveDeferredAsserts,
+  });
   const ledgerCursor = inputEvents.at(-1)?.event_id || 'none';
   const checkpoint = {
     revision: reduced.revision,

--- a/src/memory.mjs
+++ b/src/memory.mjs
@@ -1013,6 +1013,67 @@ function historicalAssertOnlyCheckpoint(vault, attempt, authority, checkpoint) {
   return currentPrefix.checkpoint;
 }
 
+function deferredAssertReplayCheckpointMigration(
+  sessionId, entry, authority, legacyReplay, fullReplay,
+) {
+  const attempt = entry?.last_memory_attempt;
+  const checkpoint = attempt?.checkpoint;
+  if (attempt?.memory_mode !== 'v2' || attempt?.state !== 'projected'
+      || attempt?.disposition !== 'applied' || !checkpointShape(checkpoint)) return null;
+  if (!Object.prototype.hasOwnProperty.call(entry, 'memory_checkpoint')
+      || !sameCheckpoint(entry.memory_checkpoint, checkpoint)
+      || !sameCheckpoint(checkpoint, legacyReplay.checkpoint)
+      || sameCheckpoint(checkpoint, fullReplay.checkpoint)) return null;
+
+  const requiredEventIds = Array.isArray(attempt.event_ids) ? [...attempt.event_ids] : [];
+  if (!requiredEventIds.length || new Set(requiredEventIds).size !== requiredEventIds.length) return null;
+  const current = fullReplay.records?.['handoff.latest']?.source;
+  if (!current?.event_id || !requiredEventIds.includes(current.event_id)) return null;
+  const relevantLegacyCandidate = legacyReplay.candidates.some(
+    (candidate) => candidate.memory_key === 'handoff.latest'
+      && candidate.event_ids.includes(current.event_id),
+  );
+  const relevantCandidateStillReal = fullReplay.candidates.some(
+    (candidate) => candidate.memory_key === 'handoff.latest',
+  );
+  if (!relevantLegacyCandidate || relevantCandidateStillReal) return null;
+
+  const currentIdentity = {
+    canonical_session_id: current.canonical_session_id,
+    activation_id: current.activation_id,
+    activation_epoch: current.activation_epoch,
+    source_turn_id: current.source_turn_id,
+    turn_sequence: current.turn_sequence,
+  };
+  if (currentIdentity.canonical_session_id !== sessionId
+      || attempt.canonical_session_id !== currentIdentity.canonical_session_id
+      || attempt.activation_id !== currentIdentity.activation_id
+      || attempt.activation_epoch !== currentIdentity.activation_epoch
+      || attempt.turn_id !== currentIdentity.source_turn_id
+      || attempt.turn_sequence !== currentIdentity.turn_sequence) return null;
+
+  const newerAttemptEvent = authority.ledgerEvents.some((event) => (
+    event.canonical_session_id === currentIdentity.canonical_session_id
+      && event.activation_id === currentIdentity.activation_id
+      && event.activation_epoch === currentIdentity.activation_epoch
+      && Number.isInteger(event.turn_sequence)
+      && event.turn_sequence > currentIdentity.turn_sequence
+  ));
+  if (newerAttemptEvent) return null;
+
+  const proof = validateSuccessorProof({ bySessionId: sessionId }, attempt, authority);
+  return {
+    sessionId,
+    expectedFingerprint: attemptFingerprint(attempt),
+    expectedMemoryCheckpointFingerprint: memoryCheckpointFingerprint(entry),
+    originalCheckpoint: cloneJson(checkpoint),
+    checkpoint: cloneJson(fullReplay.checkpoint),
+    proof,
+    migrationType: 'deferred_assert_replay_migrated',
+    eventIds: requiredEventIds,
+  };
+}
+
 function legacyCheckpointMigration(vault, sessionId, entry, authority, fullReplay) {
   const attempt = entry?.last_memory_attempt;
   const checkpoint = attempt?.checkpoint;
@@ -1042,6 +1103,8 @@ function legacyCheckpointMigration(vault, sessionId, entry, authority, fullRepla
     originalCheckpoint: cloneJson(checkpoint),
     checkpoint: cloneJson(nextCheckpoint),
     proof,
+    migrationType: 'legacy_causal_checkpoint_migrated',
+    eventIds: requiredEventIds,
   };
 }
 
@@ -1053,11 +1116,14 @@ export function migrateLegacyMemoryCheckpoints(vault, {
     const authority = readMemoryAuthority(vault);
     assertAuthorityMatches(expectedAuthority, authority);
     const inspected = readSessionRegistry(vault);
+    const legacyReplay = deriveMemoryProjection(vault, authority.ledgerEvents, {
+      resolveDeferredAsserts: false,
+    });
     const fullReplay = deriveMemoryProjection(vault, authority.ledgerEvents);
     const plans = Object.entries(inspected.sessions || {})
-      .map(([sessionId, entry]) => legacyCheckpointMigration(
-        vault, sessionId, entry, authority, fullReplay,
-      ))
+      .map(([sessionId, entry]) => deferredAssertReplayCheckpointMigration(
+        sessionId, entry, authority, legacyReplay, fullReplay,
+      ) || legacyCheckpointMigration(vault, sessionId, entry, authority, fullReplay))
       .filter(Boolean);
     assertAuthorityMatches(expectedAuthority, readMemoryAuthority(vault));
     if (!plans.length) return {
@@ -1096,14 +1162,20 @@ export function migrateLegacyMemoryCheckpoints(vault, {
 
         for (const plan of plans) {
           const entry = registry.sessions[plan.sessionId];
-          const reconciliationId = `memcp-${hash(`${plan.sessionId}\0${plan.expectedFingerprint}\0${plan.expectedMemoryCheckpointFingerprint}\0${canonicalMemoryJson(plan.checkpoint)}`).slice(0, 20)}`;
+          const reconciliationSeed = plan.migrationType === 'legacy_causal_checkpoint_migrated'
+            ? `${plan.sessionId}\0${plan.expectedFingerprint}\0${plan.expectedMemoryCheckpointFingerprint}\0${canonicalMemoryJson(plan.checkpoint)}`
+            : `${plan.migrationType}\0${plan.sessionId}\0${plan.expectedFingerprint}\0${plan.expectedMemoryCheckpointFingerprint}\0${canonicalMemoryJson(plan.checkpoint)}`;
+          const reconciliationId = `memcp-${hash(reconciliationSeed).slice(0, 20)}`;
           entry.memory_reconciliations = [
             ...(Array.isArray(entry.memory_reconciliations) ? entry.memory_reconciliations : []),
             {
               v: 1,
               reconciliation_id: reconciliationId,
-              type: 'legacy_causal_checkpoint_migrated',
+              type: plan.migrationType,
               reconciled_at: now,
+              ...(plan.migrationType === 'deferred_assert_replay_migrated'
+                ? { event_ids: [...plan.eventIds] }
+                : {}),
               causal_proof: cloneJson(plan.proof),
               original_checkpoint: cloneJson(plan.originalCheckpoint),
               checkpoint: cloneJson(plan.checkpoint),

--- a/tests/memory-cli.test.mjs
+++ b/tests/memory-cli.test.mjs
@@ -156,6 +156,69 @@ function seedOutOfOrderPromotionBridge(vault, {
   return { candidate, currentPromotion, selected };
 }
 
+function deferredAssertReplayCheckpointFixture({
+  divergentMirror = false,
+  wrongIdentity = false,
+  wrongEventIds = false,
+  candidateStillReal = false,
+  newerAttempt = false,
+} = {}) {
+  const vault = fixture();
+  const brain = join(vault, '.brain');
+  const { currentPromotion, selected } = seedOutOfOrderPromotionBridge(vault, {
+    currentOverrides: {
+      canonical_session_id: 'bridge-session',
+      source_turn_id: 'bridge-turn-prior',
+    },
+    ...(candidateStillReal ? {
+      selectedOverrides: {
+        canonical_session_id: 'bridge-other-session',
+        activation_id: 'bridge-other-activation',
+        source_turn_id: 'bridge-other-turn',
+      },
+    } : {}),
+  });
+  const ledgerPath = join(brain, 'MEMORY_EVENTS.jsonl');
+  const events = readFileSync(ledgerPath, 'utf8').trim().split('\n').map(JSON.parse);
+  if (newerAttempt) {
+    events.push({
+      ...selected,
+      event_id: 'mem-bridge-newer-attempt',
+      memory_key: 'git.local-head',
+      value: { commit: 'newer' },
+      turn_sequence: selected.turn_sequence + 1,
+      source_turn_id: 'bridge-turn-newer',
+      observed_at: '2026-07-26T12:06:00.000Z',
+    });
+  }
+  writeMemoryProjection(vault, events);
+  const legacyReplay = deriveMemoryProjection(vault, events, { resolveDeferredAsserts: false });
+  const fullReplay = deriveMemoryProjection(vault, events);
+  const legacyCheckpoint = legacyReplay.checkpoint;
+  const attempt = projectedAttempt('bridge-session', selected, legacyCheckpoint, {
+    ...(wrongIdentity ? { activation_id: 'bridge-wrong-activation' } : {}),
+    ...(wrongEventIds ? { event_ids: ['mem-bridge-not-in-ledger'] } : {}),
+  });
+  const mirror = divergentMirror
+    ? {
+      ...legacyCheckpoint,
+      state_hash: `${legacyCheckpoint.state_hash.slice(0, -1)}${legacyCheckpoint.state_hash.endsWith('0') ? '1' : '0'}`,
+    }
+    : legacyCheckpoint;
+  const registryPath = join(brain, 'SESSION_REGISTRY.json');
+  writeFileSync(registryPath, `${JSON.stringify({ version: 2, sessions: {
+    'bridge-session': {
+      memory_status: 'projected',
+      memory_checkpoint: mirror,
+      last_memory_attempt: attempt,
+    },
+  } }, null, 2)}\n`);
+  return {
+    vault, brain, registryPath, events, currentPromotion, selected,
+    legacyReplay, fullReplay, legacyCheckpoint,
+  };
+}
+
 function checkpoint(reduced) {
   return {
     revision: reduced.revision,
@@ -264,7 +327,9 @@ function historicalLegacyCheckpointFixture({
   };
 }
 
-function startCheckpointMirrorRace({ vault, registryPath: registryFile, checkpointValue }) {
+function startCheckpointMirrorRace({
+  vault, registryPath: registryFile, checkpointValue, sessionId = 'current-session',
+}) {
   const safetyUrl = new URL('../packages/vault/src/vault-path-safety.mjs', import.meta.url).href;
   const registryUrl = new URL('../hooks/obsidian-common.mjs', import.meta.url).href;
   const code = [
@@ -281,7 +346,7 @@ function startCheckpointMirrorRace({ vault, registryPath: registryFile, checkpoi
     '  }',
     '  Atomics.wait(signal, 0, 0, 250);',
     '  const registry = readSessionRegistry(process.env.WK_RACE_VAULT);',
-    "  registry.sessions['current-session'].memory_checkpoint = JSON.parse(process.env.WK_RACE_CHECKPOINT);",
+    '  registry.sessions[process.env.WK_RACE_SESSION].memory_checkpoint = JSON.parse(process.env.WK_RACE_CHECKPOINT);',
     '  writeSessionRegistry(process.env.WK_RACE_VAULT, registry);',
     "  process.stdout.write('mutated\\n');",
     '}, { timeoutMs: 2000 });',
@@ -293,6 +358,7 @@ function startCheckpointMirrorRace({ vault, registryPath: registryFile, checkpoi
       WK_RACE_REGISTRY: registryFile,
       WK_RACE_MEMORY_LOCK: join(vault, '.brain', 'MEMORY.lock'),
       WK_RACE_CHECKPOINT: JSON.stringify(checkpointValue),
+      WK_RACE_SESSION: sessionId,
     },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
@@ -669,15 +735,6 @@ test('[req:MEM-CUR-2] promoção preserva valor JSON e identidade causal do even
 test('[req:MEM-CUR-2] bridge temporal exige todas as provas legadas e causais', async () => {
   const { decideMemoryCandidate } = await import('../src/memory.mjs');
   const scenarios = [
-    {
-      name: 'promoção atual já possui identidade moderna',
-      options: {
-        currentOverrides: {
-          canonical_session_id: 'bridge-session',
-          source_turn_id: 'bridge-turn-prior',
-        },
-      },
-    },
     {
       name: 'evento escolhido pertence a outra linhagem causal',
       options: {
@@ -1220,6 +1277,117 @@ test('[req:OP-10] memory repair migra checkpoint causal pré-upgrade para bounda
     assert.equal(retry.checkpointMigration.status, 'unchanged');
     assert.equal(readFileSync(registryPath, 'utf8'), registryAfterMigration);
   } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-CUR-2] memory repair migra checkpoint do replay deferred assert com CAS e auditoria', async () => {
+  const {
+    vault, brain, registryPath, events, selected, legacyReplay, fullReplay, legacyCheckpoint,
+  } = deferredAssertReplayCheckpointFixture();
+  const ledgerBefore = readFileSync(join(brain, 'MEMORY_EVENTS.jsonl'));
+  const coreBefore = readFileSync(join(brain, 'CORE.md'));
+  try {
+    assert.ok(
+      legacyReplay.candidates.some((candidate) => candidate.memory_key === 'handoff.latest'
+        && candidate.event_ids.includes(selected.event_id)),
+      JSON.stringify(legacyReplay.candidates),
+    );
+    assert.equal(fullReplay.candidates.length, 0, JSON.stringify(fullReplay.candidates));
+    assert.equal(fullReplay.records['handoff.latest'].source.event_id, selected.event_id);
+    assert.notDeepEqual(legacyReplay.checkpoint, fullReplay.checkpoint);
+
+    const { repairMemory } = await import('../src/memory.mjs');
+    const repaired = repairMemory(vault, { now: '2026-07-30T12:00:00.000Z' });
+    assert.equal(repaired.checkpointMigration.status, 'migrated');
+    assert.equal(repaired.checkpointMigration.migrated, 1);
+    assert.deepEqual(readFileSync(join(brain, 'MEMORY_EVENTS.jsonl')), ledgerBefore);
+    assert.deepEqual(readFileSync(join(brain, 'CORE.md')), coreBefore);
+
+    const expected = deriveMemoryProjection(vault, events).checkpoint;
+    const migrated = JSON.parse(readFileSync(registryPath, 'utf8'))
+      .sessions['bridge-session'];
+    assert.deepEqual(migrated.last_memory_attempt.checkpoint, expected);
+    assert.deepEqual(migrated.memory_checkpoint, expected);
+    assert.equal(migrated.memory_status, 'projected');
+    const audit = migrated.memory_reconciliations.at(-1);
+    assert.equal(audit.type, 'deferred_assert_replay_migrated');
+    assert.deepEqual(audit.original_checkpoint, legacyCheckpoint);
+    assert.deepEqual(audit.checkpoint, expected);
+    assert.deepEqual(audit.event_ids, [selected.event_id]);
+    assert.ok(existsSync(repaired.checkpointMigration.backupPath));
+
+    const registryAfterMigration = readFileSync(registryPath, 'utf8');
+    const retry = repairMemory(vault, { now: '2026-07-30T12:01:00.000Z' });
+    assert.equal(retry.checkpointMigration.status, 'unchanged');
+    assert.equal(readFileSync(registryPath, 'utf8'), registryAfterMigration);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+for (const scenario of [
+  { name: 'checkpoint e mirror divergentes', options: { divergentMirror: true } },
+  { name: 'identidade causal do attempt divergente', options: { wrongIdentity: true } },
+  { name: 'event_ids do attempt divergentes', options: { wrongEventIds: true } },
+  { name: 'candidate do replay ainda real', options: { candidateStillReal: true } },
+  { name: 'attempt causal mais novo no ledger', options: { newerAttempt: true } },
+]) {
+  test(`[req:MEM-CUR-2] memory repair não migra replay deferred assert com ${scenario.name}`, async () => {
+    const {
+      vault, brain, registryPath,
+    } = deferredAssertReplayCheckpointFixture(scenario.options);
+    const paths = [
+      registryPath,
+      join(brain, 'MEMORY_EVENTS.jsonl'),
+      join(brain, 'MEMORY_CANDIDATES.jsonl'),
+      join(brain, 'SHARED_MEMORY.md'),
+      join(brain, 'CORE.md'),
+    ];
+    const before = new Map(paths.map((path) => [path, readFileSync(path)]));
+    try {
+      const { repairMemory } = await import('../src/memory.mjs');
+      const repaired = repairMemory(vault, { now: '2026-07-30T12:02:00.000Z' });
+      assert.equal(repaired.checkpointMigration.status, 'unchanged');
+      assert.equal(repaired.checkpointMigration.backupPath, null);
+      for (const [path, content] of before) assert.deepEqual(readFileSync(path), content, scenario.name);
+      assert.equal(
+        readdirSync(brain).some((name) => name.includes('.checkpoint-migrate-') && name.endsWith('.bak')),
+        false,
+      );
+    } finally { rmSync(vault, { recursive: true, force: true }); }
+  });
+}
+
+test('[req:MEM-CUR-2] migração do replay deferred assert faz CAS antes do backup', async () => {
+  const {
+    vault, brain, registryPath, fullReplay,
+  } = deferredAssertReplayCheckpointFixture();
+  const registryBefore = JSON.parse(readFileSync(registryPath, 'utf8'));
+  const ledgerBefore = readFileSync(join(brain, 'MEMORY_EVENTS.jsonl'));
+  const race = startCheckpointMirrorRace({
+    vault,
+    registryPath,
+    checkpointValue: fullReplay.checkpoint,
+    sessionId: 'bridge-session',
+  });
+  try {
+    await race.ready;
+    const { migrateLegacyMemoryCheckpoints } = await import('../src/memory.mjs');
+    assert.throws(
+      () => migrateLegacyMemoryCheckpoints(vault, { now: '2026-07-30T12:03:00.000Z' }),
+      /CAS perdido: memory_checkpoint/i,
+    );
+    const outcome = await race.closed;
+    assert.equal(outcome.code, 0, outcome.stderr || outcome.stdout);
+
+    registryBefore.sessions['bridge-session'].memory_checkpoint = fullReplay.checkpoint;
+    assert.deepEqual(JSON.parse(readFileSync(registryPath, 'utf8')), registryBefore);
+    assert.deepEqual(readFileSync(join(brain, 'MEMORY_EVENTS.jsonl')), ledgerBefore);
+    assert.equal(
+      readdirSync(brain).some((name) => name.includes('.checkpoint-migrate-') && name.endsWith('.bak')),
+      false,
+    );
+  } finally {
+    await race.closed.catch(() => {});
+    rmSync(vault, { recursive: true, force: true });
+  }
 });
 
 test('[req:MOD-7] memory repair migra checkpoint assert-only pré-0.59 no prefixo histórico exato', async () => {

--- a/tests/memory-hybrid-e2e.test.mjs
+++ b/tests/memory-hybrid-e2e.test.mjs
@@ -12,9 +12,8 @@ import {
   seedSyntheticHybridLifecycle,
 } from './fixtures/synthetic-memory-lifecycle.mjs';
 import {
-  enqueueMemoryEvent, projectMemoryOutbox, readMemoryLedger,
+  deriveMemoryProjection, enqueueMemoryEvent, projectMemoryOutbox, readMemoryLedger,
 } from '../hooks/memory-store.mjs';
-import { decideMemoryCandidate } from '../src/memory.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const BIN = join(ROOT, 'bin', 'wendkeep.mjs');
@@ -51,6 +50,13 @@ function runPublicHook(name, { project, vault, input }) {
     env,
     encoding: 'utf8',
     input: JSON.stringify(input),
+  });
+}
+
+function runCli(args, { project }) {
+  return spawnSync(process.execPath, [BIN, ...args], {
+    cwd: project,
+    encoding: 'utf8',
   });
 }
 
@@ -149,7 +155,7 @@ test('[req:MEM-STOP-7] synthetic Stop projects lifecycle memory and remains idem
   }
 });
 
-test('[req:MEM-CUR-2] recovery after a 0.66.1 promotion accepts the next public Stop', () => {
+test('[req:MEM-CUR-2] public Stop advances after CLI recovery despite physical/temporal inversion', () => {
   const { project, vault, brain, sessionPath, transcript } = seedSyntheticHybridLifecycle();
   const legacyBase = Date.now() - 10_000;
   const selected = {
@@ -267,11 +273,13 @@ test('[req:MEM-CUR-2] recovery after a 0.66.1 promotion accepts the next public 
   );
   const historicalPrefix = readFileSync(join(brain, 'MEMORY_EVENTS.jsonl'));
 
-  const promotion = decideMemoryCandidate(vault, {
-    action: 'promote',
-    candidateId: recoveryCandidate.candidate_id,
-    eventId: postLegacyHandoff.event_id,
-  });
+  const promoted = runCli([
+    'memory', 'promote', recoveryCandidate.candidate_id,
+    '--event', postLegacyHandoff.event_id,
+    '--vault', vault,
+  ], { project });
+  assert.equal(promoted.status, 0, promoted.stderr || promoted.stdout);
+  const promotion = JSON.parse(promoted.stdout);
   assert.equal(promotion.status, 'promoted');
   assert.deepEqual(readCandidates(brain), []);
   assert.ok(
@@ -291,18 +299,24 @@ test('[req:MEM-CUR-2] recovery after a 0.66.1 promotion accepts the next public 
     'a auditoria da escolha continua descrevendo somente os membros do candidate',
   );
   const ledgerAfterPromotion = readFileSync(join(brain, 'MEMORY_EVENTS.jsonl'));
-  const promotionRetry = decideMemoryCandidate(vault, {
-    action: 'promote',
-    candidateId: recoveryCandidate.candidate_id,
-    eventId: postLegacyHandoff.event_id,
-  });
+  const promotionRetryResult = runCli([
+    'memory', 'promote', recoveryCandidate.candidate_id,
+    '--event', postLegacyHandoff.event_id,
+    '--vault', vault,
+  ], { project });
+  assert.equal(
+    promotionRetryResult.status,
+    0,
+    promotionRetryResult.stderr || promotionRetryResult.stdout,
+  );
+  const promotionRetry = JSON.parse(promotionRetryResult.stdout);
   assert.equal(promotionRetry.alreadyApplied, true);
   assert.deepEqual(
     readFileSync(join(brain, 'MEMORY_EVENTS.jsonl')),
     ledgerAfterPromotion,
     'retry da recuperação temporal não duplica a decisão',
   );
-  const baseInstant = Date.parse(decision.observed_at) + 1_000;
+  const stopEffectiveInstant = Date.parse(laterLegacyPromotion.observed_at) - 500;
   const transcriptEvents = readFileSync(transcript, 'utf8').trim().split('\n').map(JSON.parse);
   const secondTurnId = 'wk-fixture-example-turn-two';
   transcriptEvents.push(
@@ -326,7 +340,8 @@ test('[req:MEM-CUR-2] recovery after a 0.66.1 promotion accepts the next public 
     },
   );
   transcriptEvents.forEach((event, index) => {
-    event.timestamp = new Date(baseInstant + (index * 1_000)).toISOString();
+    const distanceFromTail = transcriptEvents.length - index;
+    event.timestamp = new Date(stopEffectiveInstant - (distanceFromTail * 10)).toISOString();
   });
   writeFileSync(transcript, `${transcriptEvents.map(JSON.stringify).join('\n')}\n`);
 
@@ -345,6 +360,49 @@ test('[req:MEM-CUR-2] recovery after a 0.66.1 promotion accepts the next public 
   assert.ok(latest);
   assert.equal(latest.canonical_session_id, SYNTHETIC_MEMORY.sessionId);
   assert.equal(latest.activation_id, SYNTHETIC_MEMORY.activationOne);
+  assert.equal(latest.activation_epoch, 1);
+  assert.equal(latest.turn_sequence, 2);
+  assert.ok(
+    Date.parse(latest.observed_at) < Date.parse(laterLegacyPromotion.observed_at),
+    'o Stop é efetivamente anterior às decisões CLI embora seja anexado fisicamente depois',
+  );
+  assert.ok(
+    eventsAfterStop.findIndex((event) => event.event_id === latest.event_id)
+      > eventsAfterStop.findIndex((event) => event.event_id === decision.event_id),
+    'o Stop foi anexado fisicamente depois da correção CLI',
+  );
+  assert.ok(
+    readFileSync(join(brain, 'MEMORY_EVENTS.jsonl')).subarray(0, historicalPrefix.length)
+      .equals(historicalPrefix),
+    'o Stop preserva byte a byte o prefixo legado auditado',
+  );
+
+  const sharedAfterStop = readFileSync(join(brain, 'SHARED_MEMORY.md'), 'utf8');
+  assert.match(sharedAfterStop, /second artificial lifecycle response/i);
+  assert.doesNotMatch(sharedAfterStop, /prior continuation promoted by 0\.66\.1/i);
+  const registryAfterStop = JSON.parse(readFileSync(join(brain, 'SESSION_REGISTRY.json'), 'utf8'));
+  const sessionAfterStop = registryAfterStop.sessions[SYNTHETIC_MEMORY.sessionId];
+  const expectedCheckpoint = deriveMemoryProjection(vault, eventsAfterStop).checkpoint;
+  assert.equal(sessionAfterStop.memory_status, 'projected');
+  assert.deepEqual(sessionAfterStop.memory_checkpoint, expectedCheckpoint);
+  assert.equal(sessionAfterStop.last_memory_attempt.disposition, 'applied');
+  assert.equal(sessionAfterStop.last_memory_attempt.state, 'projected');
+  assert.deepEqual(
+    sessionAfterStop.last_memory_attempt.checkpoint,
+    sessionAfterStop.memory_checkpoint,
+    'o attempt projetado espelha o checkpoint físico/causal persistido',
+  );
+  assert.equal(readdirSync(join(brain, 'memory-outbox')).length, 0);
+
+  const healthResult = runCli(['memory', 'status', '--gate', '--vault', vault], { project });
+  const health = JSON.parse(healthResult.stdout);
+  assert.ok(
+    health.failures.every((failure) => /^core:/i.test(failure)),
+    'a fixture mínima pode omitir seções curadas, mas não possui falha operacional de memória',
+  );
+  assert.equal(health.metrics.candidates, 0);
+  assert.equal(health.metrics.pendingOutbox, 0);
+  assert.equal(health.metrics.activeConflicts, 0);
 
   const stable = {
     shared: readFileSync(join(brain, 'SHARED_MEMORY.md')),

--- a/tests/memory-store.test.mjs
+++ b/tests/memory-store.test.mjs
@@ -11,6 +11,7 @@ import {
   MemoryEventCollision,
   MemoryLedgerCorruption,
   canonicalMemoryJson,
+  deriveMemoryProjection,
   enqueueMemoryEvent,
   hashMemoryValue,
   projectMemoryOutbox,
@@ -44,6 +45,82 @@ function event(eventId, memoryKey, operation, value, extra = {}) {
     evidence: ['ADR-0107'],
     ...extra,
   };
+}
+
+function deferredAssertReplayFixture({ assertOverrides = {}, correctionOverrides = {} } = {}) {
+  const selected = event('mem-replay-selected', 'handoff.latest', 'assert', 'resumo promovido', {
+    canonical_session_id: 'replay-session',
+    activation_id: 'replay-activation',
+    activation_epoch: 7,
+    turn_sequence: 1,
+    source_turn_id: 'replay-turn-1',
+    observed_at: '2026-07-26T12:01:00.000Z',
+  });
+  const competing = event('mem-replay-competing', 'handoff.latest', 'assert', 'resumo concorrente', {
+    canonical_session_id: 'competing-session',
+    activation_id: 'competing-activation',
+    activation_epoch: 7,
+    turn_sequence: 1,
+    source_turn_id: 'competing-turn-1',
+    observed_at: '2026-07-26T12:02:00.000Z',
+  });
+  const initialCandidate = reduceMemoryEvents([selected, competing]).candidates[0];
+  const legacyPromotion = event(
+    'mem-replay-legacy-promotion', 'handoff.latest', 'replace', selected.value, {
+      canonical_session_id: undefined,
+      activation_id: selected.activation_id,
+      activation_epoch: selected.activation_epoch,
+      turn_sequence: selected.turn_sequence,
+      observed_at: '2026-07-26T12:04:00.000Z',
+      candidate_decision: {
+        candidate_id: initialCandidate.candidate_id,
+        action: 'promote',
+        event_ids: [...initialCandidate.event_ids],
+        selected_event_id: selected.event_id,
+      },
+      supersedes: [...initialCandidate.event_ids],
+    },
+  );
+  const correction = event(
+    'mem-replay-modern-correction', 'handoff.latest', 'replace', selected.value, {
+      canonical_session_id: selected.canonical_session_id,
+      activation_id: selected.activation_id,
+      activation_epoch: selected.activation_epoch,
+      turn_sequence: selected.turn_sequence,
+      source_turn_id: selected.source_turn_id,
+      observed_at: '2026-07-26T12:06:00.000Z',
+      supersedes: [...initialCandidate.event_ids, legacyPromotion.event_id],
+      ...correctionOverrides,
+    },
+  );
+  const deferredAssert = event(
+    'mem-replay-physical-late', 'handoff.latest', 'assert', 'resumo do Stop posterior', {
+      canonical_session_id: selected.canonical_session_id,
+      activation_id: selected.activation_id,
+      activation_epoch: selected.activation_epoch,
+      turn_sequence: 2,
+      source_turn_id: 'replay-turn-2',
+      observed_at: '2026-07-26T12:05:00.000Z',
+      ...assertOverrides,
+    },
+  );
+  return {
+    selected,
+    competing,
+    legacyPromotion,
+    correction,
+    deferredAssert,
+    events: [selected, competing, legacyPromotion, correction, deferredAssert],
+  };
+}
+
+function transientDeferredCandidate(fixture) {
+  return reduceMemoryEvents([
+    fixture.selected,
+    fixture.competing,
+    fixture.legacyPromotion,
+    fixture.deferredAssert,
+  ]).candidates.find((candidate) => candidate.event_ids.includes(fixture.deferredAssert.event_id));
 }
 
 function transientNames(vault) {
@@ -195,6 +272,121 @@ test('[req:MEM-HYB-4] late older handoff from the same activation stays supersed
     event_id: 'mem-handoff-late-old', by_event_id: 'mem-handoff-new',
   }]);
   assert.equal(reduced.candidates.length, 0);
+});
+
+test('[req:MEM-CUR-2] assert fisicamente posterior converge contra a fonte moderna final', () => {
+  const fixture = deferredAssertReplayFixture();
+
+  const forward = reduceMemoryEvents(fixture.events);
+  const reverse = reduceMemoryEvents([...fixture.events].reverse());
+
+  assert.deepEqual(reverse, forward, 'a ordem de chegada não altera o fixpoint causal');
+  assert.equal(forward.state['handoff.latest'], fixture.deferredAssert.value);
+  assert.equal(forward.records['handoff.latest'].source.event_id, fixture.deferredAssert.event_id);
+  assert.equal(forward.records['handoff.latest'].revision, 4);
+  assert.equal(forward.revision, 4);
+  assert.equal(forward.candidates.length, 0, JSON.stringify(forward.candidates));
+  assert.ok(forward.appliedEventIds.includes(fixture.deferredAssert.event_id));
+  assert.ok(forward.superseded.some((entry) => entry.event_id === fixture.correction.event_id
+    && entry.by_event_id === fixture.deferredAssert.event_id));
+});
+
+test('[req:MEM-CUR-2] replay legado pode ser derivado sem pós-passe para validar checkpoint antigo', () => {
+  const vault = scratch();
+  try {
+    const fixture = deferredAssertReplayFixture();
+    const legacy = reduceMemoryEvents(fixture.events, { resolveDeferredAsserts: false });
+    const legacyReverse = reduceMemoryEvents([...fixture.events].reverse(), {
+      resolveDeferredAsserts: false,
+    });
+    const legacyProjection = deriveMemoryProjection(
+      vault, fixture.events, { resolveDeferredAsserts: false },
+    );
+    const current = deriveMemoryProjection(vault, fixture.events);
+    const explicitCurrent = deriveMemoryProjection(
+      vault, fixture.events, { resolveDeferredAsserts: true },
+    );
+
+    assert.equal(legacy.state['handoff.latest'], fixture.correction.value);
+    assert.deepEqual(legacyReverse, legacy, 'replay antigo também independe da ordem de chegada');
+    assert.equal(legacy.records['handoff.latest'].source.event_id, fixture.correction.event_id);
+    assert.equal(legacy.candidates.length, 1, 'semântica anterior reproduz o candidate transitório');
+    assert.equal(legacy.appliedEventIds.includes(fixture.deferredAssert.event_id), false);
+    assert.equal(legacyProjection.stateHash, legacy.stateHash);
+    assert.equal(legacyProjection.revision, legacy.revision);
+    assert.deepEqual(explicitCurrent, current, 'default true e opção explícita convergem igualmente');
+    assert.equal(current.state['handoff.latest'], fixture.deferredAssert.value);
+    assert.equal(current.candidates.length, 0);
+    assert.notEqual(current.stateHash, legacyProjection.stateHash);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-CUR-2] assert pendente de turno menor é superseded pela fonte moderna final', () => {
+  const fixture = deferredAssertReplayFixture({ assertOverrides: { turn_sequence: 0 } });
+
+  const reduced = reduceMemoryEvents(fixture.events);
+  const withoutStaleAssert = reduceMemoryEvents(
+    fixture.events.filter((item) => item.event_id !== fixture.deferredAssert.event_id),
+  );
+
+  assert.equal(reduced.state['handoff.latest'], fixture.correction.value);
+  assert.equal(reduced.records['handoff.latest'].source.event_id, fixture.correction.event_id);
+  assert.equal(reduced.revision, 3, 'supersede não cria uma revisão artificial');
+  assert.equal(reduced.stateHash, withoutStaleAssert.stateHash, 'supersede não altera estado ou hash');
+  assert.equal(reduced.candidates.length, 0);
+  assert.equal(reduced.appliedEventIds.includes(fixture.deferredAssert.event_id), false);
+  assert.ok(reduced.superseded.some((entry) => entry.event_id === fixture.deferredAssert.event_id
+    && entry.by_event_id === fixture.correction.event_id));
+});
+
+test('[req:MEM-CUR-2] fixpoint preserva conflito com linhagem incompleta, divergente ou turno ambíguo', () => {
+  const scenarios = [
+    ['sessão divergente', { canonical_session_id: 'other-session' }],
+    ['activation divergente', { activation_id: 'other-activation' }],
+    ['epoch divergente', { activation_epoch: 8 }],
+    ['identidade incompleta', { activation_epoch: undefined }],
+    ['turno de origem ausente', { source_turn_id: undefined }],
+    ['turno ambíguo', { turn_sequence: 1 }],
+  ];
+
+  for (const [name, assertOverrides] of scenarios) {
+    const fixture = deferredAssertReplayFixture({ assertOverrides });
+    const reduced = reduceMemoryEvents(fixture.events);
+
+    assert.equal(reduced.state['handoff.latest'], fixture.correction.value, name);
+    assert.equal(reduced.records['handoff.latest'].source.event_id, fixture.correction.event_id, name);
+    assert.equal(reduced.candidates.length, 1, name);
+    assert.deepEqual(
+      reduced.candidates[0].event_ids.sort(),
+      [fixture.legacyPromotion.event_id, fixture.deferredAssert.event_id].sort(),
+      name,
+    );
+    assert.equal(reduced.appliedEventIds.includes(fixture.deferredAssert.event_id), false, name);
+  }
+});
+
+test('[req:MEM-CUR-2] decisão explícita prevalece sobre reavaliação do assert pendente', () => {
+  const fixture = deferredAssertReplayFixture();
+  const transient = transientDeferredCandidate(fixture);
+  assert.ok(transient);
+  const reject = event('mem-replay-explicit-reject', `candidate.decision.${transient.candidate_id}`, 'assert', 'rejected', {
+    observed_at: '2026-07-26T12:07:00.000Z',
+    candidate_decision: {
+      candidate_id: transient.candidate_id,
+      action: 'reject',
+      event_ids: [...transient.event_ids],
+    },
+  });
+
+  const reduced = reduceMemoryEvents([...fixture.events, reject]);
+
+  assert.equal(reduced.state['handoff.latest'], fixture.correction.value);
+  assert.equal(reduced.records['handoff.latest'].source.event_id, fixture.correction.event_id);
+  assert.equal(reduced.candidates.length, 0, 'a decisão explícita aposenta o candidate');
+  assert.equal(reduced.appliedEventIds.includes(fixture.deferredAssert.event_id), false);
+  assert.equal(reduced.superseded.some((entry) => entry.event_id === fixture.deferredAssert.event_id), false);
 });
 
 test('[req:OP-10] ledger-only reprojection separates the physical checkpoint from causal order without consuming outbox', () => {


### PR DESCRIPTION
## Resumo

- reavalia candidates transitórios de `handoff.latest` quando uma correção moderna da mesma linhagem causal chega fisicamente depois, mas com tempo lógico anterior
- preserva conflitos reais, decisões explícitas, Stops antigos e o ledger append-only
- permite que `wendkeep memory repair` migre somente checkpoints legados comprovados, com CAS, backup, auditoria e retry idempotente
- atualiza versão, CHANGELOG e documentação PT-BR/EN para 0.66.3

## Causa raiz

O reducer era single-pass. Uma promoção legada podia ser avaliada antes de um Stop moderno da mesma linhagem e criar um candidate transitório. Quando o Stop corretivo se tornava a fonte final, esse candidate e o checkpoint correspondente não eram reavaliados, deixando a projeção estagnada apesar de o lifecycle ter publicado corretamente.

## Impacto

Após atualizar para 0.66.3, `wendkeep memory repair` reconcilia apenas o estado pós-migração cuja prova causal e checkpoint anterior sejam exatos. Ambiguidade real continua exigindo curadoria explícita.

Esta PR é um follow-up da issue #20 e da PR #32 e substitui a 0.66.2 antes de sua publicação no npm.

## Validação

- `wendkeep verify`: 5/5 sensores verdes
- `wendkeep verify --deep`: 5/5 sensores verdes
- revisão independente: `MEM-CUR-2` coberto, verdict `ok:true`
- testes discriminantes: 81/81
- E2E público sintético: inversão temporal, checkpoint, Stop duplicado, ledger preservado e zero candidate/outbox/conflito
- `doctor`, `validate-memory` e `sync-defs --check`: verdes
- auditoria do diff: sem dados do projeto consumidor
