### PR TITLE
fix: recover projected memory acknowledgements (0.66.4)

### DIFF
--- a/.agents/skills/example-skill/.wendkeep-meta.json
+++ b/.agents/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.3",
+  "wendkeepVersion": "0.66.4",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.agents/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.agents/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.3",
+  "wendkeepVersion": "0.66.4",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.agents/skills/wk-debugging/.wendkeep-meta.json
+++ b/.agents/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.3",
+  "wendkeepVersion": "0.66.4",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.agents/skills/wk-planning/.wendkeep-meta.json
+++ b/.agents/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.3",
+  "wendkeepVersion": "0.66.4",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.agents/skills/wk-tdd/.wendkeep-meta.json
+++ b/.agents/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.3",
+  "wendkeepVersion": "0.66.4",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.agents/skills/wk-verify/.wendkeep-meta.json
+++ b/.agents/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.3",
+  "wendkeepVersion": "0.66.4",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.agents/skills/wk-workflow/.wendkeep-meta.json
+++ b/.agents/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.3",
+  "wendkeepVersion": "0.66.4",
   "sourceHash": "c3299e94ce34103fb599744eabec7aec581aefc6fd7c6b959e0350293ee5d8bf"
 }

--- a/.claude/skills/example-skill/.wendkeep-meta.json
+++ b/.claude/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.3",
+  "wendkeepVersion": "0.66.4",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.claude/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.claude/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.3",
+  "wendkeepVersion": "0.66.4",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.claude/skills/wk-debugging/.wendkeep-meta.json
+++ b/.claude/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.3",
+  "wendkeepVersion": "0.66.4",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.claude/skills/wk-planning/.wendkeep-meta.json
+++ b/.claude/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.3",
+  "wendkeepVersion": "0.66.4",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.claude/skills/wk-tdd/.wendkeep-meta.json
+++ b/.claude/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.3",
+  "wendkeepVersion": "0.66.4",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.claude/skills/wk-verify/.wendkeep-meta.json
+++ b/.claude/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.3",
+  "wendkeepVersion": "0.66.4",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.claude/skills/wk-workflow/.wendkeep-meta.json
+++ b/.claude/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.3",
+  "wendkeepVersion": "0.66.4",
   "sourceHash": "c3299e94ce34103fb599744eabec7aec581aefc6fd7c6b959e0350293ee5d8bf"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- wendkeep:skills:start -->
-<!-- wendkeep-version: 0.66.3; skills-sha256: 36ebe0728fe02c48230802722405c3179cb460f289429505e341db582542b82d -->
+<!-- wendkeep-version: 0.66.4; skills-sha256: 36ebe0728fe02c48230802722405c3179cb460f289429505e341db582542b82d -->
 ## wendkeep — Keep Core & operating profiles
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. **Keep Core is always active**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.66.4] — 2026-07-30
+
+### Fixed
+
+- **`memory repair` fecha o acknowledgement apenas para a outbox que a própria execução
+  consumiu integralmente.** O receipt do projetor preserva idempotência e impede que attempts
+  históricos, parciais, causalmente divergentes ou concorrentes sejam reclassificados.
+- **`memory recover-attempt <session>` recupera com segurança o estado já projetado pela
+  0.66.3.** O dry-run é padrão e `--apply` altera somente o registry/checkpoint sob prova física,
+  lock e CAS; A→B→A, ledger/sidecars divergentes, outbox pendente e links inseguros falham sem
+  escrita. O diagnóstico agora orienta esse comando quando o acknowledgement ficou pendente.
+
 ## [0.66.3] — 2026-07-30
 
 ### Fixed

--- a/README.en.md
+++ b/README.en.md
@@ -287,8 +287,10 @@ lost publication, or mismatched checkpoint blocks. See [migration](docs/en/comma
 and [diagnostics](docs/en/commands/maintenance-and-diagnostics.md).
 
 If status blocks, preserve the evidence and run `wendkeep memory repair --vault <vault>` to back up
-the corrupt ledger, retain valid lines, and re-project. Repair never reclassifies attempts. Valid
-pre-0.59 causal checkpoints and exactly re-derived assert-only historical prefixes are
+the corrupt ledger, retain valid lines, and re-project. Repair remains structural: its only narrow
+acknowledgement exception covers attempts entirely represented by the outbox consumed by that same
+run; it does not scan or reclassify historical attempts. Valid pre-0.59 causal checkpoints and
+exactly re-derived assert-only historical prefixes are
 CAS-migrated on both the attempt and `memory_checkpoint` to the correct physical boundary with
 backup/audit; divergent mirrors fail closed. A demonstrably superseded
 ambiguity uses `memory reconcile <session> --by-session <successor>
@@ -303,9 +305,12 @@ final modern source: the same session/activation/epoch and a higher turn advance
 superseded. Repair migrates the checkpoint and mirror only when it proves the exact previous
 replay, attempt identity, and absence of a real conflict; it creates a backup and audit without
 appending or rewriting events. Ambiguity stays queued for explicit curation. Do not publish or
-install 0.66.2; use 0.66.3. Decisions survive repair/replay;
-`blocked_by_core` cannot override CORE. Doctor only
-diagnoses. See [memory and curation](docs/en/commands/memory.md).
+install 0.66.2; use 0.66.3 or later. Decisions survive repair/replay;
+`blocked_by_core` cannot override CORE. Doctor only diagnoses. When status/doctor reports projected
+acknowledgement pending on 0.66.4 or later, first run the targeted dry run
+`memory recover-attempt <session> --vault <vault>`, then authorize `--apply`; it changes only
+registry/checkpoint. See syntax, preconditions, and fail-closed behavior in
+[memory and curation](docs/en/commands/memory.md).
 
 Session notes use one live `## Agentes, tokens e custos` snapshot. Main-agent and subagent hooks recompose it atomically, with costs, token dimensions, reasoning tokens and effort per model/source. Every hook that rewrites a session note takes a per-file lock and writes through a temp file + rename, so the `SubagentStop` fan-out (one hook run per subagent) can never leave a note half-written; a note whose frontmatter reads back damaged is left untouched rather than patched.
 

--- a/README.md
+++ b/README.md
@@ -283,8 +283,10 @@ ou checkpoint divergente bloqueiam. Veja [migração](docs/pt-BR/commands/memory
 [diagnóstico](docs/pt-BR/commands/maintenance-and-diagnostics.md).
 
 Se o status bloquear, preserve a evidência e rode `wendkeep memory repair --vault <cofre>` para
-salvar backup do ledger corrompido, reter linhas válidas e reprojetar. Repair nunca reclassifica
-attempts; checkpoints causais válidos pré-0.59 e prefixos históricos assert-only exatamente
+salvar backup do ledger corrompido, reter linhas válidas e reprojetar. Repair continua estrutural:
+só reconhece a exceção estreita dos attempts integralmente cobertos pela outbox que a própria
+execução consumiu; não varre nem reclassifica attempts históricos. Checkpoints causais válidos
+pré-0.59 e prefixos históricos assert-only exatamente
 rederiváveis são migrados por CAS do attempt e de `memory_checkpoint`, com backup/auditoria, para
 a fronteira física correta; espelhos divergentes falham fechados. Uma
 ambiguidade comprovadamente substituída usa `memory reconcile <sessão>
@@ -299,9 +301,12 @@ reavaliado contra a fonte moderna final: mesma sessão/activation/epoch e turno 
 turno menor fica superseded. O repair só migra checkpoint e espelho quando prova exatamente o
 replay anterior, a identidade do attempt e a ausência de conflito real; faz backup, registra audit
 e não acrescenta nem reescreve eventos. Ambiguidade continua na fila para curadoria explícita.
-Não publique nem instale a 0.66.2; use a 0.66.3. Decisões sobrevivem a repair/replay;
+Não publique nem instale a 0.66.2; use a 0.66.3 ou mais recente. Decisões sobrevivem a repair/replay;
 `blocked_by_core` não pode sobrescrever CORE.
-O doctor apenas diagnostica. Veja [memória e curadoria](docs/pt-BR/commands/memory.md).
+Desde a 0.66.4, quando status/doctor indicar acknowledgement projetado pendente, use o dry-run
+dirigido `memory recover-attempt <sessão> --vault <cofre>` e só então autorize `--apply`; ele
+altera apenas registry/checkpoint. O doctor apenas diagnostica. Veja sintaxe, pré-condições e
+falhas fechadas em [memória e curadoria](docs/pt-BR/commands/memory.md).
 
 As notas de sessão usam um único snapshot vivo `## Agentes, tokens e custos`. Os hooks do agente principal e dos subagents recompõem o bloco atomicamente, incluindo custo, dimensões de tokens, reasoning e effort por modelo/origem.
 

--- a/docs/en/commands/memory.md
+++ b/docs/en/commands/memory.md
@@ -25,6 +25,7 @@ Pass the vault explicitly in automation. Preserve backups and evidence before re
 ```bash
 npx wendkeep memory status [--gate] --vault <vault>
 npx wendkeep memory repair --vault <vault>
+npx wendkeep memory recover-attempt <session> [--apply] --vault <vault>
 npx wendkeep memory reconcile <ambiguous-session> --by-session <successor-session> --reason <reason> [--apply] --vault <vault>
 npx wendkeep memory promote <candidate> [--event <event-id>] --vault <vault>
 npx wendkeep memory reject <candidate> --vault <vault>
@@ -51,8 +52,23 @@ npx wendkeep validate-memory --vault <v2-vault>
   historical prefix only when revision, cursor, hash, identity, turns, and the
   `memory_checkpoint` mirror exactly reproduce the old semantics; the target is the current replay
   of that prefix, without absorbing later events. Both paths CAS-check the attempt and mirror and
-  record backup/audit. Repair never reclassifies registry attempts or accepts a tuple, operation,
-  or mirror that cannot be fully re-derived.
+  record backup/audit. The only narrow acknowledgement exception covers `enqueued`/`degraded`
+  attempts whose outbox was frozen and whose event IDs that same repair run consumed in full;
+  partial coverage does not change the attempt. Repair does not scan or reclassify historical
+  attempts and does not accept a tuple, operation, or mirror that cannot be fully re-derived.
+- As of 0.66.4, `memory recover-attempt` targets one session and is a dry run by default. The
+  session must exist in the registry and its latest attempt must be `v2`, `applied`, and `enqueued`
+  or `degraded`, with non-empty, unique `event_ids`. Every event must be present in the ledger and
+  belong to the attempt's project/session/activation/epoch/turn; no later event from that session
+  or target event still in the outbox may exist, and SHARED/candidates must byte-for-byte reproduce
+  the full ledger projection. An already `projected` attempt is accepted only with a valid
+  checkpoint and returns `unchanged`.
+- With `--apply`, `memory recover-attempt` changes only `SESSION_REGISTRY`: it marks
+  `last_memory_attempt`/`memory_status` as `projected` and stores the same checkpoint in the
+  attempt and `memory_checkpoint`. Ledger, CORE, SHARED, candidates, outbox, and notes remain
+  byte-identical. The command validates all authority again under `MEMORY.lock`, CAS-checks the
+  attempt, activation, epoch, turn, and checkpoint, and fails closed if any byte/context changes.
+  A busy lock is not reaped; retry after application returns `unchanged` without writing.
 - `memory reconcile` is a dry run by default. `--apply` requires two named sessions plus a reason,
   CAS-checks the exact attempt, backs up the registry, and limits mutation to the ambiguous attempt
   and its successor. Replay is CORE-aware, checkpoints use the physical ledger cursor, and the
@@ -81,11 +97,16 @@ npx wendkeep validate-memory --vault <v2-vault>
   identity, backup, audit, and CAS; it does not reorder, rewrite, or append a ledger event.
 - `validate-memory <CORE.md>` checks the 25-line cap, required sections, and secrets.
 - `validate-memory --vault` requires a complete v2 bundle and is not the legacy-vault gate.
+- For `recover-attempt`, exit `0` means a valid dry run/apply, including `unchanged`; exit `1`
+  means a precondition, authority, CAS, topology, or lock check failed; exit `2` means a missing
+  session/`--vault`, unknown or duplicate option, extra argument, or invalid value.
 
 ## Examples
 
 ```bash
 npx wendkeep memory status --gate --vault .MyApp-vault
+npx wendkeep memory recover-attempt session-123 --vault .MyApp-vault
+npx wendkeep memory recover-attempt session-123 --apply --vault .MyApp-vault
 npx wendkeep memory reconcile old --by-session current --reason "delivery continued" --vault .MyApp-vault
 npx wendkeep memory reconcile old --by-session current --reason "delivery continued" --apply --vault .MyApp-vault
 npx wendkeep validate-memory .MyApp-vault/.brain/CORE.md
@@ -107,6 +128,14 @@ of a global projection that has already advanced with concurrent events.
   repair merely to manufacture the first event.
 - `degraded` with every event ID present in either the ledger or an intact outbox is recoverable;
   let idempotent replay finish. An event ID absent from both locations means lost publication.
+- Status/doctor reports `projected acknowledgement pending` and suggests
+  `memory recover-attempt <session>`: preserve the artifacts, inspect the dry-run JSON first, and
+  use `--apply` only when `eligible: true`. `dry-run` confirms eligibility; `applied` updates
+  registry/checkpoint; `unchanged` means the recovery was already applied idempotently.
+- `recover-attempt` rejects a missing/divergent event, a target still in the outbox, stale
+  SHARED/candidates, a historical attempt, mismatched session/causal context, invalid checkpoint,
+  or busy lock. Do not bypass the gate by editing files: rerun `memory status --gate`, preserve
+  evidence, and resolve the divergent authority.
 - An `ambiguous` attempt, an `applied` attempt without event IDs, a `projected` event found only in
   the outbox, or a mismatched checkpoint is blocking: preserve the artifacts and investigate
   before repair. If the ambiguity is demonstrably superseded by a successor session, inspect the

--- a/docs/pt-BR/commands/memory.md
+++ b/docs/pt-BR/commands/memory.md
@@ -25,6 +25,7 @@ Informe o vault explicitamente em automações. Preserve backups e evidências a
 ```bash
 npx wendkeep memory status [--gate] --vault <cofre>
 npx wendkeep memory repair --vault <cofre>
+npx wendkeep memory recover-attempt <sessão> [--apply] --vault <cofre>
 npx wendkeep memory reconcile <sessão-ambígua> --by-session <sessão-sucessora> --reason <motivo> [--apply] --vault <cofre>
 npx wendkeep memory promote <candidate> [--event <event-id>] --vault <cofre>
 npx wendkeep memory reject <candidate> --vault <cofre>
@@ -51,8 +52,24 @@ npx wendkeep validate-memory --vault <cofre-v2>
   assert-only somente quando revision, cursor, hash, identidade, turns e o espelho
   `memory_checkpoint` reproduzem exatamente a semântica antiga; o alvo é o replay atual daquele
   prefixo, sem absorver eventos posteriores. Ambos os casos fazem CAS do attempt e do espelho e
-  registram backup/auditoria. O repair nunca reclassifica attempts do registry nem aceita tuple,
-  operação ou espelho que não seja rederivado integralmente.
+  registram backup/auditoria. A única exceção estreita de acknowledgement cobre attempts
+  `enqueued`/`degraded` cuja outbox foi congelada e cujos event IDs a mesma execução do repair
+  consumiu integralmente; cobertura parcial não altera o attempt. O repair não varre nem
+  reclassifica attempts históricos e não aceita tuple, operação ou espelho que não seja
+  rederivado integralmente.
+- Desde a 0.66.4, `memory recover-attempt` é dirigido a uma única sessão e faz dry-run por padrão.
+  A sessão deve existir no registry e possuir o último attempt `v2`, `applied`, em `enqueued` ou
+  `degraded`, com `event_ids` não vazios e únicos. Todos os eventos devem estar integralmente no
+  ledger, pertencer ao mesmo projeto/sessão/activation/epoch/turn do attempt, não pode haver evento
+  posterior da mesma sessão nem evento alvo restante na outbox, e SHARED/candidates devem
+  reproduzir byte a byte a projeção integral do ledger. Um attempt já `projected` só é aceito com
+  checkpoint válido e retorna `unchanged`.
+- Com `--apply`, `memory recover-attempt` altera somente `SESSION_REGISTRY`: marca
+  `last_memory_attempt`/`memory_status` como `projected` e grava o checkpoint idêntico no attempt e
+  em `memory_checkpoint`. Ledger, CORE, SHARED, candidates, outbox e notas permanecem byte-intactos.
+  O comando valida novamente toda a autoridade sob `MEMORY.lock`, faz CAS do attempt, activation,
+  epoch, turno e checkpoint e falha fechado se qualquer byte/contexto mudar. Lock ocupado não é
+  colhido; retry após aplicação retorna `unchanged` sem escrita.
 - `memory reconcile` é dry-run por padrão. `--apply` exige duas sessões nomeadas e motivo, faz CAS
   do attempt exato, salva backup do registry e limita a mutação ao attempt ambíguo e à sucessora.
   O replay é CORE-aware, usa cursor físico do ledger no checkpoint e não reescreve ledger, CORE ou
@@ -78,11 +95,16 @@ npx wendkeep validate-memory --vault <cofre-v2>
   CAS; ele não reordena, reescreve nem acrescenta evento ao ledger.
 - `validate-memory <CORE.md>` valida cap de 25 linhas, seções e segredos.
 - `validate-memory --vault` exige bundle v2 completo; não é o gate correto para vault legado.
+- Para `recover-attempt`, exit `0` indica dry-run/apply válido, inclusive `unchanged`; exit `1`
+  indica falha de pré-condição, autoridade, CAS, topologia ou lock; exit `2` indica
+  sessão/`--vault` ausente, opção desconhecida/duplicada, argumento extra ou valor inválido.
 
 ## Exemplos
 
 ```bash
 npx wendkeep memory status --gate --vault .MeuApp-vault
+npx wendkeep memory recover-attempt sessao-123 --vault .MeuApp-vault
+npx wendkeep memory recover-attempt sessao-123 --apply --vault .MeuApp-vault
 npx wendkeep memory reconcile antiga --by-session atual --reason "entrega continuada" --vault .MeuApp-vault
 npx wendkeep memory reconcile antiga --by-session atual --reason "entrega continuada" --apply --vault .MeuApp-vault
 npx wendkeep validate-memory .MeuApp-vault/.brain/CORE.md
@@ -104,6 +126,14 @@ prefixo válido de uma projeção global que já avançou com eventos concorrent
   fabricar o primeiro evento.
 - `degraded` com todos os event IDs presentes no ledger ou na outbox íntegra é recuperável; deixe o
   replay idempotente concluir. Event ID ausente nos dois lugares indica publicação perdida.
+- Status/doctor informa `acknowledgement projetado pendente` e sugere
+  `memory recover-attempt <sessão>`: preserve os artefatos, revise primeiro o JSON do dry-run e só
+  use `--apply` se `eligible: true`. `dry-run` confirma elegibilidade; `applied` atualiza
+  registry/checkpoint; `unchanged` indica que a recuperação já foi aplicada de forma idempotente.
+- `recover-attempt` recusa evento ausente/divergente, outbox alvo ainda presente, SHARED/candidates
+  stale, attempt histórico, sessão/contexto causal divergente, checkpoint inválido ou lock ocupado.
+  Não tente contornar o gate com edição manual: rode novamente `memory status --gate`, preserve a
+  evidência e resolva a autoridade divergente.
 - Attempt `ambiguous`, attempt `applied` sem event IDs, evento `projected` apenas na outbox ou
   checkpoint divergente são bloqueantes: preserve os artefatos e investigue antes de repair. Se a
   ambiguidade for comprovadamente substituída por uma sessão sucessora, revise o dry-run de

--- a/hooks/vault-health.mjs
+++ b/hooks/vault-health.mjs
@@ -338,6 +338,12 @@ function checkMemoryAttempts(registry, {
       const missing = eventIds.filter((eventId) => !ledgerEventIds.has(eventId) && !outboxEventIds.has(eventId));
       if (missing.length) {
         failures.push(`Attempt v2 perdeu ${missing.length} evento(s): ausentes do ledger e da outbox. Inspecione com: ${MEMORY_STATUS_COMMAND}.`);
+      } else if (
+        state === 'enqueued'
+        && eventIds.every((eventId) => ledgerEventIds.has(eventId))
+        && eventIds.every((eventId) => !outboxEventIds.has(eventId))
+      ) {
+        warnings.push(`Attempt de memória v2 possui acknowledgement projetado pendente. Recupere com: wendkeep memory recover-attempt ${sessionId}.`);
       } else {
         warnings.push(`Attempt de memória v2 ${state} permanece recuperável: ${eventIds.length} evento(s) durável(is) no ledger e/ou outbox.`);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.66.3",
+  "version": "0.66.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.66.3",
+      "version": "0.66.4",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.66.3",
+  "version": "0.66.4",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -100,6 +100,7 @@ Usage:
                            behind the closing block. Dry-run by default · --apply · --json.
   wendkeep lesson add "t" "l"   Record a project-local lesson (injected at SessionStart).
   wendkeep memory <sub>          Shared memory v2: status | migrate [--apply] | repair |
+                           recover-attempt <session> [--apply] |
                            reconcile <session> --by-session <session> --reason <text> [--apply] |
                            promote <candidate> [--event <event-id>] | reject <candidate>. --vault P.
                            Reconcile is dry-run by default; the original attempt remains audited.

--- a/packages/vault/src/memory-store.mjs
+++ b/packages/vault/src/memory-store.mjs
@@ -313,6 +313,8 @@ export function readMemoryLedger(vaultBase) {
     if (eventIds.has(parsed.event_id)) {
       if (eventPayloads.get(parsed.event_id) !== payload) {
         errors.push(ledgerError(lineNumber, `event_id collision: ${parsed.event_id}`, partial));
+      } else {
+        errors.push(ledgerError(lineNumber, `duplicate event_id: ${parsed.event_id}`, partial));
       }
       return;
     }
@@ -911,15 +913,18 @@ function projectLocked(vaultBase, { faultAt } = {}) {
   const projection = publishMemoryProjection(vaultBase, prepared);
   injectFault(faultAt, 'after-projection');
 
+  const consumedEventIds = [];
   for (const entry of outbox) {
     unlinkVaultFile(vaultBase, entry.path, {
       missingOk: false, label: 'evento consumido do outbox de memória',
     });
+    consumedEventIds.push(entry.event.event_id);
   }
   return {
     status: 'projected',
     appended: newEvents.length,
     consumed: outbox.length,
+    consumedEventIds,
     pending: 0,
     ...projection,
   };

--- a/src/memory.mjs
+++ b/src/memory.mjs
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import {
   constants as fsConstants, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync,
-  rmSync, writeFileSync,
+  readdirSync, rmSync, statSync, writeFileSync,
 } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { sanitizeMemoryText, renderSharedMemory, validateSharedMemory } from '../hooks/memory-schema.mjs';
@@ -536,6 +536,520 @@ function memoryCheckpointFingerprint(entry) {
     present,
     checkpoint: present ? (entry.memory_checkpoint ?? null) : null,
   }));
+}
+
+function fieldSnapshot(value, key) {
+  const present = Object.prototype.hasOwnProperty.call(value || {}, key);
+  return { present, value: present ? (value[key] ?? null) : null };
+}
+
+function attemptAuthorityFingerprint(entry, attempt) {
+  const activation = entry?.activations?.[attempt?.activation_id];
+  return hash(canonicalMemoryJson({
+    status: fieldSnapshot(entry, 'status'),
+    active_activation_id: fieldSnapshot(entry, 'active_activation_id'),
+    activation_epoch: fieldSnapshot(entry, 'activation_epoch'),
+    last_turn_id: fieldSnapshot(entry, 'last_turn_id'),
+    last_turn_sequence: fieldSnapshot(entry, 'last_turn_sequence'),
+    turn_sequence: fieldSnapshot(entry?.turn_sequences, attempt?.turn_id),
+    activation: {
+      status: fieldSnapshot(activation, 'status'),
+      epoch: fieldSnapshot(activation, 'epoch'),
+      last_stop_turn_id: fieldSnapshot(activation, 'last_stop_turn_id'),
+      last_stop_turn_sequence: fieldSnapshot(activation, 'last_stop_turn_sequence'),
+      last_turn_sequence: fieldSnapshot(activation, 'last_turn_sequence'),
+    },
+    memory_status: fieldSnapshot(entry, 'memory_status'),
+    memory_activation_id: fieldSnapshot(entry, 'memory_activation_id'),
+  }));
+}
+
+function ownsAttemptContext(entry, attempt) {
+  const activation = entry?.activations?.[attempt?.activation_id];
+  return entry?.status === 'active'
+    && entry.active_activation_id === attempt.activation_id
+    && entry.activation_epoch === attempt.activation_epoch
+    && activation?.status === 'active'
+    && activation.epoch === attempt.activation_epoch
+    && entry.last_turn_id === attempt.turn_id
+    && entry.last_turn_sequence === attempt.turn_sequence
+    && entry.turn_sequences?.[attempt.turn_id] === attempt.turn_sequence
+    && activation.last_stop_turn_id === attempt.turn_id
+    && activation.last_stop_turn_sequence === attempt.turn_sequence
+    && activation.last_turn_sequence === attempt.turn_sequence
+    && entry.memory_status === attempt.state
+    && entry.memory_activation_id === attempt.activation_id;
+}
+
+function attemptEventMatches(event, attempt, expectedProjectId) {
+  return event?.project_id === expectedProjectId
+    && event.canonical_session_id === attempt.canonical_session_id
+    && event.activation_id === attempt.activation_id
+    && event.activation_epoch === attempt.activation_epoch
+    && event.source_turn_id === attempt.turn_id
+    && event.turn_sequence === attempt.turn_sequence;
+}
+
+function readAttemptOutboxEvents(vault, eventIds) {
+  const events = [];
+  for (const eventId of eventIds) {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(eventId)) return null;
+    const path = brainPath(vault, join('memory-outbox', `${eventId}.json`));
+    const checked = checkedVaultFile(vault, path, `outbox do attempt ${eventId}`);
+    if (!checked.exists) return null;
+    try {
+      const event = JSON.parse(readVaultFile(
+        vault, checked.target, 'utf8', `outbox do attempt ${eventId}`,
+      ));
+      if (event?.event_id !== eventId) return null;
+      events.push(event);
+    } catch (error) {
+      if (error?.code === 'VAULT_PATH_UNSAFE') throw error;
+      return null;
+    }
+  }
+  return events;
+}
+
+function targetOutboxIsAbsent(vault, eventIds) {
+  return eventIds.every((eventId) => {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(eventId)) return false;
+    const path = brainPath(vault, join('memory-outbox', `${eventId}.json`));
+    return !checkedVaultFile(vault, path, `outbox do attempt ${eventId}`).exists;
+  });
+}
+
+function freezeRepairAttemptAcknowledgements(vault, options = {}) {
+  const result = withMemoryLock(vault, () => {
+    const expectedProjectId = projectId(vault);
+    const registry = readSessionRegistry(vault);
+    const frozen = [];
+    let pending = false;
+    for (const [sessionId, entry] of Object.entries(registry.sessions || {})) {
+      const attempt = entry?.last_memory_attempt;
+      const eventIds = Array.isArray(attempt?.event_ids) ? [...attempt.event_ids] : [];
+      if (attempt?.memory_mode !== 'v2' || attempt.disposition !== 'applied'
+          || !['enqueued', 'degraded'].includes(attempt.state)) continue;
+      pending = true;
+      if (!eventIds.length || new Set(eventIds).size !== eventIds.length
+          || eventIds.some((eventId) => typeof eventId !== 'string' || !eventId)
+          || sessionId !== attempt.canonical_session_id
+          || !ownsAttemptContext(entry, attempt)) continue;
+      const outboxEvents = readAttemptOutboxEvents(vault, eventIds);
+      if (!outboxEvents
+          || outboxEvents.some((event) => !attemptEventMatches(event, attempt, expectedProjectId))) {
+        continue;
+      }
+      frozen.push({
+        sessionId,
+        projectId: expectedProjectId,
+        eventIds,
+        eventFingerprints: new Map(outboxEvents.map((event) => [
+          event.event_id, hash(canonicalMemoryJson(event)),
+        ])),
+        attemptFingerprint: attemptFingerprint(attempt),
+        checkpointFingerprint: memoryCheckpointFingerprint(entry),
+        authorityFingerprint: attemptAuthorityFingerprint(entry, attempt),
+      });
+    }
+    if (pending) {
+      const ledger = readLedgerForValidation(vault, { projectId: expectedProjectId });
+      if (!ledger.ok) {
+        throw new Error(`Ledger físico inválido para acknowledgement de repair: ${(ledger.errors || []).join(' ')}`);
+      }
+    }
+    return { attempts: frozen, pending };
+  }, options.memoryLock || {});
+  return result;
+}
+
+function publishedProjectionMatches(vault, events, projection) {
+  const prepared = prepareMemoryProjection(vault, events);
+  if (!sameCheckpoint(prepared.checkpoint, projection?.checkpoint)) return false;
+  const shared = readVaultFile(
+    vault, brainPath(vault, SHARED), 'utf8', 'projeção SHARED_MEMORY.md',
+  );
+  const candidates = readVaultFile(
+    vault, brainPath(vault, CANDIDATES), 'utf8', 'projeção MEMORY_CANDIDATES.jsonl',
+  );
+  return shared === prepared.sharedContent && candidates === prepared.candidatesContent;
+}
+
+function acknowledgeRepairAttempts(vault, frozen, projection, options = {}) {
+  const receipt = new Set(Array.isArray(projection?.consumedEventIds)
+    ? projection.consumedEventIds
+    : []);
+  const covered = frozen.filter((item) => item.eventIds.every((eventId) => receipt.has(eventId)));
+  if (!covered.length) {
+    return {
+      status: 'unchanged', eligible: frozen.length, acknowledged: 0, stale: frozen.length,
+    };
+  }
+
+  const outcome = withMemoryLock(vault, () => {
+    if (options.beforeAttemptAcknowledgement) options.beforeAttemptAcknowledgement();
+    const ledger = readMemoryLedger(vault);
+    if (ledger.status !== 'ok' || !publishedProjectionMatches(vault, ledger.events, projection)) {
+      return {
+        status: 'attention', eligible: frozen.length, acknowledged: 0, stale: frozen.length,
+      };
+    }
+    const byId = new Map(ledger.events.map((event) => [event.event_id, event]));
+    const valid = covered.filter((item) => {
+      if (projectId(vault) !== item.projectId || !targetOutboxIsAbsent(vault, item.eventIds)) {
+        return false;
+      }
+      return item.eventIds.every((eventId) => {
+        const event = byId.get(eventId);
+        return event
+          && item.eventFingerprints.get(eventId) === hash(canonicalMemoryJson(event));
+      });
+    });
+    if (!valid.length) {
+      return {
+        status: 'attention', eligible: frozen.length, acknowledged: 0, stale: frozen.length,
+      };
+    }
+
+    const acknowledged = mutateSessionRegistry(vault, (registry) => {
+      const sessionIds = [];
+      for (const item of valid) {
+        const entry = registry.sessions?.[item.sessionId];
+        const attempt = entry?.last_memory_attempt;
+        if (!attempt || attemptFingerprint(attempt) !== item.attemptFingerprint
+            || memoryCheckpointFingerprint(entry) !== item.checkpointFingerprint
+            || attemptAuthorityFingerprint(entry, attempt) !== item.authorityFingerprint
+            || !ownsAttemptContext(entry, attempt)
+            || item.eventIds.some((eventId) => !attemptEventMatches(
+              byId.get(eventId), attempt, item.projectId,
+            ))) continue;
+        attempt.state = 'projected';
+        attempt.checkpoint = cloneJson(projection.checkpoint);
+        entry.memory_status = 'projected';
+        entry.memory_checkpoint = cloneJson(projection.checkpoint);
+        sessionIds.push(item.sessionId);
+      }
+      return sessionIds;
+    });
+    return {
+      status: acknowledged.length === valid.length ? 'acknowledged' : 'attention',
+      eligible: frozen.length,
+      acknowledged: acknowledged.length,
+      stale: frozen.length - acknowledged.length,
+      sessionIds: acknowledged,
+    };
+  }, options.memoryLock || {});
+  return outcome === MEMORY_LOCK_BUSY
+    ? {
+      status: 'busy', eligible: frozen.length, acknowledged: 0, stale: frozen.length,
+    }
+    : outcome;
+}
+
+function normalizeProjectedAttemptRecoveryRequest({ sessionId } = {}) {
+  const normalizedSessionId = String(sessionId || '').trim();
+  if (!normalizedSessionId) {
+    throw new TypeError('sessionId é obrigatório para recuperar attempt projetado.');
+  }
+  return { sessionId: normalizedSessionId };
+}
+
+function readStrictSessionRegistry(vault) {
+  const path = registryPath(vault);
+  const checked = checkedVaultFile(vault, path, 'SESSION_REGISTRY da recuperação', {
+    allowMissing: false,
+  });
+  const generationBefore = filesystemGeneration(checked.target);
+  let bytes;
+  try {
+    bytes = readVaultFile(vault, checked.target, undefined, 'SESSION_REGISTRY da recuperação');
+  } catch (error) {
+    throw new Error(`SESSION_REGISTRY ausente ou ilegível para recuperação: ${error?.message || error}`);
+  }
+  const generationAfter = filesystemGeneration(checked.target);
+  if (canonicalMemoryJson(generationBefore) !== canonicalMemoryJson(generationAfter)) {
+    throw new Error('SESSION_REGISTRY mudou durante o preflight da recuperação targeted.');
+  }
+  let registry;
+  try {
+    registry = JSON.parse(bytes.toString('utf8'));
+  } catch (error) {
+    throw new Error(`SESSION_REGISTRY contém JSON inválido para recuperação: ${error?.message || error}`);
+  }
+  if (!registry || typeof registry !== 'object' || Array.isArray(registry)
+      || !Number.isInteger(registry.version) || registry.version < 2
+      || !registry.sessions || typeof registry.sessions !== 'object'
+      || Array.isArray(registry.sessions)) {
+    throw new Error('SESSION_REGISTRY inválido para recuperação targeted.');
+  }
+  return {
+    registry,
+    registryHash: hash(canonicalMemoryJson(registry)),
+    registryGeneration: generationAfter,
+  };
+}
+
+function filesystemGeneration(path) {
+  const stat = statSync(path, { bigint: true });
+  return {
+    dev: String(stat.dev),
+    ino: String(stat.ino),
+    size: String(stat.size),
+    mtimeNs: String(stat.mtimeNs),
+    ctimeNs: String(stat.ctimeNs),
+    birthtimeNs: String(stat.birthtimeNs),
+  };
+}
+
+function projectedRecoveryOutboxProof(vault) {
+  const path = brainPath(vault, 'memory-outbox');
+  const checked = assertVaultPathSafe(vault, path, {
+    allowMissing: true,
+    expectedType: 'directory',
+    label: 'diretório memory-outbox da recuperação',
+  });
+  if (!checked.exists) return { exists: false, entries: [] };
+
+  const namesBefore = readdirSync(checked.target).sort();
+  const entries = namesBefore.map((name) => {
+    const memberPath = join(checked.target, name);
+    const member = checkedVaultFile(
+      vault, memberPath, `membro ${name} da memory-outbox`, { allowMissing: false },
+    );
+    const bytes = readVaultFile(
+      vault, member.target, undefined, `membro ${name} da memory-outbox`,
+    );
+    let event;
+    try {
+      event = JSON.parse(bytes.toString('utf8'));
+    } catch (error) {
+      throw new Error(`Membro ${name} da memory-outbox contém JSON inválido: ${error?.message || error}`);
+    }
+    if (!event || typeof event !== 'object' || Array.isArray(event)
+        || typeof event.event_id !== 'string' || !event.event_id.trim()) {
+      throw new Error(`Membro ${name} da memory-outbox não contém event_id válido.`);
+    }
+    return {
+      name,
+      eventId: event.event_id,
+      generation: filesystemGeneration(member.target),
+      hash: byteHash(bytes),
+    };
+  });
+  const namesAfter = readdirSync(checked.target).sort();
+  if (canonicalMemoryJson(namesBefore) !== canonicalMemoryJson(namesAfter)) {
+    throw new Error('memory-outbox mudou durante o preflight da recuperação targeted.');
+  }
+  return {
+    exists: true,
+    generation: filesystemGeneration(checked.target),
+    entries,
+  };
+}
+
+function recoveryContextFingerprint(entry, attempt) {
+  return hash(canonicalMemoryJson({
+    status: fieldSnapshot(entry, 'status'),
+    session_id: fieldSnapshot(entry, 'session_id'),
+    activation_id: fieldSnapshot(entry, 'activation_id'),
+    active_activation_id: fieldSnapshot(entry, 'active_activation_id'),
+    activation_epoch: fieldSnapshot(entry, 'activation_epoch'),
+    last_turn_id: fieldSnapshot(entry, 'last_turn_id'),
+    last_turn_sequence: fieldSnapshot(entry, 'last_turn_sequence'),
+    turn_sequences: cloneJson(entry?.turn_sequences || null),
+    activation: cloneJson(entry?.activations?.[attempt?.activation_id] || null),
+    memory_status: fieldSnapshot(entry, 'memory_status'),
+    memory_activation_id: fieldSnapshot(entry, 'memory_activation_id'),
+  }));
+}
+
+function recoveryRegistryProof(entry, attempt) {
+  return {
+    attemptFingerprint: attemptFingerprint(attempt),
+    contextFingerprint: recoveryContextFingerprint(entry, attempt),
+    checkpointFingerprint: memoryCheckpointFingerprint(entry),
+  };
+}
+
+function validStoredProjectedCheckpoint(vault, authority, attempt, entry) {
+  if (!checkpointShape(attempt?.checkpoint)
+      || !sameCheckpoint(attempt.checkpoint, entry?.memory_checkpoint)) return false;
+  const cursorIndex = authority.ledgerEvents
+    .findIndex((event) => event.event_id === attempt.checkpoint.event_cursor);
+  if (cursorIndex < 0) return false;
+  const prefix = authority.ledgerEvents.slice(0, cursorIndex + 1);
+  const prefixIds = new Set(prefix.map((event) => event.event_id));
+  if (attempt.event_ids.some((eventId) => !prefixIds.has(eventId))) return false;
+  return sameCheckpoint(
+    attempt.checkpoint,
+    prepareMemoryProjection(vault, prefix).checkpoint,
+  );
+}
+
+function prepareProjectedAttemptRecovery(vault, rawRequest) {
+  const request = normalizeProjectedAttemptRecoveryRequest(rawRequest);
+  const authority = readMemoryAuthority(vault);
+  const registrySnapshot = readStrictSessionRegistry(vault);
+  const { registry } = registrySnapshot;
+  const outboxProof = projectedRecoveryOutboxProof(vault);
+  const entry = registry.sessions[request.sessionId];
+  if (!entry) throw new Error(`Sessão não encontrada para recuperação: ${request.sessionId}`);
+
+  const attempt = entry.last_memory_attempt;
+  const eventIds = Array.isArray(attempt?.event_ids) ? [...attempt.event_ids] : [];
+  if (attempt?.memory_mode !== 'v2' || attempt?.disposition !== 'applied'
+      || !['enqueued', 'degraded', 'projected'].includes(attempt?.state)) {
+    throw new Error(`Attempt da sessão ${request.sessionId} não é v2/applied recuperável.`);
+  }
+  if (!eventIds.length
+      || eventIds.some((eventId) => typeof eventId !== 'string' || !eventId.trim())
+      || new Set(eventIds).size !== eventIds.length) {
+    throw new Error('Attempt recuperável deve possuir event_ids não vazios e únicos.');
+  }
+  if (request.sessionId !== attempt.canonical_session_id
+      || (Object.prototype.hasOwnProperty.call(entry, 'session_id')
+        && entry.session_id !== request.sessionId)
+      || !ownsAttemptContext(entry, attempt)) {
+    throw new Error('Contexto causal do attempt não pertence mais à sessão ativa.');
+  }
+
+  const eventIndexes = eventIds.map((eventId) => (
+    authority.ledgerEvents.findIndex((event) => event.event_id === eventId)
+  ));
+  if (eventIndexes.some((index) => index < 0)) {
+    throw new Error('Attempt recuperável referencia event_ids ausentes do ledger.');
+  }
+  for (const eventId of eventIds) {
+    if (!attemptEventMatches(authority.ledgerById.get(eventId), attempt, authority.projectId)) {
+      throw new Error(`Identidade causal inválida no evento ${eventId}.`);
+    }
+  }
+  const lastAttemptEventIndex = Math.max(...eventIndexes);
+  if (authority.ledgerEvents.slice(lastAttemptEventIndex + 1)
+    .some((event) => event.canonical_session_id === request.sessionId)) {
+    throw new Error('Existe evento posterior da mesma sessão; attempt histórico não pode ser recuperado.');
+  }
+  if (!targetOutboxIsAbsent(vault, eventIds)
+      || outboxProof.entries.some((item) => eventIds.includes(item.eventId))) {
+    throw new Error('A outbox ainda contém evento alvo; recuperação targeted recusada.');
+  }
+
+  const projection = prepareMemoryProjection(vault, authority.ledgerEvents);
+  const sharedBytes = readVaultFile(
+    vault, brainPath(vault, SHARED), undefined, 'projeção SHARED_MEMORY.md',
+  );
+  const candidatesBytes = readVaultFile(
+    vault, brainPath(vault, CANDIDATES), undefined, 'projeção MEMORY_CANDIDATES.jsonl',
+  );
+  if (!sharedBytes.equals(Buffer.from(projection.sharedContent))
+      || !candidatesBytes.equals(Buffer.from(projection.candidatesContent))) {
+    throw new Error('SHARED/candidates divergem da autoridade integral do ledger.');
+  }
+  assertAuthorityMatches(authority, readMemoryAuthority(vault));
+
+  const alreadyProjected = attempt.state === 'projected';
+  if (alreadyProjected && !validStoredProjectedCheckpoint(vault, authority, attempt, entry)) {
+    throw new Error('Attempt projected não possui checkpoint armazenado válido.');
+  }
+
+  return {
+    request,
+    eligible: !alreadyProjected,
+    alreadyProjected,
+    checkpoint: cloneJson(alreadyProjected ? attempt.checkpoint : projection.checkpoint),
+    proof: {
+      projectId: authority.projectId,
+      projectHash: authority.projectHash,
+      coreHash: authority.coreHash,
+      ledgerHash: authority.ledgerHash,
+      sharedHash: byteHash(sharedBytes),
+      candidatesHash: byteHash(candidatesBytes),
+      outboxProof,
+      registryHash: registrySnapshot.registryHash,
+      registryGeneration: registrySnapshot.registryGeneration,
+      eventIds,
+      eventFingerprints: eventIds.map((eventId) => (
+        hash(canonicalMemoryJson(authority.ledgerById.get(eventId)))
+      )),
+      ...recoveryRegistryProof(entry, attempt),
+    },
+  };
+}
+
+function projectedAttemptRecoveryResult(prepared, status) {
+  return {
+    status,
+    eligible: prepared.eligible,
+    sessionId: prepared.request.sessionId,
+    checkpoint: cloneJson(prepared.checkpoint),
+  };
+}
+
+function assertProjectedAttemptRecoveryProof(expected, actual) {
+  if (canonicalMemoryJson(expected.proof) !== canonicalMemoryJson(actual.proof)
+      || expected.alreadyProjected !== actual.alreadyProjected
+      || !sameCheckpoint(expected.checkpoint, actual.checkpoint)) {
+    throw new Error('CAS perdido: autoridade, attempt, contexto causal ou checkpoint mudou.');
+  }
+}
+
+export function inspectProjectedAttemptRecovery(vault, { sessionId } = {}) {
+  const prepared = prepareProjectedAttemptRecovery(vault, { sessionId });
+  return projectedAttemptRecoveryResult(
+    prepared, prepared.alreadyProjected ? 'unchanged' : 'eligible',
+  );
+}
+
+export function recoverProjectedAttempt(vault, {
+  sessionId,
+  apply = false,
+  beforeRegistryMutation,
+  memoryLock = {},
+} = {}) {
+  const prepared = prepareProjectedAttemptRecovery(vault, { sessionId });
+  if (prepared.alreadyProjected) {
+    return projectedAttemptRecoveryResult(prepared, 'unchanged');
+  }
+  if (!apply) return projectedAttemptRecoveryResult(prepared, 'dry-run');
+
+  const outcome = withMemoryLock(vault, () => {
+    const locked = prepareProjectedAttemptRecovery(vault, prepared.request);
+    assertProjectedAttemptRecoveryProof(prepared, locked);
+    if (beforeRegistryMutation) beforeRegistryMutation();
+    const current = prepareProjectedAttemptRecovery(vault, prepared.request);
+    assertProjectedAttemptRecoveryProof(locked, current);
+
+    mutateSessionRegistry(vault, (registry) => {
+      const entry = registry.sessions?.[current.request.sessionId];
+      const attempt = entry?.last_memory_attempt;
+      const expectedRegistryProof = {
+        attemptFingerprint: current.proof.attemptFingerprint,
+        contextFingerprint: current.proof.contextFingerprint,
+        checkpointFingerprint: current.proof.checkpointFingerprint,
+      };
+      if (!entry || !attempt
+          || hash(canonicalMemoryJson(registry)) !== current.proof.registryHash
+          || canonicalMemoryJson(filesystemGeneration(registryPath(vault)))
+            !== canonicalMemoryJson(current.proof.registryGeneration)
+          || canonicalMemoryJson(recoveryRegistryProof(entry, attempt))
+            !== canonicalMemoryJson(expectedRegistryProof)) {
+        throw new Error('CAS perdido: registry mudou antes do acknowledgement targeted.');
+      }
+      attempt.state = 'projected';
+      attempt.checkpoint = cloneJson(current.checkpoint);
+      entry.memory_status = 'projected';
+      entry.memory_activation_id = attempt.activation_id;
+      entry.memory_checkpoint = cloneJson(current.checkpoint);
+    });
+    return projectedAttemptRecoveryResult(current, 'applied');
+  }, memoryLock);
+
+  if (outcome === MEMORY_LOCK_BUSY) {
+    const error = new Error('MEMORY.lock indisponível; recuperação targeted não foi aplicada.');
+    error.code = 'WENDKEEP_MEMORY_LOCK_BUSY';
+    throw error;
+  }
+  return outcome;
 }
 
 function matchingAppliedReconciliation(entry, request) {
@@ -1217,13 +1731,28 @@ export function migrateLegacyMemoryCheckpoints(vault, {
 }
 
 export function repairMemory(vault, options = {}) {
-  const repaired = repairMemoryLedger(vault);
+  if (options.beforeAttemptFreeze) options.beforeAttemptFreeze();
+  const acknowledgementPreflight = freezeRepairAttemptAcknowledgements(vault, options);
+  if (acknowledgementPreflight === MEMORY_LOCK_BUSY) {
+    return { status: 'busy', stage: 'attempt-freeze' };
+  }
+  const frozenAttempts = acknowledgementPreflight.attempts;
+  const repaired = acknowledgementPreflight.pending
+    ? { status: 'unchanged', repairedLines: 0, backupPath: null }
+    : repairMemoryLedger(vault);
   if (repaired.status === 'busy') return repaired;
   const projection = projectMemoryOutbox(vault);
   if (projection.status === 'busy') return { status: 'busy', repaired, projection };
+  const attemptAcknowledgements = acknowledgeRepairAttempts(
+    vault, frozenAttempts, projection, options,
+  );
   const checkpointMigration = migrateLegacyMemoryCheckpoints(vault, options);
   return {
-    status: 'repaired', repaired, projection, checkpointMigration,
+    status: 'repaired',
+    repaired,
+    projection,
+    attemptAcknowledgements,
+    checkpointMigration,
   };
 }
 
@@ -1317,9 +1846,61 @@ function parseReconcileArgs(argv) {
   };
 }
 
+function parseRecoverAttemptArgs(argv) {
+  const positionals = [];
+  const seen = new Set();
+  let apply = false;
+  let vault = '';
+
+  for (let index = 1; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) {
+      positionals.push(token);
+      if (positionals.length > 1) {
+        throw memoryUsageError(`memory recover-attempt recebeu argumento posicional extra: ${token}.`);
+      }
+      continue;
+    }
+
+    const equalAt = token.indexOf('=');
+    const name = equalAt >= 0 ? token.slice(0, equalAt) : token;
+    if (name !== '--apply' && name !== '--vault') {
+      throw memoryUsageError(`memory recover-attempt recebeu opção desconhecida: ${name}.`);
+    }
+    if (seen.has(name)) {
+      throw memoryUsageError(`memory recover-attempt recebeu opção duplicada: ${name}.`);
+    }
+    seen.add(name);
+
+    if (name === '--apply') {
+      if (equalAt >= 0) throw memoryUsageError('--apply não aceita valor.');
+      apply = true;
+      continue;
+    }
+
+    const value = equalAt >= 0 ? token.slice(equalAt + 1) : argv[index + 1];
+    if (!value || !value.trim() || value.startsWith('--')) {
+      throw memoryUsageError('--vault requer valor não vazio que não comece com --.');
+    }
+    vault = value;
+    if (equalAt < 0) index += 1;
+  }
+
+  if (positionals.length !== 1) {
+    throw memoryUsageError('memory recover-attempt requer exatamente uma sessão obrigatória.');
+  }
+
+  return {
+    sessionId: positionals[0],
+    apply,
+    vault,
+  };
+}
+
 export function runMemory(argv) {
   const [sub, positional] = argv;
   let reconcileArgs = null;
+  let recoverAttemptArgs = null;
   if (sub === 'reconcile') {
     try {
       reconcileArgs = parseReconcileArgs(argv);
@@ -1329,7 +1910,18 @@ export function runMemory(argv) {
       return;
     }
   }
-  const vault = (reconcileArgs?.vault || option(argv, '--vault')) || process.env.OBSIDIAN_VAULT_PATH;
+  if (sub === 'recover-attempt') {
+    try {
+      recoverAttemptArgs = parseRecoverAttemptArgs(argv);
+    } catch (error) {
+      process.stderr.write(`wendkeep memory: ${error.message}\n`);
+      process.exitCode = error.code === 'WENDKEEP_MEMORY_USAGE' ? 2 : 1;
+      return;
+    }
+  }
+  const vault = (
+    recoverAttemptArgs?.vault || reconcileArgs?.vault || option(argv, '--vault')
+  ) || process.env.OBSIDIAN_VAULT_PATH;
   if (!vault) { process.stderr.write('wendkeep memory: passe --vault <path>.\n'); process.exitCode = 2; return; }
   if (!existsSync(vault)) { process.stderr.write(`wendkeep memory: not found: ${vault}\n`); process.exitCode = 2; return; }
   try {
@@ -1345,6 +1937,12 @@ export function runMemory(argv) {
         apply: reconcileArgs.apply,
       });
     }
+    else if (sub === 'recover-attempt') {
+      result = recoverProjectedAttempt(vault, {
+        sessionId: recoverAttemptArgs.sessionId,
+        apply: recoverAttemptArgs.apply,
+      });
+    }
     else if (sub === 'promote' || sub === 'reject') {
       const eventId = option(argv, '--event');
       if (sub === 'reject' && eventId) throw memoryUsageError('--event é permitido somente em memory promote.');
@@ -1352,7 +1950,7 @@ export function runMemory(argv) {
         action: sub, candidateId: positional, ...(eventId ? { eventId } : {}),
       });
     }
-    else { process.stderr.write('wendkeep memory: use status | migrate [--apply] | repair | reconcile <session> --by-session <session> --reason <text> [--apply] | promote <candidate> [--event <event-id>] | reject <candidate>.\n'); process.exitCode = 2; return; }
+    else { process.stderr.write('wendkeep memory: use status | migrate [--apply] | repair | recover-attempt <session> [--apply] | reconcile <session> --by-session <session> --reason <text> [--apply] | promote <candidate> [--event <event-id>] | reject <candidate>.\n'); process.exitCode = 2; return; }
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     if (sub === 'status' && argv.includes('--gate')) process.exitCode = result.status === 'blocked' ? 1 : 0;
     else if (sub === 'reconcile' && reconcileArgs.apply) process.exitCode = result.health?.status === 'blocked' ? 1 : 0;

--- a/tests/memory-attempt-recovery-topology.test.mjs
+++ b/tests/memory-attempt-recovery-topology.test.mjs
@@ -1,0 +1,280 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  canonicalMemoryJson,
+  prepareMemoryProjection,
+  reduceMemoryEvents,
+} from '../hooks/memory-store.mjs';
+import { recoverProjectedAttempt } from '../src/memory.mjs';
+import { renderCoreSkeleton } from '../src/validate-core.mjs';
+
+const PROJECT_ID = 'synthetic-topology-project';
+const SESSION_ID = 'synthetic-topology-session';
+const ACTIVATION_ID = 'synthetic-topology-activation';
+const TURN_ID = 'synthetic-topology-turn';
+const EVENT_ID = 'synthetic-topology-event';
+const OBSERVED_AT = '2026-07-30T15:00:00.000Z';
+const UNSAFE_TOPOLOGY = /hardlink|nlink|link simbólico|junction|reparse|redirecion/i;
+const LINK_UNAVAILABLE = new Set(['EPERM', 'EACCES', 'ENOTSUP', 'EXDEV']);
+
+function checkpointFor(events) {
+  const reduced = reduceMemoryEvents(events);
+  return {
+    revision: reduced.revision,
+    event_cursor: reduced.eventCursor,
+    state_hash: reduced.stateHash,
+  };
+}
+
+function createFixture() {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-recover-topology-vault-'));
+  const outside = mkdtempSync(join(tmpdir(), 'wk-recover-topology-outside-'));
+  const brain = join(vault, '.brain');
+  const outbox = join(brain, 'memory-outbox');
+  mkdirSync(outbox, { recursive: true });
+
+  const event = {
+    v: 1,
+    project_id: PROJECT_ID,
+    event_id: EVENT_ID,
+    memory_key: 'handoff.latest',
+    operation: 'assert',
+    value: 'synthetic topology handoff',
+    authority: 'reported',
+    canonical_session_id: SESSION_ID,
+    activation_id: ACTIVATION_ID,
+    activation_epoch: 1,
+    turn_sequence: 1,
+    source_turn_id: TURN_ID,
+    observed_at: OBSERVED_AT,
+    evidence: ['synthetic-topology-evidence'],
+  };
+  const projection = prepareMemoryProjection(vault, [event]);
+  const paths = {
+    project: join(brain, 'PROJECT.json'),
+    core: join(brain, 'CORE.md'),
+    ledger: join(brain, 'MEMORY_EVENTS.jsonl'),
+    shared: join(brain, 'SHARED_MEMORY.md'),
+    candidates: join(brain, 'MEMORY_CANDIDATES.jsonl'),
+    registry: join(brain, 'SESSION_REGISTRY.json'),
+    outbox,
+  };
+  writeFileSync(paths.project, `${JSON.stringify({
+    schemaVersion: 2,
+    projectId: PROJECT_ID,
+  })}\n`);
+  writeFileSync(paths.core, renderCoreSkeleton());
+  writeFileSync(paths.ledger, `${canonicalMemoryJson(event)}\n`);
+  writeFileSync(paths.shared, projection.sharedContent);
+  writeFileSync(paths.candidates, projection.candidatesContent);
+  writeFileSync(paths.registry, `${JSON.stringify({
+    version: 2,
+    sessions: {
+      [SESSION_ID]: {
+        status: 'active',
+        activation_id: ACTIVATION_ID,
+        active_activation_id: ACTIVATION_ID,
+        activation_epoch: 1,
+        last_turn_id: TURN_ID,
+        last_turn_sequence: 1,
+        last_prompt_turn_id: TURN_ID,
+        turn_sequences: { [TURN_ID]: 1 },
+        activations: {
+          [ACTIVATION_ID]: {
+            activation_id: ACTIVATION_ID,
+            epoch: 1,
+            status: 'active',
+            last_turn_sequence: 1,
+            last_prompt_turn_id: TURN_ID,
+            last_stop_turn_id: TURN_ID,
+            last_stop_turn_sequence: 1,
+          },
+        },
+        memory_status: 'enqueued',
+        memory_activation_id: ACTIVATION_ID,
+        memory_checkpoint: checkpointFor([]),
+        last_memory_attempt: {
+          v: 1,
+          memory_mode: 'v2',
+          canonical_session_id: SESSION_ID,
+          activation_id: ACTIVATION_ID,
+          activation_epoch: 1,
+          turn_id: TURN_ID,
+          turn_sequence: 1,
+          observed_at: OBSERVED_AT,
+          disposition: 'applied',
+          state: 'enqueued',
+          event_ids: [EVENT_ID],
+          checkpoint: null,
+        },
+      },
+    },
+  }, null, 2)}\n`);
+
+  return { vault, outside, brain, paths };
+}
+
+function snapshotAuthority(fixture) {
+  const files = {};
+  for (const [name, path] of Object.entries(fixture.paths)) {
+    if (name === 'outbox') continue;
+    files[name] = readFileSync(path);
+  }
+  return {
+    files,
+    outboxEntries: readdirSync(fixture.paths.outbox).sort(),
+  };
+}
+
+function assertNoWrite(before, fixture, outsidePath, outsideBytes) {
+  const after = snapshotAuthority(fixture);
+  assert.deepEqual(after.files.registry, before.files.registry, 'registry fica byte-idêntico');
+  assert.deepEqual(after, before, 'nenhum artefato de autoridade é alterado');
+  assert.equal(existsSync(outsidePath), true, 'origem externa continua existindo');
+  assert.deepEqual(readFileSync(outsidePath), outsideBytes, 'origem externa fica byte-idêntica');
+}
+
+function replaceFileWithLink(fixture, name, kind) {
+  const target = fixture.paths[name];
+  const bytes = readFileSync(target);
+  const outsidePath = join(fixture.outside, `${kind}-${name}`);
+  writeFileSync(outsidePath, bytes);
+  unlinkSync(target);
+  if (kind === 'hardlink') linkSync(outsidePath, target);
+  else symlinkSync(outsidePath, target, 'file');
+  return { outsidePath, outsideBytes: bytes };
+}
+
+function rejectApplyWithoutWrites(fixture, outsidePath, outsideBytes) {
+  const before = snapshotAuthority(fixture);
+  let thrown;
+  try {
+    recoverProjectedAttempt(fixture.vault, {
+      sessionId: SESSION_ID,
+      apply: true,
+    });
+  } catch (error) {
+    thrown = error;
+  }
+  assertNoWrite(before, fixture, outsidePath, outsideBytes);
+  assert.ok(thrown, 'apply deve falhar fechado em topologia insegura');
+  assert.match(String(thrown?.message || thrown), UNSAFE_TOPOLOGY);
+}
+
+test('[req:MEM-ACK-3] [sensor:memory-recovery] recover-attempt rejeita hardlinks em toda autoridade baseada em arquivo', async (t) => {
+  for (const name of ['ledger', 'shared', 'candidates', 'registry']) {
+    await t.test(name, (subtest) => {
+      const fixture = createFixture();
+      try {
+        let linked;
+        try {
+          linked = replaceFileWithLink(fixture, name, 'hardlink');
+        } catch (error) {
+          if (LINK_UNAVAILABLE.has(error?.code)) {
+            subtest.skip(`hardlink indisponível neste filesystem: ${error.code}`);
+            return;
+          }
+          throw error;
+        }
+        rejectApplyWithoutWrites(
+          fixture, linked.outsidePath, linked.outsideBytes,
+        );
+      } finally {
+        rmSync(fixture.vault, { recursive: true, force: true });
+        rmSync(fixture.outside, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test('[req:MEM-ACK-3] [sensor:memory-recovery] recover-attempt rejeita symlinks em toda autoridade baseada em arquivo', async (t) => {
+  for (const name of ['ledger', 'shared', 'candidates', 'registry']) {
+    await t.test(name, (subtest) => {
+      const fixture = createFixture();
+      try {
+        let linked;
+        try {
+          linked = replaceFileWithLink(fixture, name, 'symlink');
+        } catch (error) {
+          if (LINK_UNAVAILABLE.has(error?.code)) {
+            subtest.skip(`symlink indisponível neste filesystem: ${error.code}`);
+            return;
+          }
+          throw error;
+        }
+        rejectApplyWithoutWrites(
+          fixture, linked.outsidePath, linked.outsideBytes,
+        );
+      } finally {
+        rmSync(fixture.vault, { recursive: true, force: true });
+        rmSync(fixture.outside, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test('[req:MEM-ACK-3] [sensor:memory-recovery] recover-attempt rejeita outbox redirecionada por junction', (t) => {
+  const fixture = createFixture();
+  try {
+    const outsidePath = join(fixture.outside, 'sentinel.json');
+    const outsideBytes = Buffer.from('{"synthetic":"outside-outbox"}\n');
+    writeFileSync(outsidePath, outsideBytes);
+    rmSync(fixture.paths.outbox, { recursive: true, force: true });
+    try {
+      symlinkSync(
+        fixture.outside,
+        fixture.paths.outbox,
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
+    } catch (error) {
+      if (LINK_UNAVAILABLE.has(error?.code)) {
+        t.skip(`junction/symlink de diretório indisponível neste filesystem: ${error.code}`);
+        return;
+      }
+      throw error;
+    }
+
+    rejectApplyWithoutWrites(fixture, outsidePath, outsideBytes);
+  } finally {
+    rmSync(fixture.vault, { recursive: true, force: true });
+    rmSync(fixture.outside, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-ACK-3] [sensor:memory-recovery] recover-attempt rejeita membro hardlinked no namespace físico da outbox', (t) => {
+  const fixture = createFixture();
+  try {
+    const outsidePath = join(fixture.outside, 'other-attempt.json');
+    const outsideBytes = Buffer.from('{"synthetic":"other-attempt"}\n');
+    writeFileSync(outsidePath, outsideBytes);
+    try {
+      linkSync(outsidePath, join(fixture.paths.outbox, 'synthetic-other-event.json'));
+    } catch (error) {
+      if (LINK_UNAVAILABLE.has(error?.code)) {
+        t.skip(`hardlink indisponível neste filesystem: ${error.code}`);
+        return;
+      }
+      throw error;
+    }
+
+    rejectApplyWithoutWrites(fixture, outsidePath, outsideBytes);
+  } finally {
+    rmSync(fixture.vault, { recursive: true, force: true });
+    rmSync(fixture.outside, { recursive: true, force: true });
+  }
+});

--- a/tests/memory-attempt-recovery.test.mjs
+++ b/tests/memory-attempt-recovery.test.mjs
@@ -1,0 +1,760 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  canonicalMemoryJson,
+  prepareMemoryProjection,
+  reduceMemoryEvents,
+} from '../hooks/memory-store.mjs';
+import { renderCoreSkeleton } from '../src/validate-core.mjs';
+
+const BIN = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'wendkeep.mjs');
+const PROJECT_ID = 'synthetic-project-1';
+const SESSION_ID = 'synthetic-session-1';
+const ACTIVATION_ID = 'synthetic-activation-1';
+const TURN_ID = 'synthetic-turn-1';
+const EVENT_ID = 'synthetic-event-1';
+const OBSERVED_AT = '2026-07-30T12:00:00.000Z';
+
+function checkpointFor(events) {
+  const reduced = reduceMemoryEvents(events);
+  return {
+    revision: reduced.revision,
+    event_cursor: reduced.eventCursor,
+    state_hash: reduced.stateHash,
+  };
+}
+
+function createFixture({ state = 'enqueued' } = {}) {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-synthetic-attempt-recovery-'));
+  const brain = join(vault, '.brain');
+  const outbox = join(brain, 'memory-outbox');
+  mkdirSync(outbox, { recursive: true });
+  writeFileSync(join(brain, 'PROJECT.json'), `${JSON.stringify({
+    schemaVersion: 2,
+    projectId: PROJECT_ID,
+  })}\n`);
+  writeFileSync(join(brain, 'CORE.md'), renderCoreSkeleton());
+
+  const event = {
+    v: 1,
+    project_id: PROJECT_ID,
+    event_id: EVENT_ID,
+    memory_key: 'handoff.latest',
+    operation: 'assert',
+    value: 'synthetic projected handoff',
+    authority: 'reported',
+    canonical_session_id: SESSION_ID,
+    activation_id: ACTIVATION_ID,
+    activation_epoch: 1,
+    turn_sequence: 1,
+    source_turn_id: TURN_ID,
+    observed_at: OBSERVED_AT,
+    evidence: ['synthetic-evidence-1'],
+  };
+  const projection = prepareMemoryProjection(vault, [event]);
+  const previousCheckpoint = checkpointFor([]);
+  writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), `${canonicalMemoryJson(event)}\n`);
+  writeFileSync(join(brain, 'SHARED_MEMORY.md'), projection.sharedContent);
+  writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), projection.candidatesContent);
+  writeFileSync(join(brain, 'SESSION_REGISTRY.json'), `${JSON.stringify({
+    version: 2,
+    sessions: {
+      [SESSION_ID]: {
+        status: 'active',
+        activation_id: ACTIVATION_ID,
+        active_activation_id: ACTIVATION_ID,
+        activation_epoch: 1,
+        last_turn_id: TURN_ID,
+        last_turn_sequence: 1,
+        last_prompt_turn_id: TURN_ID,
+        turn_sequences: { [TURN_ID]: 1 },
+        activations: {
+          [ACTIVATION_ID]: {
+            activation_id: ACTIVATION_ID,
+            epoch: 1,
+            status: 'active',
+            last_turn_sequence: 1,
+            last_prompt_turn_id: TURN_ID,
+            last_stop_turn_id: TURN_ID,
+            last_stop_turn_sequence: 1,
+          },
+        },
+        memory_status: state,
+        memory_activation_id: ACTIVATION_ID,
+        memory_checkpoint: previousCheckpoint,
+        last_memory_attempt: {
+          v: 1,
+          memory_mode: 'v2',
+          canonical_session_id: SESSION_ID,
+          activation_id: ACTIVATION_ID,
+          activation_epoch: 1,
+          turn_id: TURN_ID,
+          turn_sequence: 1,
+          observed_at: OBSERVED_AT,
+          disposition: 'applied',
+          state,
+          event_ids: [EVENT_ID],
+          checkpoint: null,
+        },
+      },
+    },
+  }, null, 2)}\n`);
+
+  return {
+    vault,
+    brain,
+    outbox,
+    checkpoint: projection.checkpoint,
+    event,
+    paths: {
+      registry: join(brain, 'SESSION_REGISTRY.json'),
+      ledger: join(brain, 'MEMORY_EVENTS.jsonl'),
+      core: join(brain, 'CORE.md'),
+      shared: join(brain, 'SHARED_MEMORY.md'),
+      candidates: join(brain, 'MEMORY_CANDIDATES.jsonl'),
+      project: join(brain, 'PROJECT.json'),
+    },
+  };
+}
+
+function snapshotDirectory(path) {
+  if (!existsSync(path)) return null;
+  const snapshot = {};
+  function visit(directory, prefix = '') {
+    for (const entry of readdirSync(directory, { withFileTypes: true })
+      .sort((left, right) => left.name.localeCompare(right.name))) {
+      const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+      const target = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        snapshot[`${relative}/`] = null;
+        visit(target, relative);
+      } else {
+        snapshot[relative] = readFileSync(target);
+      }
+    }
+  }
+  visit(path);
+  return snapshot;
+}
+
+function snapshotFixture(fixture, { includeLock = false } = {}) {
+  return {
+    registry: readFileSync(fixture.paths.registry),
+    ledger: readFileSync(fixture.paths.ledger),
+    core: readFileSync(fixture.paths.core),
+    shared: readFileSync(fixture.paths.shared),
+    candidates: readFileSync(fixture.paths.candidates),
+    project: readFileSync(fixture.paths.project),
+    outbox: snapshotDirectory(fixture.outbox),
+    ...(includeLock ? { lock: snapshotDirectory(join(fixture.brain, 'MEMORY.lock')) } : {}),
+  };
+}
+
+function readRegistry(fixture) {
+  return JSON.parse(readFileSync(fixture.paths.registry, 'utf8'));
+}
+
+function writeRegistry(fixture, registry) {
+  writeFileSync(fixture.paths.registry, `${JSON.stringify(registry, null, 2)}\n`);
+}
+
+function writeLedgerAndProjection(fixture, events, ledgerContent) {
+  const projection = prepareMemoryProjection(fixture.vault, events);
+  writeFileSync(
+    fixture.paths.ledger,
+    ledgerContent ?? `${events.map(canonicalMemoryJson).join('\n')}${events.length ? '\n' : ''}`,
+  );
+  writeFileSync(fixture.paths.shared, projection.sharedContent);
+  writeFileSync(fixture.paths.candidates, projection.candidatesContent);
+  return projection;
+}
+
+function assertRejectedWithoutWrites(fixture, action, error, message) {
+  const before = snapshotFixture(fixture);
+  let thrown;
+  try {
+    action();
+  } catch (caught) {
+    thrown = caught;
+  }
+  assert.deepEqual(snapshotFixture(fixture), before, message);
+  assert.ok(thrown, `${message}: expected recovery to reject`);
+  assert.match(String(thrown?.message || thrown), error);
+}
+
+function runRecoverAttempt(args) {
+  return spawnSync(process.execPath, [BIN, 'memory', 'recover-attempt', ...args], {
+    encoding: 'utf8',
+  });
+}
+
+test('[req:MEM-ACK-2] [req:MEM-ACK-3] [sensor:memory-recovery] recover-attempt repairs an already projected 0.66.3 attempt', async () => {
+  const {
+    inspectProjectedAttemptRecovery,
+    recoverProjectedAttempt,
+  } = await import('../src/memory.mjs');
+  const fixture = createFixture();
+  try {
+    const before = snapshotFixture(fixture);
+
+    const inspection = inspectProjectedAttemptRecovery(fixture.vault, {
+      sessionId: SESSION_ID,
+    });
+    assert.equal(inspection.status, 'eligible');
+    assert.equal(inspection.eligible, true);
+    assert.deepEqual(inspection.checkpoint, fixture.checkpoint);
+    assert.deepEqual(snapshotFixture(fixture), before, 'inspect must not change any byte');
+
+    const dryRun = recoverProjectedAttempt(fixture.vault, {
+      sessionId: SESSION_ID,
+    });
+    assert.equal(dryRun.status, 'dry-run');
+    assert.equal(dryRun.eligible, true);
+    assert.deepEqual(dryRun.checkpoint, fixture.checkpoint);
+    assert.deepEqual(snapshotFixture(fixture), before, 'dry-run must not change any byte');
+
+    const applied = recoverProjectedAttempt(fixture.vault, {
+      sessionId: SESSION_ID,
+      apply: true,
+    });
+    assert.equal(applied.status, 'applied');
+    assert.deepEqual(applied.checkpoint, fixture.checkpoint);
+
+    const afterApply = snapshotFixture(fixture);
+    assert.notDeepEqual(afterApply.registry, before.registry, 'apply must update the registry');
+    assert.deepEqual(afterApply.ledger, before.ledger, 'ledger stays byte-identical');
+    assert.deepEqual(afterApply.core, before.core, 'CORE stays byte-identical');
+    assert.deepEqual(afterApply.shared, before.shared, 'SHARED stays byte-identical');
+    assert.deepEqual(afterApply.candidates, before.candidates, 'candidates stay byte-identical');
+    assert.deepEqual(afterApply.project, before.project, 'project authority stays byte-identical');
+    assert.deepEqual(afterApply.outbox, before.outbox, 'empty outbox stays byte-identical');
+
+    const registry = JSON.parse(afterApply.registry.toString('utf8'));
+    const recovered = registry.sessions[SESSION_ID];
+    assert.equal(recovered.memory_status, 'projected');
+    assert.equal(recovered.last_memory_attempt.state, 'projected');
+    assert.deepEqual(recovered.last_memory_attempt.checkpoint, fixture.checkpoint);
+    assert.deepEqual(recovered.memory_checkpoint, fixture.checkpoint);
+
+    const beforeRetry = snapshotFixture(fixture);
+    const retry = recoverProjectedAttempt(fixture.vault, {
+      sessionId: SESSION_ID,
+      apply: true,
+    });
+    assert.equal(retry.status, 'unchanged');
+    assert.deepEqual(snapshotFixture(fixture), beforeRetry, 'second apply must be byte-idempotent');
+  } finally {
+    rmSync(fixture.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-ACK-2] [req:MEM-ACK-3] [sensor:memory-recovery] recover-attempt repairs a degraded projected attempt and changes only registry', async () => {
+  const { recoverProjectedAttempt } = await import('../src/memory.mjs');
+  const fixture = createFixture({ state: 'degraded' });
+  try {
+    const before = snapshotFixture(fixture);
+    const recovered = recoverProjectedAttempt(fixture.vault, {
+      sessionId: SESSION_ID,
+      apply: true,
+    });
+    const after = snapshotFixture(fixture);
+
+    assert.equal(recovered.status, 'applied');
+    assert.deepEqual(recovered.checkpoint, fixture.checkpoint);
+    assert.notDeepEqual(after.registry, before.registry);
+    assert.deepEqual(
+      { ...after, registry: before.registry },
+      before,
+      'degraded recovery must not change any artifact outside SESSION_REGISTRY',
+    );
+    const entry = readRegistry(fixture).sessions[SESSION_ID];
+    assert.equal(entry.memory_status, 'projected');
+    assert.equal(entry.last_memory_attempt.state, 'projected');
+    assert.deepEqual(entry.memory_checkpoint, fixture.checkpoint);
+    assert.deepEqual(entry.last_memory_attempt.checkpoint, fixture.checkpoint);
+  } finally {
+    rmSync(fixture.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-ACK-2] [req:MEM-ACK-3] [sensor:memory-recovery] recover-attempt rejects incomplete or non-unique ledger proof with zero writes', async (t) => {
+  const { recoverProjectedAttempt } = await import('../src/memory.mjs');
+  const cases = [
+    {
+      name: 'attempt event id absent from ledger',
+      arrange(fixture) {
+        const registry = readRegistry(fixture);
+        registry.sessions[SESSION_ID].last_memory_attempt.event_ids = ['synthetic-event-missing'];
+        writeRegistry(fixture, registry);
+      },
+      error: /event_ids?.*ausent|ausent.*ledger/i,
+    },
+    {
+      name: 'physically duplicated identical event id',
+      arrange(fixture) {
+        const line = canonicalMemoryJson(fixture.event);
+        writeFileSync(fixture.paths.ledger, `${line}\n${line}\n`);
+      },
+      error: /duplicad.*event_id|event_id.*duplicad/i,
+    },
+    {
+      name: 'divergent event id collision',
+      arrange(fixture) {
+        const collision = {
+          ...fixture.event,
+          value: 'synthetic divergent collision payload',
+        };
+        writeFileSync(
+          fixture.paths.ledger,
+          `${canonicalMemoryJson(fixture.event)}\n${canonicalMemoryJson(collision)}\n`,
+        );
+      },
+      error: /collision|colis[aã]o|duplicad/i,
+    },
+    {
+      name: 'partial ledger tail',
+      arrange(fixture) {
+        writeFileSync(
+          fixture.paths.ledger,
+          `${canonicalMemoryJson(fixture.event)}\n{"v":1,"event_id":"synthetic-partial-tail"`,
+        );
+      },
+      error: /ledger.*inv[aá]lid|JSON|parcial|partial/i,
+    },
+  ];
+
+  for (const scenario of cases) {
+    await t.test(scenario.name, () => {
+      const fixture = createFixture();
+      try {
+        scenario.arrange(fixture);
+        assertRejectedWithoutWrites(
+          fixture,
+          () => recoverProjectedAttempt(fixture.vault, {
+            sessionId: SESSION_ID,
+            apply: true,
+          }),
+          scenario.error,
+          `${scenario.name} must leave every artifact byte-identical`,
+        );
+      } finally {
+        rmSync(fixture.vault, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test('[req:MEM-ACK-2] [req:MEM-ACK-3] [sensor:memory-recovery] recover-attempt isolates each divergent causal identity field with zero writes', async (t) => {
+  const { recoverProjectedAttempt } = await import('../src/memory.mjs');
+  const cases = [
+    ['project_id', 'synthetic-project-divergent'],
+    ['canonical_session_id', 'synthetic-session-divergent'],
+    ['activation_id', 'synthetic-activation-divergent'],
+    ['activation_epoch', 2],
+    ['source_turn_id', 'synthetic-turn-divergent'],
+    ['turn_sequence', 2],
+  ];
+
+  for (const [field, divergentValue] of cases) {
+    await t.test(field, () => {
+      const fixture = createFixture();
+      try {
+        const divergentEvent = { ...fixture.event, [field]: divergentValue };
+        writeLedgerAndProjection(fixture, [divergentEvent]);
+        assertRejectedWithoutWrites(
+          fixture,
+          () => recoverProjectedAttempt(fixture.vault, {
+            sessionId: SESSION_ID,
+            apply: true,
+          }),
+          /projeto|project|identidade causal|contexto causal/i,
+          `${field} divergence must leave every artifact byte-identical`,
+        );
+      } finally {
+        rmSync(fixture.vault, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test('[req:MEM-ACK-2] [req:MEM-ACK-3] [sensor:memory-recovery] recover-attempt rejects stale deriveds and target outbox ownership with zero writes', async (t) => {
+  const { recoverProjectedAttempt } = await import('../src/memory.mjs');
+  const cases = [
+    {
+      name: 'SHARED stale',
+      arrange(fixture) {
+        writeFileSync(fixture.paths.shared, `${readFileSync(fixture.paths.shared, 'utf8')}synthetic stale SHARED\n`);
+      },
+      error: /SHARED.*diverg|SHARED.*autoridade/i,
+    },
+    {
+      name: 'candidates stale',
+      arrange(fixture) {
+        writeFileSync(fixture.paths.candidates, '{"synthetic":"stale-candidates"}\n');
+      },
+      error: /candidates.*diverg|candidates.*autoridade/i,
+    },
+    {
+      name: 'target event remains in outbox',
+      arrange(fixture) {
+        writeFileSync(
+          join(fixture.outbox, `${EVENT_ID}.json`),
+          `${canonicalMemoryJson(fixture.event)}\n`,
+        );
+      },
+      error: /outbox.*evento alvo|evento alvo.*outbox/i,
+    },
+  ];
+
+  for (const scenario of cases) {
+    await t.test(scenario.name, () => {
+      const fixture = createFixture();
+      try {
+        scenario.arrange(fixture);
+        assertRejectedWithoutWrites(
+          fixture,
+          () => recoverProjectedAttempt(fixture.vault, {
+            sessionId: SESSION_ID,
+            apply: true,
+          }),
+          scenario.error,
+          `${scenario.name} must leave every artifact byte-identical`,
+        );
+      } finally {
+        rmSync(fixture.vault, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test('[req:MEM-ACK-3] [sensor:memory-recovery] recover-attempt rejects a target event stored under a non-canonical safe outbox name with zero writes', async () => {
+  const { recoverProjectedAttempt } = await import('../src/memory.mjs');
+  const fixture = createFixture();
+  try {
+    writeFileSync(
+      join(fixture.outbox, 'misnamed.json'),
+      `${canonicalMemoryJson(fixture.event)}\n`,
+    );
+
+    assertRejectedWithoutWrites(
+      fixture,
+      () => recoverProjectedAttempt(fixture.vault, {
+        sessionId: SESSION_ID,
+        apply: true,
+      }),
+      /outbox.*evento alvo|evento alvo.*outbox/i,
+      'misnamed target outbox event must leave registry, ledger, SHARED, candidates, and outbox byte-identical',
+    );
+  } finally {
+    rmSync(fixture.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-ACK-3] [sensor:memory-recovery] recover-attempt loses CAS for each newer registry dimension and preserves the injected bytes', async (t) => {
+  const { recoverProjectedAttempt } = await import('../src/memory.mjs');
+  const newerCheckpoint = {
+    revision: 41,
+    event_cursor: 'synthetic-event-newer-checkpoint',
+    causal_event_cursor: 'synthetic-event-newer-checkpoint',
+    state_hash: 'synthetic-state-newer-checkpoint',
+  };
+  const cases = [
+    {
+      name: 'newer activation',
+      mutate(entry) {
+        entry.active_activation_id = 'synthetic-activation-newer';
+        entry.activation_epoch = 2;
+        entry.activations['synthetic-activation-newer'] = {
+          activation_id: 'synthetic-activation-newer',
+          epoch: 2,
+          status: 'active',
+          last_turn_sequence: 0,
+        };
+      },
+    },
+    {
+      name: 'newer epoch',
+      mutate(entry) {
+        entry.activation_epoch = 2;
+        entry.activations[ACTIVATION_ID].epoch = 2;
+      },
+    },
+    {
+      name: 'newer turn',
+      mutate(entry) {
+        entry.last_turn_id = 'synthetic-turn-newer';
+        entry.last_turn_sequence = 2;
+        entry.turn_sequences['synthetic-turn-newer'] = 2;
+        entry.activations[ACTIVATION_ID].last_turn_sequence = 2;
+        entry.activations[ACTIVATION_ID].last_stop_turn_id = 'synthetic-turn-newer';
+        entry.activations[ACTIVATION_ID].last_stop_turn_sequence = 2;
+      },
+    },
+    {
+      name: 'newer attempt',
+      mutate(entry) {
+        entry.last_memory_attempt = {
+          ...entry.last_memory_attempt,
+          observed_at: '2026-07-30T12:01:00.000Z',
+        };
+      },
+    },
+    {
+      name: 'newer checkpoint',
+      mutate(entry) {
+        entry.memory_checkpoint = newerCheckpoint;
+      },
+    },
+  ];
+
+  for (const scenario of cases) {
+    await t.test(scenario.name, () => {
+      const fixture = createFixture();
+      let injectedSnapshot;
+      let thrown;
+      try {
+        try {
+          recoverProjectedAttempt(fixture.vault, {
+            sessionId: SESSION_ID,
+            apply: true,
+            beforeRegistryMutation() {
+              const registry = readRegistry(fixture);
+              scenario.mutate(registry.sessions[SESSION_ID]);
+              writeRegistry(fixture, registry);
+              injectedSnapshot = snapshotFixture(fixture);
+            },
+          });
+        } catch (caught) {
+          thrown = caught;
+        }
+
+        assert.ok(injectedSnapshot, `${scenario.name} must execute the deterministic race hook`);
+        assert.deepEqual(
+          snapshotFixture(fixture),
+          injectedSnapshot,
+          `${scenario.name} must not be overwritten or supplemented by recovery`,
+        );
+        assert.ok(thrown, `${scenario.name} must reject the lost CAS`);
+        assert.match(String(thrown.message || thrown), /CAS|contexto causal|attempt|checkpoint|mudou/i);
+      } finally {
+        rmSync(fixture.vault, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test('[req:MEM-ACK-3] [sensor:memory-recovery] recover-attempt detects an exact A-B-A registry race with zero recovery writes', async () => {
+  const { recoverProjectedAttempt } = await import('../src/memory.mjs');
+  const fixture = createFixture();
+  let restoredSnapshot;
+  let thrown;
+  try {
+    try {
+      recoverProjectedAttempt(fixture.vault, {
+        sessionId: SESSION_ID,
+        apply: true,
+        beforeRegistryMutation() {
+          const original = readFileSync(fixture.paths.registry);
+          const registry = JSON.parse(original.toString('utf8'));
+          registry.sessions[SESSION_ID].activation_id = 'synthetic-activation-b';
+          writeRegistry(fixture, registry);
+          writeFileSync(fixture.paths.registry, original);
+          restoredSnapshot = snapshotFixture(fixture);
+        },
+      });
+    } catch (caught) {
+      thrown = caught;
+    }
+
+    assert.ok(restoredSnapshot, 'A-B-A hook must execute');
+    const after = snapshotFixture(fixture);
+    assert.deepEqual(
+      { ...after, registry: restoredSnapshot.registry },
+      restoredSnapshot,
+      'exact A-B-A must leave every non-registry artifact byte-identical',
+    );
+    assert.equal(
+      after.registry.equals(restoredSnapshot.registry),
+      true,
+      'exact A-B-A must not be followed by a recovery registry write',
+    );
+    assert.ok(thrown, 'exact A-B-A must reject the lost CAS');
+    assert.match(String(thrown.message || thrown), /CAS|A-B-A|mudou/i);
+  } finally {
+    rmSync(fixture.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-ACK-3] [sensor:memory-recovery] MEMORY.lock busy rejects recover-attempt and preserves every artifact including the lock', async () => {
+  const { recoverProjectedAttempt } = await import('../src/memory.mjs');
+  const fixture = createFixture();
+  const lock = join(fixture.brain, 'MEMORY.lock');
+  try {
+    mkdirSync(lock);
+    const before = snapshotFixture(fixture, { includeLock: true });
+    let thrown;
+    try {
+      recoverProjectedAttempt(fixture.vault, {
+        sessionId: SESSION_ID,
+        apply: true,
+        memoryLock: { timeoutMs: 20, staleMs: 60_000 },
+      });
+    } catch (caught) {
+      thrown = caught;
+    }
+
+    assert.deepEqual(
+      snapshotFixture(fixture, { includeLock: true }),
+      before,
+      'busy MEMORY.lock and every memory artifact must remain byte-identical',
+    );
+    assert.ok(thrown, 'busy MEMORY.lock must reject recovery');
+    assert.equal(thrown.code, 'WENDKEEP_MEMORY_LOCK_BUSY');
+    assert.match(thrown.message, /MEMORY\.lock.*indispon[ií]vel|lock.*ocupad/i);
+  } finally {
+    rmSync(fixture.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-ACK-3] [sensor:memory-recovery] projected retry keeps its valid historical checkpoint instead of refreshing to the ledger tip', async () => {
+  const {
+    inspectProjectedAttemptRecovery,
+    recoverProjectedAttempt,
+  } = await import('../src/memory.mjs');
+  const fixture = createFixture();
+  try {
+    const laterEvent = {
+      ...fixture.event,
+      event_id: 'synthetic-event-later-other-session',
+      memory_key: 'handoff.other.latest',
+      value: 'synthetic later handoff from another session',
+      canonical_session_id: 'synthetic-session-other',
+      activation_id: 'synthetic-activation-other',
+      source_turn_id: 'synthetic-turn-other',
+      observed_at: '2026-07-30T12:02:00.000Z',
+    };
+    const latestProjection = writeLedgerAndProjection(fixture, [fixture.event, laterEvent]);
+    assert.notDeepEqual(latestProjection.checkpoint, fixture.checkpoint);
+
+    const registry = readRegistry(fixture);
+    const entry = registry.sessions[SESSION_ID];
+    entry.memory_status = 'projected';
+    entry.memory_checkpoint = fixture.checkpoint;
+    entry.last_memory_attempt.state = 'projected';
+    entry.last_memory_attempt.checkpoint = fixture.checkpoint;
+    writeRegistry(fixture, registry);
+    const before = snapshotFixture(fixture);
+
+    const inspection = inspectProjectedAttemptRecovery(fixture.vault, {
+      sessionId: SESSION_ID,
+    });
+    assert.equal(inspection.status, 'unchanged');
+    assert.deepEqual(inspection.checkpoint, fixture.checkpoint);
+    assert.deepEqual(snapshotFixture(fixture), before);
+
+    const retry = recoverProjectedAttempt(fixture.vault, {
+      sessionId: SESSION_ID,
+      apply: true,
+    });
+    assert.equal(retry.status, 'unchanged');
+    assert.deepEqual(retry.checkpoint, fixture.checkpoint);
+    assert.notDeepEqual(retry.checkpoint, latestProjection.checkpoint);
+    assert.deepEqual(
+      snapshotFixture(fixture),
+      before,
+      'projected retry must preserve every byte and the historical checkpoint',
+    );
+  } finally {
+    rmSync(fixture.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-ACK-2] [sensor:memory-recovery] CLI recover-attempt dry-run reports status without changing Vault bytes', () => {
+  const fixture = createFixture();
+  try {
+    const before = snapshotFixture(fixture);
+    const result = runRecoverAttempt([SESSION_ID, '--vault', fixture.vault]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).status, 'dry-run');
+    assert.deepEqual(snapshotFixture(fixture), before, 'CLI dry-run must not change any byte');
+  } finally {
+    rmSync(fixture.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-ACK-2] [req:MEM-ACK-3] [sensor:memory-recovery] CLI recover-attempt apply reports applied and retry is byte-idempotent', () => {
+  const fixture = createFixture();
+  try {
+    const applied = runRecoverAttempt([SESSION_ID, '--apply', '--vault', fixture.vault]);
+    assert.equal(applied.status, 0, applied.stderr);
+    assert.equal(JSON.parse(applied.stdout).status, 'applied');
+
+    const beforeRetry = snapshotFixture(fixture);
+    const retry = runRecoverAttempt([SESSION_ID, '--apply', '--vault', fixture.vault]);
+    assert.equal(retry.status, 0, retry.stderr);
+    assert.equal(JSON.parse(retry.stdout).status, 'unchanged');
+    assert.deepEqual(snapshotFixture(fixture), beforeRetry, 'CLI retry must not change any byte');
+  } finally {
+    rmSync(fixture.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-ACK-2] [sensor:memory-recovery] CLI recover-attempt rejects malformed arguments before touching the Vault', async (t) => {
+  const missingVault = join(tmpdir(), `wk-missing-attempt-recovery-${process.pid}-${Date.now()}`);
+  const cases = [
+    {
+      name: 'missing session',
+      args: ['--vault', missingVault],
+      error: /recover-attempt.*sess[aã]o|sess[aã]o.*obrigat[oó]ri/i,
+    },
+    {
+      name: 'extra positional',
+      args: [SESSION_ID, 'synthetic-extra', '--vault', missingVault],
+      error: /posicional extra.*synthetic-extra/i,
+    },
+    {
+      name: 'duplicate --apply',
+      args: [SESSION_ID, '--apply', '--apply', '--vault', missingVault],
+      error: /duplicad.*--apply|--apply.*duplicad/i,
+    },
+    {
+      name: 'duplicate --vault',
+      args: [SESSION_ID, '--vault', missingVault, '--vault', missingVault],
+      error: /duplicad.*--vault|--vault.*duplicad/i,
+    },
+    {
+      name: 'unknown flag',
+      args: [SESSION_ID, '--synthetic-unknown', '--vault', missingVault],
+      error: /op[cç][aã]o desconhecida.*--synthetic-unknown/i,
+    },
+    {
+      name: 'flag value starts with --',
+      args: [SESSION_ID, '--vault', '--apply'],
+      error: /--vault.*valor|valor.*--vault/i,
+    },
+  ];
+
+  for (const scenario of cases) {
+    await t.test(scenario.name, () => {
+      const result = runRecoverAttempt(scenario.args);
+      assert.equal(result.status, 2, result.stderr);
+      assert.match(result.stderr, scenario.error);
+      assert.doesNotMatch(result.stderr, /not found/i);
+    });
+  }
+});

--- a/tests/memory-cli.test.mjs
+++ b/tests/memory-cli.test.mjs
@@ -11,7 +11,7 @@ import { join } from 'node:path';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  canonicalMemoryJson, deriveMemoryProjection, hashMemoryValue, prepareMemoryProjection,
+  canonicalMemoryJson, deriveMemoryProjection, enqueueMemoryEvent, hashMemoryValue, prepareMemoryProjection,
   reduceMemoryEvents,
 } from '../hooks/memory-store.mjs';
 import { renderSharedMemory } from '../hooks/memory-schema.mjs';
@@ -942,6 +942,472 @@ test('memory repair preserva bytes corrompidos em backup antes de reconstruir', 
     assert.ok(existsSync(result.repaired.backupPath));
     assert.equal(readFileSync(result.repaired.backupPath, 'utf8'), '{parcial');
     assert.equal(readFileSync(ledgerPath, 'utf8'), '');
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+function enqueuedMemoryEntry(sessionId, event, checkpointValue, eventIds = [event.event_id]) {
+  return {
+    status: 'active',
+    active_activation_id: event.activation_id,
+    activation_epoch: event.activation_epoch,
+    last_turn_id: event.source_turn_id,
+    last_turn_sequence: event.turn_sequence,
+    turn_sequences: { [event.source_turn_id]: event.turn_sequence },
+    activations: {
+      [event.activation_id]: {
+        activation_id: event.activation_id,
+        epoch: event.activation_epoch,
+        status: 'active',
+        last_stop_turn_id: event.source_turn_id,
+        last_stop_turn_sequence: event.turn_sequence,
+        last_turn_sequence: event.turn_sequence,
+      },
+    },
+    memory_status: 'enqueued',
+    memory_activation_id: event.activation_id,
+    memory_checkpoint: checkpointValue,
+    last_memory_attempt: {
+      v: 1,
+      memory_mode: 'v2',
+      canonical_session_id: sessionId,
+      activation_id: event.activation_id,
+      activation_epoch: event.activation_epoch,
+      turn_id: event.source_turn_id,
+      turn_sequence: event.turn_sequence,
+      disposition: 'applied',
+      state: 'enqueued',
+      event_ids: eventIds,
+      checkpoint: null,
+    },
+  };
+}
+
+test('[req:MEM-ACK-1] [sensor:memory-recovery] repair acknowledges only its consumed outbox', async () => {
+  const vault = fixture();
+  const brain = join(vault, '.brain');
+  const ledgerPath = join(brain, 'MEMORY_EVENTS.jsonl');
+  const sharedPath = join(brain, 'SHARED_MEMORY.md');
+  const candidatesPath = join(brain, 'MEMORY_CANDIDATES.jsonl');
+  const corePath = join(brain, 'CORE.md');
+  const registryPath = join(brain, 'SESSION_REGISTRY.json');
+  const outboxPath = join(brain, 'memory-outbox');
+  const existing = {
+    ...memoryEvent('mem-repair-ack-existing', 'synthetic checkpoint N', 1),
+    memory_key: 'handoff.existing',
+  };
+  const pending = {
+    ...memoryEvent('mem-repair-ack-pending', 'synthetic consumed outbox', 2),
+    memory_key: 'handoff.pending',
+  };
+  const projectionN = writeMemoryProjection(vault, [existing]);
+  enqueueMemoryEvent(vault, pending);
+  writeFileSync(registryPath, `${JSON.stringify({
+    version: 2,
+    sessions: {
+      'current-session': {
+        status: 'active',
+        active_activation_id: pending.activation_id,
+        activation_epoch: pending.activation_epoch,
+        last_turn_id: pending.source_turn_id,
+        last_turn_sequence: pending.turn_sequence,
+        turn_sequences: { [pending.source_turn_id]: pending.turn_sequence },
+        activations: {
+          [pending.activation_id]: {
+            activation_id: pending.activation_id,
+            epoch: pending.activation_epoch,
+            status: 'active',
+            last_stop_turn_id: pending.source_turn_id,
+            last_stop_turn_sequence: pending.turn_sequence,
+            last_turn_sequence: pending.turn_sequence,
+          },
+        },
+        memory_status: 'enqueued',
+        memory_activation_id: pending.activation_id,
+        memory_checkpoint: projectionN.checkpoint,
+        last_memory_attempt: {
+          v: 1,
+          memory_mode: 'v2',
+          canonical_session_id: 'current-session',
+          activation_id: pending.activation_id,
+          activation_epoch: pending.activation_epoch,
+          turn_id: pending.source_turn_id,
+          turn_sequence: pending.turn_sequence,
+          disposition: 'applied',
+          state: 'enqueued',
+          event_ids: [pending.event_id],
+          checkpoint: null,
+        },
+      },
+    },
+  }, null, 2)}\n`);
+  const ledgerBefore = readFileSync(ledgerPath);
+  const sharedBefore = readFileSync(sharedPath);
+  const coreBefore = readFileSync(corePath);
+
+  try {
+    const { repairMemory } = await import('../src/memory.mjs');
+    const repaired = repairMemory(vault, { now: '2026-07-30T15:00:00.000Z' });
+    const ledgerAfter = readFileSync(ledgerPath);
+    const sharedAfter = readFileSync(sharedPath);
+    const registryAfter = JSON.parse(readFileSync(registryPath, 'utf8'));
+    const current = registryAfter.sessions['current-session'];
+
+    assert.equal(repaired.projection.appended, 1);
+    assert.equal(ledgerAfter.toString('utf8').trim().split('\n').length, 2);
+    assert.notDeepEqual(ledgerAfter, ledgerBefore);
+    assert.notDeepEqual(sharedAfter, sharedBefore);
+    assert.equal(readdirSync(outboxPath).length, 0);
+    assert.deepEqual(readFileSync(corePath), coreBefore);
+    assert.equal(current.memory_status, 'projected');
+    assert.equal(current.last_memory_attempt.state, 'projected');
+    assert.equal(current.last_memory_attempt.disposition, 'applied');
+    assert.deepEqual(current.last_memory_attempt.event_ids, [pending.event_id]);
+    assert.deepEqual(current.memory_checkpoint, repaired.projection.checkpoint);
+    assert.deepEqual(current.last_memory_attempt.checkpoint, repaired.projection.checkpoint);
+
+    const stableBytes = new Map([
+      [ledgerPath, readFileSync(ledgerPath)],
+      [sharedPath, readFileSync(sharedPath)],
+      [candidatesPath, readFileSync(candidatesPath)],
+      [corePath, readFileSync(corePath)],
+      [registryPath, readFileSync(registryPath)],
+    ]);
+    const retry = repairMemory(vault, { now: '2026-07-30T15:01:00.000Z' });
+    assert.equal(retry.projection.appended, 0);
+    assert.equal(retry.projection.consumed, 0);
+    for (const [path, bytes] of stableBytes) assert.deepEqual(readFileSync(path), bytes);
+    assert.equal(readdirSync(outboxPath).length, 0);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-ACK-1] [req:MEM-ACK-3] [sensor:memory-recovery] repair fails closed before acknowledging a physically duplicated ledger event', async () => {
+  const vault = fixture();
+  const brain = join(vault, '.brain');
+  const ledgerPath = join(brain, 'MEMORY_EVENTS.jsonl');
+  const sharedPath = join(brain, 'SHARED_MEMORY.md');
+  const candidatesPath = join(brain, 'MEMORY_CANDIDATES.jsonl');
+  const registryPath = join(brain, 'SESSION_REGISTRY.json');
+  const pending = {
+    ...memoryEvent('mem-repair-duplicate-physical', 'synthetic duplicate authority', 2),
+    memory_key: 'handoff.duplicate.physical',
+  };
+  const projection = writeMemoryProjection(vault, [pending]);
+  const canonicalLine = canonicalMemoryJson(pending);
+  writeFileSync(ledgerPath, `${canonicalLine}\n${canonicalLine}\n`);
+  enqueueMemoryEvent(vault, pending);
+  const outboxPath = join(brain, 'memory-outbox', `${pending.event_id}.json`);
+  writeFileSync(registryPath, `${JSON.stringify({
+    version: 2,
+    sessions: {
+      'current-session': enqueuedMemoryEntry(
+        'current-session', pending, projection.checkpoint,
+      ),
+    },
+  }, null, 2)}\n`);
+  const stable = new Map([
+    [registryPath, readFileSync(registryPath)],
+    [outboxPath, readFileSync(outboxPath)],
+    [ledgerPath, readFileSync(ledgerPath)],
+    [sharedPath, readFileSync(sharedPath)],
+    [candidatesPath, readFileSync(candidatesPath)],
+  ]);
+
+  try {
+    const { repairMemory } = await import('../src/memory.mjs');
+    let result;
+    let failure;
+    try {
+      result = repairMemory(vault, { now: '2026-07-30T15:00:30.000Z' });
+    } catch (error) {
+      failure = error;
+    }
+
+    for (const [path, bytes] of stable) {
+      assert.deepEqual(
+        readFileSync(path),
+        bytes,
+        `${path} must remain byte-stable when physical ledger authority is duplicated`,
+      );
+    }
+    assert.ok(
+      failure
+        || result?.status === 'attention'
+        || result?.attemptAcknowledgements?.status === 'attention',
+      'repair must fail or return attention for a physically duplicated event_id',
+    );
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-ACK-1] [sensor:memory-recovery] repair projects a partial outbox without partially acknowledging its attempt', async () => {
+  const vault = fixture();
+  const brain = join(vault, '.brain');
+  const registryPath = join(brain, 'SESSION_REGISTRY.json');
+  const present = {
+    ...memoryEvent('mem-repair-partial-present', 'synthetic partial event present', 2),
+    memory_key: 'handoff.partial.present',
+  };
+  const absent = {
+    ...memoryEvent('mem-repair-partial-absent', 'synthetic partial event absent', 2),
+    memory_key: 'handoff.partial.absent',
+  };
+  const projectionN = writeMemoryProjection(vault, [{
+    ...memoryEvent('mem-repair-partial-existing', 'synthetic partial checkpoint N', 1),
+    memory_key: 'handoff.partial.existing',
+  }]);
+  enqueueMemoryEvent(vault, present);
+  writeFileSync(registryPath, `${JSON.stringify({
+    version: 2,
+    sessions: {
+      'current-session': enqueuedMemoryEntry(
+        'current-session', present, projectionN.checkpoint, [present.event_id, absent.event_id],
+      ),
+    },
+  }, null, 2)}\n`);
+  const registryBefore = readFileSync(registryPath);
+
+  try {
+    const { repairMemory } = await import('../src/memory.mjs');
+    const repaired = repairMemory(vault, { now: '2026-07-30T15:02:00.000Z' });
+    const ledger = readFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), 'utf8');
+
+    assert.equal(repaired.projection.appended, 1);
+    assert.match(ledger, new RegExp(present.event_id));
+    assert.doesNotMatch(ledger, new RegExp(absent.event_id));
+    assert.deepEqual(repaired.attemptAcknowledgements, {
+      status: 'unchanged', eligible: 0, acknowledged: 0, stale: 0,
+    });
+    assert.deepEqual(readFileSync(registryPath), registryBefore);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-ACK-1] [sensor:memory-recovery] repair does not acknowledge an outbox payload from a divergent causal context', async (t) => {
+  const variants = [
+    ['session', { canonical_session_id: 'different-session' }],
+    ['activation', { activation_id: 'different-activation' }],
+    ['epoch', { activation_epoch: 2 }],
+    ['turn', { source_turn_id: 'different-turn', turn_sequence: 99 }],
+  ];
+
+  for (const [label, divergence] of variants) {
+    await t.test(label, async () => {
+      const vault = fixture();
+      const brain = join(vault, '.brain');
+      const registryPath = join(brain, 'SESSION_REGISTRY.json');
+      const intended = {
+        ...memoryEvent(`mem-repair-divergent-${label}`, `synthetic divergent ${label}`, 2),
+        memory_key: `handoff.divergent.${label}`,
+      };
+      const payload = { ...intended, ...divergence };
+      const projectionN = writeMemoryProjection(vault, [{
+        ...memoryEvent(`mem-repair-divergent-existing-${label}`, 'synthetic divergent checkpoint N', 1),
+        memory_key: `handoff.divergent.existing.${label}`,
+      }]);
+      enqueueMemoryEvent(vault, payload);
+      writeFileSync(registryPath, `${JSON.stringify({
+        version: 2,
+        sessions: {
+          'current-session': enqueuedMemoryEntry(
+            'current-session', intended, projectionN.checkpoint,
+          ),
+        },
+      }, null, 2)}\n`);
+      const registryBefore = readFileSync(registryPath);
+
+      try {
+        const { repairMemory } = await import('../src/memory.mjs');
+        const repaired = repairMemory(vault, { now: '2026-07-30T15:03:00.000Z' });
+        const ledger = readFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), 'utf8');
+
+        assert.equal(repaired.projection.appended, 1);
+        assert.match(ledger, new RegExp(payload.event_id));
+        assert.deepEqual(repaired.attemptAcknowledgements, {
+          status: 'unchanged', eligible: 0, acknowledged: 0, stale: 0,
+        });
+        assert.deepEqual(readFileSync(registryPath), registryBefore);
+      } finally { rmSync(vault, { recursive: true, force: true }); }
+    });
+  }
+});
+
+test('[req:MEM-ACK-3] [sensor:memory-recovery] repair loses CAS when a newer attempt replaces the frozen context before acknowledgement', async () => {
+  const vault = fixture();
+  const brain = join(vault, '.brain');
+  const registryPath = join(brain, 'SESSION_REGISTRY.json');
+  const pending = {
+    ...memoryEvent('mem-repair-cas-pending', 'synthetic CAS pending attempt', 2),
+    memory_key: 'handoff.cas.pending',
+  };
+  const projectionN = writeMemoryProjection(vault, [{
+    ...memoryEvent('mem-repair-cas-existing', 'synthetic CAS checkpoint N', 1),
+    memory_key: 'handoff.cas.existing',
+  }]);
+  enqueueMemoryEvent(vault, pending);
+  writeFileSync(registryPath, `${JSON.stringify({
+    version: 2,
+    sessions: {
+      'current-session': enqueuedMemoryEntry('current-session', pending, projectionN.checkpoint),
+    },
+  }, null, 2)}\n`);
+  const newerEvent = {
+    ...memoryEvent('mem-repair-cas-newer', 'synthetic newer CAS attempt', 3),
+    activation_id: 'newer-activation',
+    activation_epoch: 2,
+    memory_key: 'handoff.cas.newer',
+  };
+  const newerCheckpoint = {
+    revision: 73,
+    event_cursor: 'mem-repair-cas-newer-checkpoint',
+    causal_event_cursor: 'mem-repair-cas-newer-checkpoint',
+    state_hash: 'synthetic-newer-checkpoint-state',
+  };
+  const newerEntry = enqueuedMemoryEntry(
+    'current-session', newerEvent, newerCheckpoint, [newerEvent.event_id],
+  );
+  newerEntry.last_memory_attempt.checkpoint = newerCheckpoint;
+  const newerRegistryBytes = Buffer.from(`${JSON.stringify({
+    version: 2,
+    sessions: { 'current-session': newerEntry },
+  }, null, 2)}\n`);
+
+  try {
+    const { repairMemory } = await import('../src/memory.mjs');
+    const repaired = repairMemory(vault, {
+      now: '2026-07-30T15:04:00.000Z',
+      beforeAttemptAcknowledgement() {
+        writeFileSync(registryPath, newerRegistryBytes);
+      },
+    });
+    const current = JSON.parse(readFileSync(registryPath, 'utf8')).sessions['current-session'];
+
+    assert.equal(repaired.projection.appended, 1);
+    assert.deepEqual(repaired.attemptAcknowledgements, {
+      status: 'attention',
+      eligible: 1,
+      acknowledged: 0,
+      stale: 1,
+      sessionIds: [],
+    });
+    assert.deepEqual(readFileSync(registryPath), newerRegistryBytes);
+    assert.deepEqual(current.last_memory_attempt, newerEntry.last_memory_attempt);
+    assert.deepEqual(current.memory_checkpoint, newerCheckpoint);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-ACK-1] [req:MEM-ACK-3] [sensor:memory-recovery] repair does not drain outbox when attempt freeze loses MEMORY.lock', async () => {
+  const vault = fixture();
+  const brain = join(vault, '.brain');
+  const registryPath = join(brain, 'SESSION_REGISTRY.json');
+  const lockPath = join(brain, 'MEMORY.lock');
+  const pending = {
+    ...memoryEvent('mem-repair-freeze-busy', 'synthetic freeze busy attempt', 2),
+    memory_key: 'handoff.freeze.busy',
+  };
+  const projectionN = writeMemoryProjection(vault, [{
+    ...memoryEvent('mem-repair-freeze-existing', 'synthetic freeze checkpoint N', 1),
+    memory_key: 'handoff.freeze.existing',
+  }]);
+  enqueueMemoryEvent(vault, pending);
+  writeFileSync(registryPath, `${JSON.stringify({
+    version: 2,
+    sessions: {
+      'current-session': enqueuedMemoryEntry('current-session', pending, projectionN.checkpoint),
+    },
+  }, null, 2)}\n`);
+  const outboxPath = join(brain, 'memory-outbox', `${pending.event_id}.json`);
+  const stable = new Map([
+    [join(brain, 'MEMORY_EVENTS.jsonl'), readFileSync(join(brain, 'MEMORY_EVENTS.jsonl'))],
+    [join(brain, 'SHARED_MEMORY.md'), readFileSync(join(brain, 'SHARED_MEMORY.md'))],
+    [join(brain, 'MEMORY_CANDIDATES.jsonl'), readFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'))],
+    [registryPath, readFileSync(registryPath)],
+    [outboxPath, readFileSync(outboxPath)],
+  ]);
+
+  try {
+    const { repairMemory } = await import('../src/memory.mjs');
+    const result = repairMemory(vault, {
+      beforeAttemptFreeze() { mkdirSync(lockPath); },
+      memoryLock: { timeoutMs: 20, staleMs: 60_000 },
+    });
+
+    assert.equal(result.status, 'busy');
+    assert.equal(existsSync(outboxPath), true, 'outbox must remain durable for a retry');
+    for (const [path, bytes] of stable) assert.deepEqual(readFileSync(path), bytes);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-ACK-1] [req:MEM-ACK-3] [sensor:memory-recovery] repair acknowledges two fully covered attempts once and retry is byte-idempotent', async () => {
+  const vault = fixture();
+  const brain = join(vault, '.brain');
+  const ledgerPath = join(brain, 'MEMORY_EVENTS.jsonl');
+  const sharedPath = join(brain, 'SHARED_MEMORY.md');
+  const candidatesPath = join(brain, 'MEMORY_CANDIDATES.jsonl');
+  const corePath = join(brain, 'CORE.md');
+  const registryPath = join(brain, 'SESSION_REGISTRY.json');
+  const outboxPath = join(brain, 'memory-outbox');
+  const first = {
+    ...memoryEvent('mem-repair-batch-first', 'synthetic batch first', 2),
+    canonical_session_id: 'first-session',
+    activation_id: 'first-activation',
+    memory_key: 'handoff.batch.first',
+  };
+  const second = {
+    ...memoryEvent('mem-repair-batch-second', 'synthetic batch second', 3),
+    canonical_session_id: 'second-session',
+    activation_id: 'second-activation',
+    memory_key: 'handoff.batch.second',
+  };
+  const projectionN = writeMemoryProjection(vault, [{
+    ...memoryEvent('mem-repair-batch-existing', 'synthetic batch checkpoint N', 1),
+    memory_key: 'handoff.batch.existing',
+  }]);
+  enqueueMemoryEvent(vault, first);
+  enqueueMemoryEvent(vault, second);
+  writeFileSync(registryPath, `${JSON.stringify({
+    version: 2,
+    sessions: {
+      'first-session': enqueuedMemoryEntry('first-session', first, projectionN.checkpoint),
+      'second-session': enqueuedMemoryEntry('second-session', second, projectionN.checkpoint),
+    },
+  }, null, 2)}\n`);
+
+  try {
+    const { repairMemory } = await import('../src/memory.mjs');
+    const repaired = repairMemory(vault, { now: '2026-07-30T15:05:00.000Z' });
+    const registry = JSON.parse(readFileSync(registryPath, 'utf8'));
+
+    assert.equal(repaired.projection.appended, 2);
+    assert.deepEqual(repaired.attemptAcknowledgements, {
+      status: 'acknowledged',
+      eligible: 2,
+      acknowledged: 2,
+      stale: 0,
+      sessionIds: ['first-session', 'second-session'],
+    });
+    for (const sessionId of ['first-session', 'second-session']) {
+      const entry = registry.sessions[sessionId];
+      assert.equal(entry.memory_status, 'projected');
+      assert.equal(entry.last_memory_attempt.state, 'projected');
+      assert.deepEqual(entry.memory_checkpoint, repaired.projection.checkpoint);
+      assert.deepEqual(entry.last_memory_attempt.checkpoint, repaired.projection.checkpoint);
+    }
+    assert.equal(readdirSync(outboxPath).length, 0);
+
+    const stableBytes = new Map([
+      [ledgerPath, readFileSync(ledgerPath)],
+      [sharedPath, readFileSync(sharedPath)],
+      [candidatesPath, readFileSync(candidatesPath)],
+      [corePath, readFileSync(corePath)],
+      [registryPath, readFileSync(registryPath)],
+    ]);
+    const retry = repairMemory(vault, { now: '2026-07-30T15:06:00.000Z' });
+
+    assert.equal(retry.projection.appended, 0);
+    assert.equal(retry.projection.consumed, 0);
+    assert.deepEqual(retry.attemptAcknowledgements, {
+      status: 'unchanged', eligible: 0, acknowledged: 0, stale: 0,
+    });
+    for (const [path, bytes] of stableBytes) assert.deepEqual(readFileSync(path), bytes);
+    assert.equal(readdirSync(outboxPath).length, 0);
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
 

--- a/tests/vault-health-memory.test.mjs
+++ b/tests/vault-health-memory.test.mjs
@@ -80,13 +80,19 @@ function byteSnapshot(vault) {
   return entries;
 }
 
-function writeLastMemoryAttempt(vault, attempt, sessionId = 'example-session-health') {
+function writeLastMemoryAttempt(
+  vault,
+  attempt,
+  sessionId = 'example-session-health',
+  entryOverrides = {},
+) {
   writeFileSync(join(vault, '.brain', 'SESSION_REGISTRY.json'), `${JSON.stringify({
     version: 2,
     sessions: {
       [sessionId]: {
         status: 'done',
         session_file: '02-Sessions/example-session.md',
+        ...entryOverrides,
         last_memory_attempt: attempt,
       },
     },
@@ -262,6 +268,44 @@ test('[req:MEM-STOP-5] [req:MEM-STOP-6] [sensor:memory-health] degraded attempt 
     assert.equal(result.status, 'warning');
     assert.match(result.warnings.join('\n'), /recuper|attempt/i);
     assert.doesNotMatch(JSON.stringify(result), /example-private-payload-must-not-be-rendered/);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-ACK-2] [sensor:memory-recovery] health identifies projected acknowledgement pending', () => {
+  const previous = event('mem-example-previous-checkpoint', {
+    memory_key: 'example.previous', value: 'synthetic previous checkpoint', turn_sequence: 0,
+  });
+  const projected = event('mem-example-projected-ack-pending', {
+    memory_key: 'example.projected-ack', value: 'synthetic projected acknowledgement',
+  });
+  const vault = createBundle([previous, projected]);
+  const brain = join(vault, '.brain');
+  const outbox = join(brain, 'memory-outbox');
+  try {
+    mkdirSync(outbox);
+    writeLastMemoryAttempt(vault, memoryAttempt({
+      event_ids: [projected.event_id],
+      checkpoint: null,
+    }), 'example-session-health', {
+      memory_status: 'enqueued',
+      memory_checkpoint: checkpointFor([previous]),
+    });
+    const snapshot = () => ({
+      registry: readFileSync(join(brain, 'SESSION_REGISTRY.json')),
+      ledger: readFileSync(join(brain, 'MEMORY_EVENTS.jsonl')),
+      shared: readFileSync(join(brain, 'SHARED_MEMORY.md')),
+      outbox: readdirSync(outbox),
+    });
+    const before = snapshot();
+
+    const result = checkMemoryBundle(vault);
+
+    assert.equal(result.ok, true, result.failures.join('; '));
+    assert.equal(result.status, 'warning');
+    assert.deepEqual(result.failures, []);
+    assert.match(result.warnings.join('\n'), /acknowledgement projetado pendente/i);
+    assert.match(result.warnings.join('\n'), /memory recover-attempt example-session-health/i);
+    assert.deepEqual(snapshot(), before, 'health must not change registry, ledger, SHARED, or outbox');
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
 

--- a/wendkeep.sensors.json
+++ b/wendkeep.sensors.json
@@ -96,6 +96,14 @@
       "severity": "critical",
       "type": "command",
       "command": "node --test tests/session-stop-migration-lifecycle.test.mjs tests/memory-activation.test.mjs tests/session-memory-lifecycle.test.mjs tests/vault-health-memory.test.mjs"
+    },
+    {
+      "id": "memory-recovery",
+      "name": "Memory recovery",
+      "description": "Exercises projected-attempt acknowledgement recovery, causal safety, topology defenses and diagnostics",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test tests/memory-cli.test.mjs tests/memory-attempt-recovery.test.mjs tests/memory-attempt-recovery-topology.test.mjs tests/vault-health-memory.test.mjs"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- bind automatic memory acknowledgements to the exact outbox receipt consumed by the same repair run
- add dry-run-by-default memory recover-attempt <session> with strict causal, CAS, lock, and filesystem-topology guards
- harden diagnostics, bilingual documentation, focused sensors, and the 0.66.4 release metadata

## Verification
- npm test
- npm run check
- wendkeep verify --change memory-projected-attempt-recovery
- wendkeep verify --deep --change memory-projected-attempt-recovery
- independent verdict: ok:true, MEM-ACK-1/2/3 covered

Closes #20