### PR TITLE
fix: registra subagentes Codex com causalidade (0.66.5)

### DIFF
--- a/.agents/skills/example-skill/.wendkeep-meta.json
+++ b/.agents/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.4",
+  "wendkeepVersion": "0.66.5",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.agents/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.agents/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.4",
+  "wendkeepVersion": "0.66.5",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.agents/skills/wk-debugging/.wendkeep-meta.json
+++ b/.agents/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.4",
+  "wendkeepVersion": "0.66.5",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.agents/skills/wk-planning/.wendkeep-meta.json
+++ b/.agents/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.4",
+  "wendkeepVersion": "0.66.5",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.agents/skills/wk-tdd/.wendkeep-meta.json
+++ b/.agents/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.4",
+  "wendkeepVersion": "0.66.5",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.agents/skills/wk-verify/.wendkeep-meta.json
+++ b/.agents/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.4",
+  "wendkeepVersion": "0.66.5",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.agents/skills/wk-workflow/.wendkeep-meta.json
+++ b/.agents/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.4",
+  "wendkeepVersion": "0.66.5",
   "sourceHash": "c3299e94ce34103fb599744eabec7aec581aefc6fd7c6b959e0350293ee5d8bf"
 }

--- a/.claude/skills/example-skill/.wendkeep-meta.json
+++ b/.claude/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.4",
+  "wendkeepVersion": "0.66.5",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.claude/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.claude/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.4",
+  "wendkeepVersion": "0.66.5",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.claude/skills/wk-debugging/.wendkeep-meta.json
+++ b/.claude/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.4",
+  "wendkeepVersion": "0.66.5",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.claude/skills/wk-planning/.wendkeep-meta.json
+++ b/.claude/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.4",
+  "wendkeepVersion": "0.66.5",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.claude/skills/wk-tdd/.wendkeep-meta.json
+++ b/.claude/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.4",
+  "wendkeepVersion": "0.66.5",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.claude/skills/wk-verify/.wendkeep-meta.json
+++ b/.claude/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.4",
+  "wendkeepVersion": "0.66.5",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.claude/skills/wk-workflow/.wendkeep-meta.json
+++ b/.claude/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.4",
+  "wendkeepVersion": "0.66.5",
   "sourceHash": "c3299e94ce34103fb599744eabec7aec581aefc6fd7c6b959e0350293ee5d8bf"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- wendkeep:skills:start -->
-<!-- wendkeep-version: 0.66.4; skills-sha256: 36ebe0728fe02c48230802722405c3179cb460f289429505e341db582542b82d -->
+<!-- wendkeep-version: 0.66.5; skills-sha256: 36ebe0728fe02c48230802722405c3179cb460f289429505e341db582542b82d -->
 ## wendkeep — Keep Core & operating profiles
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. **Keep Core is always active**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.66.5] — 2026-08-01
+
+### Fixed
+
+- **A observabilidade Codex passa a registrar o grafo completo de subagentes.** Metadata é
+  lida incrementalmente mesmo em rollouts grandes; descendentes em dias posteriores ou níveis
+  aninhados são atribuídos uma única vez, enquanto transcripts top-level permanecem no bucket
+  principal e sinais duplicados ou atrasados não regridem o snapshot publicado.
+- **SessionStop e SubagentStop convergem sob frontier causal e estado explícito.** O schema 2
+  distingue `complete`, `none` e `degraded`, coalesce rajadas com lease, preserva o último
+  snapshot íntegro diante de fonte incompleta e mantém cache/runtime reconstruíveis sem publicar
+  zero silencioso.
+- **Rebuild, import e doctor agora reconciliam a observabilidade persistida.** Preview permanece
+  sem escrita, apply rejeita resultado parcial, import atualiza notas completas porém stale e o
+  doctor correlaciona checkpoint, manifest e dirty para expor degradação real.
+
+### Security
+
+- **Diagnostics e provas públicas aplicam uma fronteira de privacidade estável.** Somente pares
+  allowlisted `{code,count}` podem ser persistidos; paths, identificadores, prompts e exceções
+  brutas ficam fora de fixtures, evidências e notas de release.
+
 ## [0.66.4] — 2026-07-30
 
 ### Fixed

--- a/README.en.md
+++ b/README.en.md
@@ -211,10 +211,10 @@ The README is the map; the guides provide syntax, options, exit codes, examples,
 | **Operating profiles** | `profile`, `flow`, always-on Keep Core, and Wend Runtime governance | [Operating profiles](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/operating-profiles.md) |
 | **Changes and verification** | `change`, specs, sensors, TDD, evidence, and archive | [Changes and verification](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/changes-and-verification.md) |
 | **Shared memory** | CORE, SHARED, status, validation, repair, and curation | [Memory](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/memory.md) |
-| **Sessions and import** | hooks, registry, session focus, and Claude/Codex backfill | [Sessions and import](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/sessions-and-import.md) |
+| **Sessions and import** | causal hooks, observability reconciliation, and Claude/Codex backfill | [Sessions and import](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/sessions-and-import.md) |
 | **Notes and knowledge** | BUG/APR/ADR, repairs, renumbering, lessons, and dashboard | [Notes and knowledge](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/notes-and-knowledge.md) |
-| **Costs and observability** | stats, aggregation, trends, and historical rebuild | [Costs and observability](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/costs-and-observability.md) |
-| **Maintenance and diagnostics** | doctor, definition drift, theme, version, and help | [Maintenance and diagnostics](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/maintenance-and-diagnostics.md) |
+| **Costs and observability** | safe dry-run, tri-state, aggregation, trends, and historical rebuild | [Costs and observability](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/costs-and-observability.md) |
+| **Maintenance and diagnostics** | doctor, frontier/manifest freshness, drift, version, and help | [Maintenance and diagnostics](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/maintenance-and-diagnostics.md) |
 
 Operations that deserve step-by-step guidance: [verify and exits 0/1/2](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/verify.md),
 [legacy-memory migration](https://github.com/rogersialves/wendkeep/blob/main/docs/en/commands/memory-migration.md), and

--- a/README.md
+++ b/README.md
@@ -207,10 +207,10 @@ O README mostra o mapa; os guias trazem sintaxe, opções, códigos de saída, e
 | **Perfis de operação** | `profile`, `flow`, Keep Core sempre ativo e governança do Wend Runtime | [Perfis de Operação](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/operating-profiles.md) |
 | **Changes e verificação** | `change`, specs, sensores, TDD, evidência e archive | [Changes e verificação](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/changes-and-verification.md) |
 | **Memória compartilhada** | CORE, SHARED, status, validação, repair e curadoria | [Memória](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/memory.md) |
-| **Sessões e importação** | hooks, registry, foco de sessão e backfill Claude/Codex | [Sessões e importação](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/sessions-and-import.md) |
+| **Sessões e importação** | hooks causais, reconciliação de observabilidade e backfill Claude/Codex | [Sessões e importação](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/sessions-and-import.md) |
 | **Notas e conhecimento** | BUG/APR/ADR, reparos, renumeração, lessons e dashboard | [Notas e conhecimento](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/notes-and-knowledge.md) |
-| **Custos e observabilidade** | stats, agregação, tendências e rebuild histórico | [Custos e observabilidade](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/costs-and-observability.md) |
-| **Manutenção e diagnóstico** | doctor, drift de defs, tema, versão e ajuda | [Manutenção e diagnóstico](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/maintenance-and-diagnostics.md) |
+| **Custos e observabilidade** | dry-run seguro, tri-state, agregação, tendências e rebuild histórico | [Custos e observabilidade](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/costs-and-observability.md) |
+| **Manutenção e diagnóstico** | doctor, frescor do frontier/manifest, drift, versão e ajuda | [Manutenção e diagnóstico](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/maintenance-and-diagnostics.md) |
 
 Operações que merecem instrução passo a passo: [verify e seus exits 0/1/2](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/verify.md),
 [migração de memória legada](https://github.com/rogersialves/wendkeep/blob/main/docs/pt-BR/commands/memory-migration.md) e

--- a/docs/en/commands/costs-and-observability.md
+++ b/docs/en/commands/costs-and-observability.md
@@ -26,7 +26,7 @@ A consistent registry, complete price table, and transcript access for rebuilt s
 ```bash
 npx wendkeep stats [--vault <vault>] [--json]
 npx wendkeep cost [--since <date>] [--top [N]] [--trend day|week|month] [--write] [--json]
-npx wendkeep cost rebuild [--session <id|file>] [--limit N] [--apply] [--json]
+npx wendkeep cost rebuild [--session <id|file>] [--limit N] [--max-graph-nodes N] [--max-fallback-days N] [--max-fallback-candidates N] [--apply] [--json]
 ```
 
 ## Options and exit codes
@@ -34,10 +34,18 @@ npx wendkeep cost rebuild [--session <id|file>] [--limit N] [--apply] [--json]
 - `wendkeep stats` emits one shareable line or JSON.
 - `wendkeep cost` aggregates total/model/day; `--trend` adds projection and `--write` refreshes
   `00-Custo.md`.
-- `wendkeep cost rebuild` is dry-run by default; `--apply` writes notes and
-  `.brain/COST_REBUILD.json`.
-- Exit `0` means a consistent calculation; non-zero reports insufficient registry, price,
-  transcript, or parsing state.
+- `wendkeep cost rebuild` is dry-run by default and performs **zero writes**: it acquires no write
+  lock, changes no note, registry, or runtime state, and does not create `.brain/COST_REBUILD.json`.
+- `--apply` publishes only `complete` or `none` candidates. The `none` state clears the section
+  only after a stable offline scan proves that no subagent was started.
+- A `degraded` or `stale` candidate returns exit `1` and preserves the note without changes; the
+  batch continues so other safe sessions can be processed and the report can expose sanitized
+  diagnostic codes.
+- The `--max-graph-nodes`, `--max-fallback-days`, and `--max-fallback-candidates` overrides are
+  exclusively for a targeted rebuild with `--session`. Using them without `--session` is invalid
+  usage and returns exit `2`; hooks, import, and bulk rebuild retain the default limits.
+- Exit `0` means a consistent preview/apply; exit `1` means a partial `degraded`/`stale` result;
+  exit `2` means invalid syntax or context.
 
 ## Examples
 
@@ -45,12 +53,16 @@ npx wendkeep cost rebuild [--session <id|file>] [--limit N] [--apply] [--json]
 npx wendkeep stats --vault .MyApp-vault
 npx wendkeep cost --since 2026-07-01 --top 10 --trend week
 npx wendkeep cost rebuild --session 019abc --json
+npx wendkeep cost rebuild --session 019abc --max-graph-nodes 8192 --json
+npx wendkeep cost rebuild --session 019abc --apply
 ```
 
 ## Expected result
 
-Totals retain input/output/cache/reasoning dimensions by model and period. Rebuild shows a preview
-before changing notes and leaves a reproducible report when applied.
+Totals retain input/output/cache/reasoning dimensions by model and period. Tri-state composition
+returns `complete`, `none`, or `degraded`, plus a frontier, manifest, and sanitized diagnostics.
+Run and review the dry-run before repeating the same command with `--apply`; a semantically
+identical second apply preserves the note, checkpoint, report, and mtime.
 
 ## Common errors and diagnosis
 
@@ -58,6 +70,8 @@ before changing notes and leaves a reproducible report when applied.
 - Wrong-provider costs: validate the session identity chain.
 - Missing transcript: do not estimate silently; keep the gap visible.
 - Duplicated parent/subagent/fork totals: verify registry relationships and deduplication.
+- `degraded`/`stale`: preserve the note and inspect diagnostics/frontier before authorizing apply.
+- Rejected override: add `--session <id|file>` or remove the three targeted limits.
 
 ## Next steps
 

--- a/docs/en/commands/maintenance-and-diagnostics.md
+++ b/docs/en/commands/maintenance-and-diagnostics.md
@@ -39,6 +39,11 @@ npx wendkeep --help
   events remain durable in the outbox/ledger is a recoverable warning.
 - An ambiguous attempt, a lost event ID (absent from ledger and outbox), `projected` state found
   only in the outbox, or a mismatched checkpoint is blocking.
+- For session observability, `legacy`, `degraded`, `stale`, and `manifest-unproven` require
+  reconciliation or more evidence. Only fresh `none` and fresh `complete` are healthy: frontier,
+  checkpoint, root stat, and source manifest must agree.
+- `doctor` remains read-only. It recommends the targeted dry-run first and only advises repeating
+  the command with `--apply` after human review.
 - `sync-defs --check` detects drift without writes; `--reseed` restores packaged `wk-*` skills.
 - `theme sync` reapplies the CSS snippet and graph groups without recreating the vault.
 - `wendkeep --version` prints the running version; `wendkeep --help` lists the public interface.
@@ -52,6 +57,8 @@ npx wendkeep --version
 npx wendkeep sync-defs --check --vault .MyApp-vault --project .
 npx wendkeep doctor --vault .MyApp-vault
 npx wendkeep memory status --gate --vault .MyApp-vault
+npx wendkeep cost rebuild --session <id> --json
+npx wendkeep cost rebuild --session <id> --apply
 ```
 
 ## Expected result
@@ -59,7 +66,9 @@ npx wendkeep memory status --gate --vault .MyApp-vault
 Doctor names sessions, registry, links, notes, prices, derived sections, and memory as healthy or
 provides a specific diagnostic/repair command. For memory, it distinguishes a valid initial empty
 state, recoverable pending replay, and lost/divergent lifecycle state. It never repairs implicitly
-or echoes private projector-error content into its report.
+or echoes private projector-error content into its report. For session observability, it separates
+fresh `none`/`complete` from legacy, degraded, stale, or manifest-unproven state and gives a
+dry-run path before any write.
 
 ## Common errors and diagnosis
 
@@ -70,6 +79,9 @@ or echoes private projector-error content into its report.
 - `ambiguous`, lost publication, or a mismatched checkpoint: blocking; preserve registry, ledger,
   outbox, and SHARED so `last_memory_attempt` can be correlated before repair.
 - Corrupt bundle: preserve evidence and run `memory status --gate` before `memory repair`.
+- `legacy`/`degraded`/`stale`/`manifest-unproven` observability: run
+  `wendkeep cost rebuild --session <id> --json`, review diagnostics, and only then authorize
+  `--apply`.
 
 ## Next steps
 

--- a/docs/en/commands/sessions-and-import.md
+++ b/docs/en/commands/sessions-and-import.md
@@ -46,6 +46,14 @@ npx wendkeep import [options]
 - `Stop` accepts only a transcript-proven turn from the compatible active activation. Duplicates
   are no-ops; stale/superseded Stops neither publish memory nor overwrite a newer epoch's
   checkpoint.
+- `Stop` receives an absolute **45 s** deadline from hook entry. Reads check the clock between
+  rollouts and on every chunk; reaching the limit returns `degraded` before the host timeout.
+- `SubagentStop` receives an absolute **15 s** deadline. Signals arriving within the **250 ms**
+  window are coalesced: only the highest sequence recomposes/publishes, without losing the last
+  child.
+- Observability is tri-state: `complete` publishes the full snapshot; `none` means zero proven by
+  a causal Stop or stable offline scan; `degraded` preserves the previous snapshot and allowlisted
+  diagnostics. An isolated `SubagentStop` never publishes `none`.
 - When compacting conversations into `## Iterações`, the hook escapes code delimiters cut by the
   size limit; inline backticks and fences never remain open and consume the following line.
 - `session list` reads `SESSION_REGISTRY`; `show` displays one session and `use` only changes human
@@ -53,6 +61,9 @@ npx wendkeep import [options]
 - `import --source all|claude|codex`, `--since`, `--limit`, `--from`, and `--codex-from` bound scope.
 - `--dry-run`/`--json` support audit before writes; `--stamp-ids` and `--rescan-decisions` address
   specific historical gaps.
+- `import` reconciles observability even when no `wk-turn` is missing: a legacy schema, stale
+  frontier, or unproven manifest triggers recomposition without duplicating iterations. A fresh
+  checkpoint remains byte-identical; `degraded` is reported and does not change the note.
 - Exit `0` means consistent processing; non-zero reports invalid source/config/write instead of
   presenting silent partial success.
 
@@ -71,6 +82,8 @@ registry keeps one `SessionStart` epoch per activation plus the latest native tu
 `Stop` events may acknowledge turns in that epoch without closing it. Repeated imports of the
 same `session_id` deduplicate; human focus does not close or re-identify live hooks. Every
 automatic iteration remains valid Markdown even when a message must be truncated.
+Duplicate/stale hooks converge on the same frontier, and imports may refresh only observability
+without creating a new turn block.
 
 ## Common errors and diagnosis
 
@@ -82,6 +95,8 @@ automatic iteration remains valid Markdown even when a message must be truncated
 - Fork duplicates: bound source/date and inspect `forked_from_id`/`source.subagent`.
 - Codex does not capture: approve hooks and start a new session after `sync`.
 - Contaminated cost: validate `session_id → session_file → transcript_path → provider`.
+- `degraded` observability: preserve the note and run a targeted rebuild dry-run; never force a
+  partial snapshot over the last `complete` one.
 
 ## Next steps
 

--- a/docs/pt-BR/commands/costs-and-observability.md
+++ b/docs/pt-BR/commands/costs-and-observability.md
@@ -26,7 +26,7 @@ Registry consistente, tabela de preços completa e acesso aos transcripts das se
 ```bash
 npx wendkeep stats [--vault <cofre>] [--json]
 npx wendkeep cost [--since <data>] [--top [N]] [--trend day|week|month] [--write] [--json]
-npx wendkeep cost rebuild [--session <id|arquivo>] [--limit N] [--apply] [--json]
+npx wendkeep cost rebuild [--session <id|arquivo>] [--limit N] [--max-graph-nodes N] [--max-fallback-days N] [--max-fallback-candidates N] [--apply] [--json]
 ```
 
 ## Opções e códigos de saída
@@ -34,10 +34,18 @@ npx wendkeep cost rebuild [--session <id|arquivo>] [--limit N] [--apply] [--json
 - `wendkeep stats` gera uma linha compartilhável ou JSON.
 - `wendkeep cost` agrega total/modelo/dia; `--trend` inclui projeção e `--write` atualiza
   `00-Custo.md`.
-- `wendkeep cost rebuild` é dry-run por padrão; `--apply` grava notas e
-  `.brain/COST_REBUILD.json`.
-- Exit `0` indica cálculo consistente; não zero indica registry, preço, transcript ou parsing
-  insuficiente.
+- `wendkeep cost rebuild` é dry-run por padrão e tem **zero escrita**: não adquire lock de
+  gravação, não altera nota, registry ou runtime e não cria `.brain/COST_REBUILD.json`.
+- `--apply` publica somente candidatos `complete` ou `none`. O estado `none` só zera a seção
+  quando um scan offline estável comprovou que nenhum subagente foi iniciado.
+- Um candidato `degraded` ou `stale` produz exit `1` e preserva a nota sem alteração; o lote
+  continua para que outras sessões seguras possam ser processadas e o relatório exponha os
+  códigos sanitizados.
+- Os overrides `--max-graph-nodes`, `--max-fallback-days` e `--max-fallback-candidates` são
+  exclusivamente para rebuild direcionado com `--session`. Usá-los sem `--session` é uso inválido
+  e produz exit `2`; hooks, import e rebuild em lote mantêm os limites padrão.
+- Exit `0` significa preview/aplicação consistente; exit `1` indica resultado parcial
+  `degraded`/`stale`; exit `2` indica sintaxe ou contexto inválido.
 
 ## Exemplos
 
@@ -45,12 +53,16 @@ npx wendkeep cost rebuild [--session <id|arquivo>] [--limit N] [--apply] [--json
 npx wendkeep stats --vault .MeuApp-vault
 npx wendkeep cost --since 2026-07-01 --top 10 --trend week
 npx wendkeep cost rebuild --session 019abc --json
+npx wendkeep cost rebuild --session 019abc --max-graph-nodes 8192 --json
+npx wendkeep cost rebuild --session 019abc --apply
 ```
 
 ## Resultado esperado
 
-Totais preservam dimensões de input/output/cache/reasoning por modelo e período. Rebuild mostra a
-prévia antes de alterar notas e deixa um relatório reproduzível quando aplicado.
+Totais preservam dimensões de input/output/cache/reasoning por modelo e período. A composição
+tri-state devolve `complete`, `none` ou `degraded`, mais frontier, manifest e diagnostics
+sanitizados. Rode e revise o dry-run antes de repetir o mesmo comando com `--apply`; uma segunda
+aplicação semanticamente idêntica preserva nota, checkpoint, relatório e mtime.
 
 ## Erros comuns e diagnóstico
 
@@ -58,6 +70,8 @@ prévia antes de alterar notas e deixa um relatório reproduzível quando aplica
 - Custos de provider errado: valide a cadeia de identidade da sessão.
 - Transcript ausente: não estime silenciosamente; mantenha a lacuna visível.
 - Total duplicado por subagent/fork: confirme relação pai/subagent e deduplicação do registry.
+- `degraded`/`stale`: preserve a nota e investigue diagnostics/frontier antes de autorizar apply.
+- Override rejeitado: acrescente `--session <id|arquivo>` ou remova os três limites direcionados.
 
 ## Próximos passos
 

--- a/docs/pt-BR/commands/maintenance-and-diagnostics.md
+++ b/docs/pt-BR/commands/maintenance-and-diagnostics.md
@@ -39,6 +39,11 @@ npx wendkeep --help
   continuam duráveis na outbox/ledger é warning recuperável.
 - Attempt ambíguo, event ID perdido (ausente de ledger e outbox), estado `projected` apenas na
   outbox ou checkpoint divergente são falhas bloqueantes.
+- Para observabilidade de sessão, `legacy`, `degraded`, `stale` e `manifest-unproven` exigem
+  reconciliação ou evidência adicional. Somente `none` fresco e `complete` fresco são saudáveis:
+  frontier, checkpoint, root stat e source manifest precisam concordar.
+- O `doctor` permanece somente leitura/read-only. Ele recomenda primeiro o dry-run direcionado;
+  somente depois da revisão humana orienta repetir com `--apply`.
 - `sync-defs --check` detecta drift sem gravar; `--reseed` restaura skills `wk-*` do pacote.
 - `theme sync` reaplica snippet CSS e grupos do grafo sem recriar o cofre.
 - `wendkeep --version` imprime a versão executada; `wendkeep --help` lista a interface pública.
@@ -52,6 +57,8 @@ npx wendkeep --version
 npx wendkeep sync-defs --check --vault .MeuApp-vault --project .
 npx wendkeep doctor --vault .MeuApp-vault
 npx wendkeep memory status --gate --vault .MeuApp-vault
+npx wendkeep cost rebuild --session <id> --json
+npx wendkeep cost rebuild --session <id> --apply
 ```
 
 ## Resultado esperado
@@ -59,7 +66,9 @@ npx wendkeep memory status --gate --vault .MeuApp-vault
 O doctor nomeia sessões, registry, links, notas, preços, derivadas e memória como saudáveis ou
 fornece um comando específico de diagnóstico/reparo. Na memória, ele distingue vazio inicial
 válido, replay pendente recuperável e lifecycle perdido/divergente. Nenhum reparo é aplicado
-implicitamente nem o conteúdo privado do erro do projector é reproduzido no relatório.
+implicitamente nem o conteúdo privado do erro do projector é reproduzido no relatório. Na
+observabilidade de sessão, ele separa `none`/`complete` frescos de estado legado, degradado, stale
+ou sem manifest comprovado e oferece um caminho dry-run antes de qualquer escrita.
 
 ## Erros comuns e diagnóstico
 
@@ -70,6 +79,8 @@ implicitamente nem o conteúdo privado do erro do projector é reproduzido no re
 - `ambiguous`, publicação perdida ou checkpoint divergente: bloqueante; preserve registry, ledger,
   outbox e SHARED para correlacionar `last_memory_attempt` antes de reparar.
 - Bundle corrompido: preserve a evidência e use `memory status --gate` antes de `memory repair`.
+- Observabilidade `legacy`/`degraded`/`stale`/`manifest-unproven`: rode
+  `wendkeep cost rebuild --session <id> --json`, revise diagnostics e só então autorize `--apply`.
 
 ## Próximos passos
 

--- a/docs/pt-BR/commands/sessions-and-import.md
+++ b/docs/pt-BR/commands/sessions-and-import.md
@@ -46,6 +46,13 @@ npx wendkeep import [opções]
 - `Stop` aceita somente o turno comprovado pelo transcript e pela activation ativa compatível.
   Duplicatas são no-op; Stops stale/superseded não publicam memória nem sobrescrevem o checkpoint
   de um epoch mais novo.
+- `Stop` recebe deadline absoluto de **45 s** desde a entrada do hook. A leitura verifica o relógio
+  entre rollouts e a cada chunk; ao atingir o limite, devolve `degraded` antes do timeout do host.
+- `SubagentStop` recebe deadline absoluto de **15 s**. Sinais que chegam na janela de **250 ms**
+  são coalescidos: somente a maior sequência recompõe/publica, sem perder o último filho.
+- A observabilidade usa tri-state: `complete` publica o snapshot integral; `none` representa zero
+  comprovado por Stop causal ou scan offline estável; `degraded` preserva o snapshot anterior e
+  diagnostics allowlisted. `SubagentStop` isolado nunca publica `none`.
 - Ao compactar conversas em `## Iterações`, o hook escapa delimitadores de código cortados pelo
   limite de tamanho; backticks inline ou fences nunca ficam abertos para engolir a linha seguinte.
 - `session list` lê `SESSION_REGISTRY`; `show` exibe uma sessão e `use` muda apenas o foco humano
@@ -53,6 +60,9 @@ npx wendkeep import [opções]
 - `import --source all|claude|codex`, `--since`, `--limit`, `--from` e `--codex-from` limitam escopo.
 - `--dry-run`/`--json` permitem auditar antes de gravar; `--stamp-ids` e `--rescan-decisions`
   corrigem históricos específicos.
+- `import` reconcilia a observabilidade mesmo quando nenhum `wk-turn` está ausente: schema legado,
+  frontier stale ou manifest não comprovado disparam recomposição sem duplicar iterações. Um
+  checkpoint fresco permanece byte-idêntico; `degraded` é reportado e não altera a nota.
 - Exit `0` indica processamento consistente; exit não zero indica configuração, fonte ou escrita
   inválida sem transformar isso em sucesso parcial silencioso.
 
@@ -70,7 +80,9 @@ Cada sessão canônica aponta para provider, transcript, arquivo de nota e custo
 O registry mantém um epoch de `SessionStart` por activation e o turno nativo mais recente; vários
 `Stop` podem confirmar turnos do mesmo epoch sem fechá-lo. Importações repetidas do mesmo
 `session_id` são deduplicadas; o foco humano não encerra nem altera a identidade dos hooks. Cada
-iteração automática permanece Markdown válido mesmo quando uma fala precisa ser truncada.
+iteração automática permanece Markdown válido mesmo quando uma fala precisa ser truncada. Hooks
+duplicados/stale convergem no mesmo frontier, e importações podem atualizar só a observabilidade
+sem criar um novo bloco de turno.
 
 ## Erros comuns e diagnóstico
 
@@ -82,6 +94,8 @@ iteração automática permanece Markdown válido mesmo quando uma fala precisa 
 - Duplicatas de forks: limite por fonte/data e revise `forked_from_id`/`source.subagent`.
 - Codex não captura: aprove os hooks e reinicie a sessão após `sync`.
 - Custo contaminado: valide `session_id → session_file → transcript_path → provider`.
+- Observabilidade `degraded`: preserve a nota e rode o rebuild direcionado em dry-run; não force
+  um snapshot parcial sobre o último `complete`.
 
 ## Próximos passos
 

--- a/hooks/codex-rollout-meta.mjs
+++ b/hooks/codex-rollout-meta.mjs
@@ -1,0 +1,112 @@
+import {
+  closeSync,
+  openSync,
+  readSync,
+} from 'node:fs';
+
+export const DEFAULT_CODEX_META_LINE_BYTES = 4 * 1024 * 1024;
+const READ_CHUNK_BYTES = 64 * 1024;
+
+function trimCarriageReturn(buffer) {
+  return buffer.length > 0 && buffer[buffer.length - 1] === 0x0d
+    ? buffer.subarray(0, buffer.length - 1)
+    : buffer;
+}
+
+// Codex writes session_meta as the first physical JSONL line. Read only that line: the
+// transcript body can be hundreds of MiB and is irrelevant to identity/discovery.
+export function readFirstJsonlLine(
+  path,
+  { maxBytes = DEFAULT_CODEX_META_LINE_BYTES } = {},
+) {
+  if (typeof path !== 'string' || !path) {
+    return { ok: false, reason: 'INVALID_PATH' };
+  }
+
+  const limit = Number(maxBytes);
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    return { ok: false, reason: 'READ_ERROR' };
+  }
+
+  let fd;
+  try {
+    fd = openSync(path, 'r');
+    const parts = [];
+    let totalBytes = 0;
+
+    while (totalBytes <= limit) {
+      // The extra byte distinguishes an exactly-at-limit line followed by LF from a line
+      // whose content exceeds the limit.
+      const remaining = (limit + 1) - totalBytes;
+      const chunk = Buffer.allocUnsafe(Math.min(READ_CHUNK_BYTES, remaining));
+      const bytesRead = readSync(fd, chunk, 0, chunk.length, null);
+
+      if (bytesRead === 0) {
+        if (totalBytes === 0) return { ok: false, reason: 'EMPTY_FILE' };
+        const lineBuffer = trimCarriageReturn(Buffer.concat(parts, totalBytes));
+        return {
+          ok: true,
+          line: lineBuffer.toString('utf8'),
+          lineBytes: lineBuffer.length,
+        };
+      }
+
+      const bytes = chunk.subarray(0, bytesRead);
+      const newlineAt = bytes.indexOf(0x0a);
+      if (newlineAt !== -1) {
+        if (totalBytes + newlineAt > limit) {
+          return { ok: false, reason: 'LINE_TOO_LONG' };
+        }
+        parts.push(bytes.subarray(0, newlineAt));
+        const lineBuffer = trimCarriageReturn(Buffer.concat(parts, totalBytes + newlineAt));
+        if (lineBuffer.length === 0) return { ok: false, reason: 'EMPTY_FILE' };
+        return {
+          ok: true,
+          line: lineBuffer.toString('utf8'),
+          lineBytes: lineBuffer.length,
+        };
+      }
+
+      parts.push(bytes);
+      totalBytes += bytesRead;
+      if (totalBytes > limit) return { ok: false, reason: 'LINE_TOO_LONG' };
+    }
+
+    return { ok: false, reason: 'LINE_TOO_LONG' };
+  } catch {
+    return { ok: false, reason: 'READ_ERROR' };
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* already closed */ }
+    }
+  }
+}
+
+export function readCodexRolloutMeta(
+  path,
+  { maxLineBytes = DEFAULT_CODEX_META_LINE_BYTES } = {},
+) {
+  const first = readFirstJsonlLine(path, { maxBytes: maxLineBytes });
+  if (!first.ok) return first;
+
+  let event;
+  try {
+    event = JSON.parse(first.line);
+  } catch {
+    return { ok: false, reason: 'INVALID_JSON' };
+  }
+
+  if (!event || typeof event !== 'object' || Array.isArray(event)
+    || event.type !== 'session_meta') {
+    return { ok: false, reason: 'NOT_SESSION_META' };
+  }
+  if (!event.payload || typeof event.payload !== 'object' || Array.isArray(event.payload)) {
+    return { ok: false, reason: 'INVALID_META' };
+  }
+
+  return {
+    ok: true,
+    meta: event.payload,
+    lineBytes: first.lineBytes,
+  };
+}

--- a/hooks/codex-subagent-graph.mjs
+++ b/hooks/codex-subagent-graph.mjs
@@ -1,0 +1,903 @@
+import { createHash } from "node:crypto";
+import { closeSync, openSync, readSync, readdirSync, statSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { StringDecoder } from "node:string_decoder";
+
+import { readCodexRolloutMeta } from "./codex-rollout-meta.mjs";
+import {
+  addUsage,
+  costBreakdown,
+  emptyTokenUsage,
+  normalizeCodexUsage,
+  priceForModel,
+} from "./token-usage.mjs";
+
+export const CODEX_SUBAGENT_GRAPH_LIMITS = Object.freeze({
+  maxGraphNodes: 4096,
+  maxFallbackDays: 31,
+  maxFallbackCandidates: 20_000,
+  maxLiveUncachedBytes: 512 * 1024 * 1024,
+});
+
+const READ_CHUNK_BYTES = 64 * 1024;
+const CACHE_VERSION = 1;
+const DIAGNOSTIC_ORDER = [
+  "PARENT_META_INVALID",
+  "CHILD_MISSING",
+  "CHILD_META_INVALID",
+  "ROOT_MISMATCH",
+  "LEGACY_CHAIN_UNPROVEN",
+  "DUPLICATE_ROLLOUT_ID",
+  "GRAPH_LIMIT_EXCEEDED",
+  "FALLBACK_LIMIT_EXCEEDED",
+  "LIVE_BYTE_BUDGET_EXCEEDED",
+  "LIVE_DEADLINE_EXCEEDED",
+  "SOURCE_CHANGED_DURING_SCAN",
+  "CACHE_INVALID",
+];
+
+const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+const stableHash = (value) => sha256(JSON.stringify(value));
+const round4 = (value) => Math.round((Number(value) || 0) * 10_000) / 10_000;
+
+function tokenTotal(usage) {
+  const explicit = Number(usage?.total);
+  if (Number.isFinite(explicit) && explicit > 0) return explicit;
+  return (
+    (Number(usage?.input) || 0) +
+    (Number(usage?.cached) || 0) +
+    (Number(usage?.cacheWrite) || 0) +
+    (Number(usage?.output) || 0)
+  );
+}
+
+function normalizedLimits(overrides = {}) {
+  const result = { ...CODEX_SUBAGENT_GRAPH_LIMITS };
+  for (const key of Object.keys(result)) {
+    const value = Number(overrides?.[key]);
+    if (Number.isSafeInteger(value) && value > 0) result[key] = value;
+  }
+  return result;
+}
+
+function makeClock(now) {
+  if (typeof now === "function") {
+    return (phase) => {
+      const value = Number(now(phase));
+      return Number.isFinite(value) ? value : Date.now();
+    };
+  }
+  if (Number.isFinite(Number(now))) return () => Number(now);
+  return () => Date.now();
+}
+
+function safeStat(path) {
+  try {
+    const stat = statSync(path);
+    if (!stat.isFile()) return null;
+    return { size: stat.size, mtimeMs: stat.mtimeMs };
+  } catch {
+    return null;
+  }
+}
+
+function sameStat(left, right) {
+  return Boolean(
+    left &&
+    right &&
+    Number(left.size) === Number(right.size) &&
+    Number(left.mtimeMs) === Number(right.mtimeMs),
+  );
+}
+
+function cacheKey(rolloutId, stat) {
+  return `${rolloutId}\u0000${stat.size}\u0000${stat.mtimeMs}`;
+}
+
+function validCachedSummary(value, rolloutId) {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    value.rolloutId === rolloutId &&
+    Array.isArray(value.activities) &&
+    Array.isArray(value.tools) &&
+    Array.isArray(value.modelRows) &&
+    value.totals &&
+    typeof value.totals === "object",
+  );
+}
+
+function normalizeInputCache(cache, diagnostic) {
+  if (cache == null) return {};
+  if (
+    !cache ||
+    typeof cache !== "object" ||
+    cache.version !== CACHE_VERSION ||
+    !cache.entries ||
+    typeof cache.entries !== "object" ||
+    Array.isArray(cache.entries)
+  ) {
+    diagnostic("CACHE_INVALID");
+    return {};
+  }
+  return cache.entries;
+}
+
+function parseDateParts(value) {
+  const match = String(value || "").match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return null;
+  const date = new Date(
+    Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])),
+  );
+  if (!Number.isFinite(date.getTime())) return null;
+  return {
+    date,
+    year: match[1],
+    month: match[2],
+    day: match[3],
+    key: `${match[1]}-${match[2]}-${match[3]}`,
+  };
+}
+
+function rolloutLocation(path) {
+  const normalized = String(path || "").replace(/\\/g, "/");
+  const match = normalized.match(/^(.*)\/(\d{4})\/(\d{2})\/(\d{2})\/[^/]+$/);
+  if (!match) return null;
+  return {
+    base: match[1],
+    date: parseDateParts(`${match[2]}-${match[3]}-${match[4]}`),
+  };
+}
+
+function dayDir(base, dateParts) {
+  return join(base, dateParts.year, dateParts.month, dateParts.day);
+}
+
+function addDays(date, amount) {
+  return new Date(date.getTime() + amount * 86_400_000);
+}
+
+function partsFromDate(date) {
+  const pad = (value) => String(value).padStart(2, "0");
+  return parseDateParts(
+    `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`,
+  );
+}
+
+function listJsonl(dir) {
+  try {
+    return readdirSync(dir)
+      .filter((name) => name.toLowerCase().endsWith(".jsonl"))
+      .sort()
+      .map((name) => join(dir, name));
+  } catch {
+    return [];
+  }
+}
+
+function idMatchesFilename(path, rolloutId) {
+  const name = basename(path).toLowerCase();
+  return (
+    name.endsWith(`-${String(rolloutId).toLowerCase()}.jsonl`) ||
+    name === `${String(rolloutId).toLowerCase()}.jsonl`
+  );
+}
+
+function normalizeActivity(event, parentRolloutId) {
+  const payload = event?.payload || {};
+  if (event?.type !== "event_msg" || payload.type !== "sub_agent_activity")
+    return null;
+  const childId = String(
+    payload.agent_thread_id || payload.agentThreadId || "",
+  ).trim();
+  const kind = String(payload.kind || "")
+    .trim()
+    .toLowerCase();
+  if (!childId || !["started", "interacted", "interrupted"].includes(kind))
+    return null;
+  return {
+    parentRolloutId,
+    childId,
+    kind,
+    timestamp: event.timestamp || payload.timestamp || "",
+    agentPath: String(payload.agent_path || payload.agentPath || ""),
+    transcriptPath: "",
+    source: "transcript",
+  };
+}
+
+function normalizeSignal(signal) {
+  if (!signal || typeof signal !== "object") return null;
+  const childId = String(
+    signal.rolloutId ||
+      signal.rollout_id ||
+      signal.agentThreadId ||
+      signal.agent_thread_id ||
+      "",
+  ).trim();
+  const parentRolloutId = String(
+    signal.parentRolloutId ||
+      signal.parent_rollout_id ||
+      signal.parentThreadId ||
+      signal.parent_thread_id ||
+      "",
+  ).trim();
+  if (!childId) return null;
+  const rawKind = String(
+    signal.kind || signal.eventKind || signal.event_kind || "started",
+  ).toLowerCase();
+  const kind = ["interacted", "interrupted"].includes(rawKind)
+    ? rawKind
+    : "started";
+  return {
+    parentRolloutId,
+    childId,
+    kind,
+    timestamp: signal.timestamp || signal.startedAt || signal.started_at || "",
+    agentPath: String(signal.agentPath || signal.agent_path || ""),
+    transcriptPath: String(
+      signal.transcriptPath || signal.transcript_path || signal.path || "",
+    ),
+    source: "signal",
+  };
+}
+
+function modelRowCost(row) {
+  return costBreakdown(row.usage, priceForModel(row.model))?.total || 0;
+}
+
+function emptyScanSummary(rolloutId) {
+  return {
+    rolloutId,
+    activities: [],
+    malformedLines: 0,
+    effort: "",
+    calls: 0,
+    tools: [],
+    totals: emptyTokenUsage(),
+    modelRows: [],
+    cost: 0,
+  };
+}
+
+function parseRolloutStream(path, rolloutId, shouldContinue) {
+  const summary = emptyScanSummary(rolloutId);
+  const tools = new Set();
+  const byModel = new Map();
+  let currentModel = "unknown";
+  let currentProvider = "unknown";
+  let fd;
+  let carry = "";
+  const decoder = new StringDecoder("utf8");
+
+  const parseLine = (line) => {
+    if (!line) return;
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      summary.malformedLines += 1;
+      return;
+    }
+    const payload = event?.payload || {};
+    if (event?.type === "session_meta") {
+      currentModel = String(payload.model || currentModel || "unknown");
+      currentProvider = String(
+        payload.model_provider || currentProvider || "unknown",
+      );
+      return;
+    }
+    if (event?.type === "turn_context") {
+      currentModel = String(payload.model || currentModel || "unknown");
+      currentProvider = String(
+        payload.model_provider || currentProvider || "unknown",
+      );
+      summary.effort = String(
+        payload.effort ||
+          payload.reasoning_effort ||
+          payload.collaboration_mode?.settings?.reasoning_effort ||
+          summary.effort ||
+          "",
+      );
+      return;
+    }
+    const subagentActivity = normalizeActivity(event, rolloutId);
+    if (subagentActivity) {
+      summary.activities.push(subagentActivity);
+      return;
+    }
+    if (event?.type === "response_item" && payload.type === "function_call") {
+      tools.add(String(payload.name || "function_call"));
+      return;
+    }
+    if (
+      event?.type === "response_item" &&
+      payload.type === "tool_search_call"
+    ) {
+      tools.add("tool_search");
+      return;
+    }
+    if (event?.type === "response_item" && payload.type === "web_search_call") {
+      tools.add("web_search");
+      return;
+    }
+    if (event?.type !== "event_msg" || payload.type !== "token_count") return;
+    const info = payload.info || {};
+    if (!info.last_token_usage) return;
+    const usage = normalizeCodexUsage(info.last_token_usage);
+    const model = String(
+      info.model || payload.model || currentModel || "unknown",
+    );
+    const provider = String(
+      info.model_provider ||
+        payload.model_provider ||
+        currentProvider ||
+        "unknown",
+    );
+    const key = `${provider}\u0000${model}\u0000${summary.effort}`;
+    const row = byModel.get(key) || {
+      provider,
+      model,
+      effort: summary.effort,
+      calls: 0,
+      usage: emptyTokenUsage(),
+    };
+    row.calls += 1;
+    addUsage(row.usage, usage);
+    byModel.set(key, row);
+    summary.calls += 1;
+    addUsage(summary.totals, usage);
+  };
+
+  try {
+    fd = openSync(path, "r");
+    const buffer = Buffer.allocUnsafe(READ_CHUNK_BYTES);
+    while (true) {
+      if (!shouldContinue("chunk")) return { ok: false, summary };
+      const bytesRead = readSync(fd, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      carry += decoder.write(buffer.subarray(0, bytesRead));
+      let newlineAt;
+      while ((newlineAt = carry.indexOf("\n")) !== -1) {
+        const line = carry.slice(0, newlineAt).replace(/\r$/, "");
+        carry = carry.slice(newlineAt + 1);
+        parseLine(line);
+      }
+    }
+    carry += decoder.end();
+    if (carry) parseLine(carry.replace(/\r$/, ""));
+  } catch {
+    return { ok: false, summary };
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+
+  summary.tools = [...tools].sort();
+  summary.modelRows = [...byModel.values()]
+    .sort((left, right) =>
+      `${left.provider}\u0000${left.model}\u0000${left.effort}`.localeCompare(
+        `${right.provider}\u0000${right.model}\u0000${right.effort}`,
+      ),
+    )
+    .map((row) => {
+      const cost = round4(modelRowCost(row));
+      return {
+        ...row,
+        tokens: tokenTotal(row.usage),
+        cost,
+        costs: { model: cost },
+      };
+    });
+  summary.cost = round4(
+    summary.modelRows.reduce((total, row) => total + row.cost, 0),
+  );
+  return { ok: true, summary };
+}
+
+function fileDigest(path, shouldContinue) {
+  let fd;
+  const hash = createHash("sha256");
+  try {
+    fd = openSync(path, "r");
+    const buffer = Buffer.allocUnsafe(READ_CHUNK_BYTES);
+    while (true) {
+      if (!shouldContinue("duplicate-hash")) return null;
+      const bytesRead = readSync(fd, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      hash.update(buffer.subarray(0, bytesRead));
+    }
+    return hash.digest("hex");
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+function sourceSubagent(meta) {
+  return meta?.source?.subagent || null;
+}
+
+function immediateParent(meta) {
+  return String(
+    meta?.parent_thread_id ||
+      sourceSubagent(meta)?.thread_spawn?.parent_thread_id ||
+      "",
+  ).trim();
+}
+
+function makeAgent(meta, summary, status, fallbackDepth) {
+  const spawn = sourceSubagent(meta)?.thread_spawn || {};
+  const calls = Number(summary.calls) || 0;
+  const tokens = tokenTotal(summary.totals);
+  return {
+    id: String(meta.id),
+    parentId: immediateParent(meta),
+    depth: Number(spawn.depth) || fallbackDepth,
+    agentType: String(spawn.agent_nickname || "codex-subagent"),
+    workflow: null,
+    status: status || "started",
+    model:
+      calls > 0 ? String(summary.modelRows[0]?.model || "unknown") : "unknown",
+    effort: calls > 0 ? String(summary.effort || "") : "",
+    tools: summary.tools.length,
+    toolNames: [...summary.tools],
+    calls,
+    tokens,
+    cost: round4(summary.cost),
+    modelRows: summary.modelRows.map((row) => ({ ...row })),
+  };
+}
+
+function aggregateAgents(agents) {
+  const usage = emptyTokenUsage();
+  const tools = new Set();
+  const byModel = new Map();
+  let calls = 0;
+  let cost = 0;
+  for (const agent of agents) {
+    calls += agent.calls || 0;
+    cost += agent.cost || 0;
+    for (const name of agent.toolNames || []) tools.add(name);
+    for (const row of agent.modelRows || []) {
+      addUsage(usage, row.usage || {});
+      const key = `${row.provider || "unknown"}\u0000${row.model || "unknown"}\u0000${row.effort || ""}`;
+      const current = byModel.get(key) || {
+        provider: row.provider || "unknown",
+        model: row.model || "unknown",
+        effort: row.effort || "",
+        calls: 0,
+        usage: emptyTokenUsage(),
+        cost: 0,
+      };
+      current.calls += row.calls || 0;
+      addUsage(current.usage, row.usage || {});
+      current.cost += row.cost || row.costs?.model || 0;
+      byModel.set(key, current);
+    }
+  }
+  const modelRows = [...byModel.values()]
+    .sort((left, right) =>
+      `${left.provider}\u0000${left.model}\u0000${left.effort}`.localeCompare(
+        `${right.provider}\u0000${right.model}\u0000${right.effort}`,
+      ),
+    )
+    .map((row) => ({
+      ...row,
+      tokens: tokenTotal(row.usage),
+      cost: round4(row.cost),
+      costs: { model: round4(row.cost) },
+      source: "subagent",
+    }));
+  return {
+    count: agents.length,
+    calls,
+    tokens: tokenTotal(usage),
+    cost: round4(cost),
+    wasted: 0,
+    usage,
+    tools: [...tools].sort(),
+    modelRows,
+  };
+}
+
+/**
+ * Compose a deterministic Codex subagent graph from registered top-level rollouts.
+ * Transcripts are authoritative; cache is a caller-owned, discardable optimization.
+ */
+export function composeCodexSubagentGraph({
+  rootPaths = [],
+  canonicalSessionId = "",
+  signals = [],
+  cache = null,
+  mode = "live",
+  limits: limitOverrides = {},
+  deadlineAt = Number.POSITIVE_INFINITY,
+  now,
+} = {}) {
+  const live = mode !== "offline";
+  const limits = normalizedLimits(limitOverrides);
+  const clock = makeClock(now);
+  const diagnosticCounts = new Map();
+  const diagnostic = (code, count = 1) => {
+    if (!DIAGNOSTIC_ORDER.includes(code)) return;
+    diagnosticCounts.set(code, (diagnosticCounts.get(code) || 0) + count);
+  };
+  let aborted = false;
+  const shouldContinue = (phase) => {
+    if (aborted) return false;
+    if (live && clock(phase) >= Number(deadlineAt)) {
+      diagnostic("LIVE_DEADLINE_EXCEEDED");
+      aborted = true;
+      return false;
+    }
+    return true;
+  };
+
+  const inputCache = normalizeInputCache(cache, diagnostic);
+  const outputCache = {};
+  const stats = {
+    parsedRollouts: 0,
+    cacheHits: 0,
+    fallbackDays: 0,
+    fallbackCandidates: 0,
+    uncachedBytes: 0,
+  };
+  const sourceByPath = new Map();
+  const statuses = new Map();
+  const statusRank = { started: 1, interacted: 2, interrupted: 3 };
+  const updateStatus = (activityItem) => {
+    const current = statuses.get(activityItem.childId) || "started";
+    if ((statusRank[activityItem.kind] || 0) >= (statusRank[current] || 0)) {
+      statuses.set(activityItem.childId, activityItem.kind);
+    }
+  };
+  const graphEvidence = new Set();
+  const queue = [];
+  const queuedEdges = new Set();
+  const enqueue = (item) => {
+    if (!item?.childId) return;
+    updateStatus(item);
+    if (item.kind !== "started") return;
+    const key = `${item.parentRolloutId}\u0000started\u0000${item.childId}`;
+    graphEvidence.add(key);
+    if (queuedEdges.has(key)) return;
+    queuedEdges.add(key);
+    queue.push(item);
+  };
+
+  const roots = [
+    ...new Set(
+      (Array.isArray(rootPaths) ? rootPaths : [rootPaths])
+        .filter((value) => typeof value === "string" && value)
+        .map((value) => resolve(value)),
+    ),
+  ].sort();
+  if (roots.length === 0) diagnostic("PARENT_META_INVALID");
+  const rootLocations = roots.map(rolloutLocation).filter(Boolean);
+  const bases = [...new Set(rootLocations.map((item) => item.base))].sort();
+  const rootDates = rootLocations.map((item) => item.date).filter(Boolean);
+  const rootRecords = [];
+  const rootIds = new Set();
+  const acceptedParents = new Set();
+  const depthById = new Map();
+
+  const addSource = (path, rolloutId, stat) => {
+    sourceByPath.set(resolve(path), {
+      path: resolve(path),
+      rolloutId,
+      ...stat,
+    });
+  };
+
+  const scanWithCache = (path, rolloutId, stat, role) => {
+    const key = cacheKey(rolloutId, stat);
+    const cached = inputCache[key];
+    if (cached !== undefined) {
+      if (validCachedSummary(cached, rolloutId)) {
+        stats.cacheHits += 1;
+        outputCache[key] = cached;
+        return cached;
+      }
+      diagnostic("CACHE_INVALID");
+    }
+    if (live && stats.uncachedBytes + stat.size > limits.maxLiveUncachedBytes) {
+      diagnostic("LIVE_BYTE_BUDGET_EXCEEDED");
+      aborted = true;
+      return null;
+    }
+    stats.uncachedBytes += stat.size;
+    const parsed = parseRolloutStream(path, rolloutId, shouldContinue);
+    if (!parsed.ok) {
+      if (!aborted)
+        diagnostic(
+          role === "root" ? "PARENT_META_INVALID" : "CHILD_META_INVALID",
+        );
+      return null;
+    }
+    stats.parsedRollouts += 1;
+    outputCache[key] = parsed.summary;
+    if (parsed.summary.malformedLines > 0) {
+      diagnostic(
+        role === "root" ? "PARENT_META_INVALID" : "CHILD_META_INVALID",
+      );
+    }
+    return parsed.summary;
+  };
+
+  if (shouldContinue("start")) {
+    for (const path of roots) {
+      if (!shouldContinue("root")) break;
+      const stat = safeStat(path);
+      const metaResult = readCodexRolloutMeta(path);
+      if (!stat || !metaResult.ok || !metaResult.meta?.id) {
+        diagnostic("PARENT_META_INVALID");
+        continue;
+      }
+      const meta = metaResult.meta;
+      const rolloutId = String(meta.id);
+      addSource(path, rolloutId, stat);
+      if (sourceSubagent(meta)) {
+        diagnostic("PARENT_META_INVALID");
+        continue;
+      }
+      if (rootIds.has(rolloutId)) {
+        diagnostic("DUPLICATE_ROLLOUT_ID");
+        continue;
+      }
+      if (rootIds.size >= limits.maxGraphNodes) {
+        diagnostic("GRAPH_LIMIT_EXCEEDED");
+        aborted = true;
+        break;
+      }
+      rootIds.add(rolloutId);
+      acceptedParents.add(rolloutId);
+      depthById.set(rolloutId, 0);
+      const summary = scanWithCache(path, rolloutId, stat, "root");
+      rootRecords.push({ path, rolloutId, stat, meta, summary });
+      for (const item of summary?.activities || []) enqueue(item);
+    }
+  }
+
+  const normalizedSignals = (Array.isArray(signals) ? signals : [signals])
+    .map(normalizeSignal)
+    .filter(Boolean)
+    .sort((left, right) =>
+      `${left.timestamp}\u0000${left.parentRolloutId}\u0000${left.childId}\u0000${left.kind}`.localeCompare(
+        `${right.timestamp}\u0000${right.parentRolloutId}\u0000${right.childId}\u0000${right.kind}`,
+      ),
+    );
+  for (const item of normalizedSignals) enqueue(item);
+
+  const directCandidates = (item) => {
+    const candidates = new Set();
+    if (item.transcriptPath && safeStat(item.transcriptPath))
+      candidates.add(resolve(item.transcriptPath));
+    if (
+      item.agentPath &&
+      item.agentPath.toLowerCase().endsWith(".jsonl") &&
+      safeStat(item.agentPath)
+    ) {
+      candidates.add(resolve(item.agentPath));
+    }
+    const date = parseDateParts(item.timestamp);
+    if (date) {
+      for (const base of bases) {
+        for (const path of listJsonl(dayDir(base, date))) {
+          if (idMatchesFilename(path, item.childId))
+            candidates.add(resolve(path));
+        }
+      }
+    }
+    return [...candidates].sort();
+  };
+
+  const fallbackCandidates = (item) => {
+    if (!rootDates.length || !bases.length) return [];
+    const start = new Date(
+      Math.min(...rootDates.map((entry) => entry.date.getTime())),
+    );
+    const latestRoot = new Date(
+      Math.max(...rootDates.map((entry) => entry.date.getTime())),
+    );
+    const hinted = parseDateParts(item.timestamp)?.date;
+    const end = addDays(hinted && hinted > latestRoot ? hinted : latestRoot, 1);
+    const span = Math.floor((end.getTime() - start.getTime()) / 86_400_000) + 1;
+    const daysToScan = Math.min(span, limits.maxFallbackDays);
+    if (span > limits.maxFallbackDays) diagnostic("FALLBACK_LIMIT_EXCEEDED");
+    const found = [];
+    for (let offset = 0; offset < daysToScan; offset += 1) {
+      if (!shouldContinue("fallback-day")) break;
+      stats.fallbackDays += 1;
+      const date = partsFromDate(addDays(start, offset));
+      for (const base of bases) {
+        for (const path of listJsonl(dayDir(base, date))) {
+          const resolved = resolve(path);
+          if (roots.includes(resolved)) continue;
+          if (stats.fallbackCandidates >= limits.maxFallbackCandidates) {
+            diagnostic("FALLBACK_LIMIT_EXCEEDED");
+            return found;
+          }
+          stats.fallbackCandidates += 1;
+          const metaResult = readCodexRolloutMeta(resolved);
+          if (
+            metaResult.ok &&
+            String(metaResult.meta?.id || "") === item.childId
+          )
+            found.push(resolved);
+        }
+      }
+    }
+    return [...new Set(found)].sort();
+  };
+
+  const agents = [];
+  const attempted = new Set();
+  while (queue.length > 0 && !aborted) {
+    if (!shouldContinue("node")) break;
+    const item = queue.shift();
+    if (
+      rootIds.has(item.childId) ||
+      acceptedParents.has(item.childId) ||
+      attempted.has(item.childId)
+    )
+      continue;
+    attempted.add(item.childId);
+    let candidates = directCandidates(item);
+    if (!candidates.length) candidates = fallbackCandidates(item);
+    if (!candidates.length) {
+      diagnostic("CHILD_MISSING");
+      continue;
+    }
+
+    const valid = [];
+    for (const path of candidates) {
+      const stat = safeStat(path);
+      const metaResult = readCodexRolloutMeta(path);
+      if (
+        !stat ||
+        !metaResult.ok ||
+        String(metaResult.meta?.id || "") !== item.childId
+      ) {
+        diagnostic("CHILD_META_INVALID");
+        continue;
+      }
+      addSource(path, item.childId, stat);
+      valid.push({ path, stat, meta: metaResult.meta });
+    }
+    if (!valid.length) continue;
+    if (valid.length > 1) {
+      const hashes = new Set(
+        valid
+          .map((candidate) => fileDigest(candidate.path, shouldContinue))
+          .filter(Boolean),
+      );
+      if (hashes.size !== 1 || hashes.size === 0) {
+        if (!aborted) diagnostic("DUPLICATE_ROLLOUT_ID");
+        continue;
+      }
+    }
+    const candidate = valid[0];
+    const meta = candidate.meta;
+    if (!sourceSubagent(meta)) {
+      diagnostic("CHILD_META_INVALID");
+      continue;
+    }
+    const parentId = immediateParent(meta);
+    const sessionRoot = String(meta.session_id || "").trim();
+    const compatibleRoots = new Set([
+      String(canonicalSessionId || ""),
+      ...rootIds,
+    ]);
+    if (sessionRoot && !compatibleRoots.has(sessionRoot)) {
+      diagnostic("ROOT_MISMATCH");
+      continue;
+    }
+    const effectiveParentId =
+      item.parentRolloutId ||
+      (item.source === "signal" && acceptedParents.has(parentId)
+        ? parentId
+        : "");
+    if (
+      !acceptedParents.has(effectiveParentId) ||
+      parentId !== effectiveParentId
+    ) {
+      diagnostic(sessionRoot ? "ROOT_MISMATCH" : "LEGACY_CHAIN_UNPROVEN");
+      continue;
+    }
+    if (!sessionRoot && (!parentId || !acceptedParents.has(parentId))) {
+      diagnostic("LEGACY_CHAIN_UNPROVEN");
+      continue;
+    }
+    if (rootIds.size + agents.length >= limits.maxGraphNodes) {
+      diagnostic("GRAPH_LIMIT_EXCEEDED");
+      aborted = true;
+      break;
+    }
+
+    const summary = scanWithCache(
+      candidate.path,
+      item.childId,
+      candidate.stat,
+      "child",
+    );
+    if (!summary) continue;
+    const depth = (depthById.get(parentId) || 0) + 1;
+    const agent = makeAgent(meta, summary, statuses.get(item.childId), depth);
+    agents.push(agent);
+    acceptedParents.add(item.childId);
+    depthById.set(item.childId, agent.depth);
+    for (const activityItem of summary.activities) enqueue(activityItem);
+  }
+
+  agents.sort((left, right) => left.id.localeCompare(right.id));
+  const aggregate = aggregateAgents(agents);
+  if (!aborted && sourceByPath.size > 0 && shouldContinue("before-recheck")) {
+    for (const source of sourceByPath.values()) {
+      const current = safeStat(source.path);
+      if (!sameStat(current, source)) diagnostic("SOURCE_CHANGED_DURING_SCAN");
+    }
+  }
+
+  const rootStats = rootRecords
+    .map((record) => ({
+      rolloutId: record.rolloutId,
+      size: record.stat.size,
+      mtimeMs: record.stat.mtimeMs,
+    }))
+    .sort((left, right) => left.rolloutId.localeCompare(right.rolloutId));
+  const sourceManifest = [...sourceByPath.values()].sort((left, right) =>
+    `${left.rolloutId}\u0000${left.path}`.localeCompare(
+      `${right.rolloutId}\u0000${right.path}`,
+    ),
+  );
+  const sourceHashInput = sourceManifest
+    .map((source) => ({
+      rolloutId: source.rolloutId,
+      size: source.size,
+      mtimeMs: source.mtimeMs,
+    }))
+    .sort((left, right) =>
+      `${left.rolloutId}\u0000${left.size}\u0000${left.mtimeMs}`.localeCompare(
+        `${right.rolloutId}\u0000${right.size}\u0000${right.mtimeMs}`,
+      ),
+    );
+  const diagnostics = DIAGNOSTIC_ORDER.filter((code) =>
+    diagnosticCounts.has(code),
+  ).map((code) => ({ code, count: diagnosticCounts.get(code) }));
+  const state =
+    diagnostics.length > 0
+      ? "degraded"
+      : agents.length > 0
+        ? "complete"
+        : "none";
+
+  return {
+    state,
+    frontier: {
+      rootsStatHash: stableHash(rootStats),
+      graphCursor: stableHash([...graphEvidence].sort()),
+      sourceManifestHash: stableHash(sourceHashInput),
+    },
+    subagents: agents,
+    descendantIds: agents.map((agent) => agent.id),
+    workflows: [],
+    aggregate,
+    diagnostics,
+    sourceManifest,
+    cache: { version: CACHE_VERSION, entries: outputCache },
+    stats,
+  };
+}

--- a/hooks/harness-doctor.mjs
+++ b/hooks/harness-doctor.mjs
@@ -8,7 +8,88 @@ import { buildEffectiveRequirementPackage, checkSpecsState, evaluateVerdict, tas
 import { getLocale } from './locale.mjs';
 import { priceForModel } from './token-usage.mjs';
 import { countMissing, indexDerivedBySession, listSessionNotes, missingDerivedLinks } from './derived-sections.mjs';
-import { readControl } from './obsidian-common.mjs';
+import { readControl, readSessionRegistry } from './obsidian-common.mjs';
+import { parseObservabilityCheckpoint } from './session-observability-state.mjs';
+import { readObservabilityStore } from './session-observability-store.mjs';
+import { assessObservabilityFreshness } from './session-observability-lifecycle.mjs';
+
+export function checkSessionObservability(vaultBase, deps = {}) {
+  const readRegistry = deps.readRegistry || readSessionRegistry;
+  const readStore = deps.readStore || readObservabilityStore;
+  const readNote = deps.readNote || readFileSync;
+  const statSource = deps.statSource || statSync;
+  const registry = readRegistry(vaultBase);
+  const result = { ok: true, scanned: 0, healthy: 0, issues: [] };
+  const entries = Object.entries(registry?.sessions || {})
+    .map(([sessionId, entry]) => ({ sessionId, ...entry }))
+    .filter((entry) => entry.session_file)
+    .sort((a, b) => a.sessionId.localeCompare(b.sessionId));
+
+  for (const entry of entries) {
+    if (entry.provider && entry.provider !== 'codex') continue;
+    const notePath = join(vaultBase, entry.session_file);
+    let content;
+    try { content = readNote(notePath, 'utf8'); } catch { continue; }
+    if (!entry.provider && /^provider:\s*["']?claude/m.test(content)) continue;
+    result.scanned += 1;
+    const command = `wendkeep cost rebuild --session ${entry.sessionId} --json`;
+    const checkpoint = parseObservabilityCheckpoint(content);
+    if (!checkpoint) {
+      result.issues.push({
+        sessionId: entry.sessionId, status: 'legacy', diagnostics: [], command,
+      });
+      continue;
+    }
+    if (checkpoint.state === 'degraded') {
+      result.issues.push({
+        sessionId: entry.sessionId,
+        status: 'degraded',
+        diagnostics: checkpoint.diagnostics,
+        command,
+      });
+      continue;
+    }
+
+    let runtime;
+    try { runtime = readStore(vaultBase, entry.sessionId); } catch {
+      runtime = null;
+    }
+    const assessment = assessObservabilityFreshness({
+      checkpoint,
+      runtimeState: runtime,
+      statSource,
+    });
+    if (!assessment.fresh) {
+      result.issues.push({
+        sessionId: entry.sessionId,
+        status: assessment.status,
+        diagnostics: assessment.diagnostics,
+        command,
+      });
+      continue;
+    }
+    result.healthy += 1;
+  }
+  result.ok = result.issues.length === 0;
+  return result;
+}
+
+export function renderSessionObservabilityLines(result) {
+  const issues = result?.issues || [];
+  const lines = [
+    `[observabilidade] ${result?.healthy || 0} saudável(is) · ${issues.length} reparável(is)`,
+  ];
+  for (const issue of issues) {
+    const diagnostics = issue.diagnostics?.length
+      ? ` (${issue.diagnostics.map(({ code, count }) => `${code}:${count}`).join(', ')})`
+      : '';
+    lines.push(`  ✗ ${issue.sessionId}: ${issue.status}${diagnostics}`);
+    lines.push(`    → ${issue.command}`);
+    lines.push(`    → ${issue.command} --apply`);
+  }
+  if (!issues.length) lines.push('  ✓ frontiers, checkpoints e manifests consistentes');
+  return lines;
+}
 
 export function checkHarness(vaultBase, projectRoot) {
   const loc = getLocale(vaultBase);

--- a/hooks/import-sessions.mjs
+++ b/hooks/import-sessions.mjs
@@ -16,10 +16,20 @@ import {
 } from './session-stop.mjs';
 import { buildSessionContent, allocateSessionPath } from './session-start.mjs';
 import { createLinkedNotes } from './linked-notes.mjs';
-import { updateSessionObservability } from './session-observability.mjs';
+import {
+  composeSessionObservability,
+  publishSessionObservability,
+} from './session-observability.mjs';
 import { readSessionRegistry, upsertSessionRegistry, removeSessionRegistryEntry, formatLocalIso, formatDate, providerMeta, isBootstrapPrompt } from './obsidian-common.mjs';
 import { getLocale } from './locale.mjs';
 import { captureProseDecisions } from './decision-capture.mjs';
+import { readCodexRolloutMeta } from './codex-rollout-meta.mjs';
+import {
+  parseObservabilityCheckpoint,
+  sanitizeObservabilityDiagnostics,
+} from './session-observability-state.mjs';
+import { readObservabilityStore } from './session-observability-store.mjs';
+import { assessObservabilityFreshness } from './session-observability-lifecycle.mjs';
 
 // Claude encodes a project's absolute path as its `.claude/projects` dir name by replacing each
 // path separator and the drive colon with '-'. `C:\GitHub\WendKeep` -> `C--GitHub-WendKeep`.
@@ -97,41 +107,6 @@ function readPrefix(path, bytes = 4096) {
   }
 }
 
-// Read the first physical line in full, growing the buffer until a newline is found (capped).
-// A fixed prefix truncated any rollout whose session_meta line exceeded the window, silently
-// dropping that session from discovery — Codex meta lines can be large (env, git, instructions).
-function readFirstLine(path, maxBytes = 4 * 1024 * 1024) {
-  let fd;
-  try {
-    fd = openSync(path, 'r');
-    const chunk = Buffer.alloc(65536);
-    let acc = '';
-    let pos = 0;
-    while (pos < maxBytes) {
-      const n = readSync(fd, chunk, 0, chunk.length, pos);
-      if (n <= 0) break;
-      acc += chunk.slice(0, n).toString('utf-8');
-      const nl = acc.indexOf('\n');
-      if (nl >= 0) return acc.slice(0, nl);
-      pos += n;
-    }
-    return acc; // single-line file, or gave up at the cap
-  } catch {
-    return '';
-  } finally {
-    if (fd !== undefined) { try { closeSync(fd); } catch { /* already closed */ } }
-  }
-}
-
-// Pull the session_meta payload (id + cwd). session_meta is line 1 of a rollout.
-function readSessionMeta(path) {
-  const line = readFirstLine(path);
-  if (!line.trim()) return null;
-  let e;
-  try { e = JSON.parse(line); } catch { return null; }
-  return e.type === 'session_meta' ? (e.payload || {}) : null;
-}
-
 // The `session_id` recorded in a note's frontmatter (empty when absent).
 function noteSessionId(path) {
   const m = readPrefix(path, 2048).match(/^session_id:\s*["']?([^"'\r\n]+)["']?\s*$/m);
@@ -189,8 +164,9 @@ export function discoverCodexTranscripts(projectPath, fromDir) {
   if (!dir || !existsSync(dir)) return { dir, transcripts: [] };
   const transcripts = [];
   for (const path of walkFiles(dir, /\.jsonl$/i)) {
-    const meta = readSessionMeta(path);
-    if (!meta || !meta.id) continue;
+    const metaResult = readCodexRolloutMeta(path);
+    if (!metaResult.ok || !metaResult.meta.id) continue;
+    const meta = metaResult.meta;
     if (projectPath && !cwdMatchesProject(meta.cwd, projectPath)) continue;
     // A subagent thread's rollout is a SIBLING file of its parent's — same dir, own id. The
     // meta says what the file IS; ignoring it turned hierarchy into a duplicate session note.
@@ -248,11 +224,6 @@ export function importSession(vaultBase, txPath, opts = {}) {
     insertIteration(absPath, block, turn.turnId, tx, vaultBase);
   }
 
-  // Cost + subagent telemetry, exactly like the live Stop hook. Fail-open.
-  try {
-    updateSessionObservability({ vaultBase, sessionPath: absPath, transcriptPath: txPath });
-  } catch { /* observability is best-effort */ }
-
   // Finalize: derived notes + closing section + ended_at from the last turn.
   const endedAt = formatLocalIso(endDate);
   const created = mergeCreatedNotes(
@@ -270,6 +241,17 @@ export function importSession(vaultBase, txPath, opts = {}) {
     transcript_path: txPath,
     imported: true,
   });
+
+  // Materialize only after the authoritative registry entry exists. This gives import the
+  // same causal CAS + runtime manifest as live hooks instead of a note-only legacy snapshot.
+  try {
+    reconcileImportedObservability({
+      vaultBase,
+      sessionId,
+      sessionPath: absPath,
+      transcriptPath: txPath,
+    });
+  } catch { /* observability is best-effort and reported on a later reconciliation */ }
 
   return { sessionId, relPath, turns: turns.length };
 }
@@ -333,12 +315,105 @@ export function stampSessionIds(vaultBase) {
   return report;
 }
 
+export function reconcileImportedObservability({
+  vaultBase,
+  sessionId,
+  sessionPath,
+  transcriptPath,
+  dryRun = false,
+} = {}, dependencies = {}) {
+  const readRegistry = dependencies.readRegistry || readSessionRegistry;
+  const readStore = dependencies.readStore || readObservabilityStore;
+  const compose = dependencies.compose || composeSessionObservability;
+  const publish = dependencies.publish || publishSessionObservability;
+  if (!vaultBase || !sessionId || !sessionPath || !existsSync(sessionPath)) {
+    return {
+      status: 'degraded',
+      diagnostics: [{ code: 'PARENT_META_INVALID', count: 1 }],
+    };
+  }
+
+  let entry;
+  let content;
+  let runtimeState;
+  try {
+    entry = readRegistry(vaultBase)?.sessions?.[sessionId];
+    content = readFileSync(sessionPath, 'utf8');
+    runtimeState = readStore(vaultBase, sessionId);
+  } catch {
+    return { status: 'degraded', diagnostics: [{ code: 'CACHE_INVALID', count: 1 }] };
+  }
+  if (!entry) {
+    return {
+      status: 'degraded',
+      diagnostics: [{ code: 'PARENT_META_INVALID', count: 1 }],
+    };
+  }
+  const checkpoint = parseObservabilityCheckpoint(content);
+  const assessment = assessObservabilityFreshness({ checkpoint, runtimeState });
+  if (assessment.fresh) return { status: 'fresh', diagnostics: [] };
+
+  let candidate;
+  try {
+    candidate = compose({
+      sessionContent: content,
+      sessionEntry: { ...entry, transcript_path: entry.transcript_path || transcriptPath },
+      canonicalConversationId: sessionId,
+      runtimeState,
+      allowNone: true,
+      mode: 'offline',
+    });
+  } catch {
+    return {
+      status: 'degraded',
+      diagnostics: [{ code: 'PARENT_META_INVALID', count: 1 }],
+    };
+  }
+  const diagnostics = sanitizeObservabilityDiagnostics(candidate?.diagnostics || []);
+  if (candidate?.state === 'degraded') return { status: 'degraded', diagnostics };
+  if (candidate?.state !== 'complete' && candidate?.state !== 'none') {
+    return {
+      status: 'degraded',
+      diagnostics: [{ code: 'PARENT_META_INVALID', count: 1 }],
+    };
+  }
+  if (dryRun) return { status: 'would-reconcile', diagnostics };
+
+  let outcome;
+  try {
+    outcome = publish({
+      vaultBase,
+      sessionPath,
+      canonicalConversationId: sessionId,
+      candidate,
+      caller: 'import-reconcile',
+      allowSourceRefresh: true,
+      allowDegradedRecovery: true,
+    });
+  } catch {
+    return { status: 'degraded', diagnostics: [{ code: 'CACHE_INVALID', count: 1 }] };
+  }
+  if (outcome?.status === 'published' || outcome?.status === 'unchanged') {
+    return { status: 'published', diagnostics };
+  }
+  if (outcome?.status === 'stale' || outcome?.status === 'conflict') {
+    return {
+      status: 'stale',
+      diagnostics: [{ code: 'STALE_FRONTIER', count: 1 }],
+    };
+  }
+  return { status: 'degraded', diagnostics };
+}
+
 // Import every not-yet-captured transcript from the requested source(s). Deduped by session_id
 // against the registry. Options: { projectPath, source ('all'|'claude'|'codex'), from, codexFrom,
 // since (ISO/date), limit, dryRun }. importSession is provider-agnostic, so both sources share
 // the same dedup + import loop.
 export function runImport(vaultBase, opts = {}) {
-  const { projectPath = process.cwd(), source = 'all', from = '', codexFrom = '', since = '', limit = 0, dryRun = false } = opts;
+  const {
+    projectPath = process.cwd(), source = 'all', from = '', codexFrom = '', since = '',
+    limit = 0, dryRun = false, reconcileObservability = reconcileImportedObservability,
+  } = opts;
   const src = String(source).toLowerCase();
   const transcripts = [];
   let claudeDir = '';
@@ -355,7 +430,57 @@ export function runImport(vaultBase, opts = {}) {
   }
   const notes = capturedSessionNotes(vaultBase);
   const sinceMs = since ? Date.parse(since) : 0;
-  const report = { source: src, claudeDir, codexDir, scanned: transcripts.length, imported: 0, repaired: 0, skipped: 0, subagents: 0, errors: [], sessions: [] };
+  const report = {
+    source: src, claudeDir, codexDir, scanned: transcripts.length, imported: 0,
+    repaired: 0, skipped: 0, subagents: 0, observabilityReconciled: 0,
+    observabilityFresh: 0, observabilityDegraded: 0, errors: [], sessions: [],
+  };
+
+  const degradedObservability = () => ({
+    status: 'degraded',
+    diagnostics: [{ code: 'CACHE_INVALID', count: 1 }],
+  });
+  const reportableObservabilityStatuses = new Set([
+    'degraded', 'fresh', 'published', 'stale', 'unchanged', 'would-reconcile',
+  ]);
+  const sanitizeReportedObservability = (result) => {
+    try {
+      const status = String(result?.status || 'degraded');
+      if (!reportableObservabilityStatuses.has(status)) return degradedObservability();
+      const projected = (result?.diagnostics || []).map((diagnostic) => ({
+        code: diagnostic?.code,
+        count: diagnostic?.count,
+      }));
+      return { status, diagnostics: sanitizeObservabilityDiagnostics(projected) };
+    } catch {
+      return degradedObservability();
+    }
+  };
+
+  const reconcileExistingObservability = (transcript, sessionPath, turns) => {
+    if (typeof reconcileObservability !== 'function') return null;
+    let result;
+    try {
+      result = reconcileObservability({
+        vaultBase,
+        sessionId: transcript.sessionId,
+        sessionPath,
+        transcriptPath: transcript.path,
+        dryRun,
+      });
+    } catch {
+      result = degradedObservability();
+    }
+    const observability = sanitizeReportedObservability(result);
+    if (observability.status === 'fresh' || observability.status === 'unchanged') {
+      report.observabilityFresh++;
+    } else if (observability.status === 'published' || observability.status === 'would-reconcile') {
+      report.observabilityReconciled++;
+    } else {
+      report.observabilityDegraded++;
+    }
+    return observability;
+  };
 
   let done = 0;
   for (const t of transcripts) {
@@ -390,7 +515,14 @@ export function runImport(vaultBase, opts = {}) {
     if (existingNote) {
       const have = noteTurnIds(existingNote);
       const missing = turns.filter((turn) => !have.has(String(turn.turnId)));
-      if (!missing.length) { report.skipped++; continue; }
+      if (!missing.length) {
+        const observability = reconcileExistingObservability(t, existingNote, 0);
+        if (observability) report.sessions.push({
+          sessionId: t.sessionId, turns: 0, observability,
+        });
+        report.skipped++;
+        continue;
+      }
       if (dryRun) {
         report.sessions.push({ sessionId: t.sessionId, turns: missing.length, repaired: true, dryRun: true });
         report.repaired++;
@@ -404,10 +536,13 @@ export function runImport(vaultBase, opts = {}) {
             turn.turnId, tx, vaultBase,
           );
         }
-        try {
-          updateSessionObservability({ vaultBase, sessionPath: existingNote, transcriptPath: t.path });
-        } catch { /* best-effort */ }
-        report.sessions.push({ sessionId: t.sessionId, turns: missing.length, repaired: true });
+        const observability = reconcileExistingObservability(t, existingNote, missing.length);
+        report.sessions.push({
+          sessionId: t.sessionId,
+          turns: missing.length,
+          repaired: true,
+          ...(observability ? { observability } : {}),
+        });
         report.repaired++;
         done++;
       } catch (error) {

--- a/hooks/session-identity.mjs
+++ b/hooks/session-identity.mjs
@@ -5,14 +5,49 @@ import {
   inspectTranscriptIdentityContent,
   resolveSessionIdentitySnapshot,
 } from '../packages/integrations/src/session-identity.mjs';
+import { readCodexRolloutMeta } from './codex-rollout-meta.mjs';
+
+function unknownTranscriptIdentity() {
+  return {
+    transcriptProvider: 'unknown',
+    provider: 'unknown',
+    canonicalConversationId: '',
+    transcriptId: '',
+    parentConversationId: '',
+  };
+}
+
+function inspectCodexMeta(meta, fallbackTranscriptId) {
+  return {
+    transcriptProvider: 'openai',
+    provider: 'codex',
+    canonicalConversationId: meta.session_id || meta.id || '',
+    transcriptId: meta.id || fallbackTranscriptId,
+    parentConversationId: meta.parent_thread_id || meta.forked_from_id || '',
+  };
+}
+
+function withoutCodexSessionMeta(content) {
+  return String(content || '').split('\n').filter((line) => {
+    try { return JSON.parse(line)?.type !== 'session_meta'; } catch { return true; }
+  }).join('\n');
+}
 
 export function inspectTranscriptIdentity(transcriptPath) {
-  const content = transcriptPath && existsSync(transcriptPath)
-    ? readFileSync(transcriptPath, 'utf-8')
-    : '';
-  return inspectTranscriptIdentityContent(content, {
-    fallbackTranscriptId: transcriptPath ? basename(transcriptPath, '.jsonl') : '',
+  const fallbackTranscriptId = transcriptPath ? basename(transcriptPath, '.jsonl') : '';
+  if (!transcriptPath || !existsSync(transcriptPath)) return unknownTranscriptIdentity();
+
+  const codexMeta = readCodexRolloutMeta(transcriptPath);
+  if (codexMeta.ok) return inspectCodexMeta(codexMeta.meta, fallbackTranscriptId);
+
+  // Claude JSONL has no session_meta header. Preserve its existing full-content inspection,
+  // but never reinterpret a later/misplaced Codex meta as the file identity.
+  let content;
+  try { content = readFileSync(transcriptPath, 'utf-8'); } catch { return unknownTranscriptIdentity(); }
+  const inspected = inspectTranscriptIdentityContent(withoutCodexSessionMeta(content), {
+    fallbackTranscriptId,
   });
+  return inspected.provider === 'claude' ? inspected : unknownTranscriptIdentity();
 }
 
 export function resolveSessionIdentity(vaultBase, input = {}, provider = detectProvider()) {

--- a/hooks/session-observability-lifecycle.mjs
+++ b/hooks/session-observability-lifecycle.mjs
@@ -1,0 +1,129 @@
+import { createHash } from 'node:crypto';
+import { statSync } from 'node:fs';
+import { readCodexRolloutMeta } from './codex-rollout-meta.mjs';
+
+const stableHash = (value) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
+
+function addTranscriptPath(paths, value) {
+  if (typeof value === 'string' && value.trim()) paths.add(value.trim());
+}
+
+function collectActivationPaths(paths, activations) {
+  if (!activations || typeof activations !== 'object') return;
+  const values = Array.isArray(activations) ? activations : Object.values(activations);
+  for (const activation of values) {
+    if (!activation || typeof activation !== 'object') continue;
+    addTranscriptPath(paths, activation.transcript_path);
+    for (const path of activation.transcript_paths || []) addTranscriptPath(paths, path);
+  }
+}
+
+function isCodexDescendant(meta) {
+  return Boolean(meta?.source && typeof meta.source === 'object' && meta.source.subagent);
+}
+
+// Resolve every transcript explicitly attached to the registry entry. Classification is
+// authoritative only when the rollout's first session_meta line can be read: filename and
+// directory layout are deliberately not used as subagent heuristics.
+export function resolveObservabilityRoots(entry, { readMeta = readCodexRolloutMeta } = {}) {
+  if (!entry || typeof entry !== 'object') {
+    return {
+      state: 'degraded',
+      rootPaths: [],
+      descendantPaths: [],
+      diagnostics: [{ code: 'MAIN_TRANSCRIPT_UNRESOLVED', count: 1 }],
+    };
+  }
+
+  const candidates = new Set();
+  addTranscriptPath(candidates, entry.transcript_path);
+  for (const path of entry.transcript_paths || []) addTranscriptPath(candidates, path);
+  collectActivationPaths(candidates, entry.activations);
+
+  const rootPaths = [];
+  const descendantPaths = [];
+  let unreadable = 0;
+  for (const path of [...candidates].sort((a, b) => a.localeCompare(b))) {
+    const result = readMeta(path);
+    if (!result?.ok) {
+      unreadable += 1;
+      continue;
+    }
+    if (isCodexDescendant(result.meta)) descendantPaths.push(path);
+    else rootPaths.push(path);
+  }
+
+  if (unreadable > 0) {
+    return {
+      state: 'degraded',
+      rootPaths,
+      descendantPaths,
+      diagnostics: [{ code: 'MAIN_TRANSCRIPT_UNRESOLVED', count: unreadable }],
+    };
+  }
+
+  return { state: 'complete', rootPaths, descendantPaths, diagnostics: [] };
+}
+
+function sameFrontier(left, right) {
+  return Boolean(left && right && JSON.stringify(left) === JSON.stringify(right));
+}
+
+export function assessObservabilityFreshness({
+  checkpoint,
+  runtimeState,
+  statSource = statSync,
+} = {}) {
+  if (!checkpoint) return { fresh: false, status: 'legacy', diagnostics: [] };
+  if (checkpoint.state === 'degraded') {
+    return {
+      fresh: false,
+      status: 'degraded',
+      diagnostics: checkpoint.diagnostics || [],
+    };
+  }
+  const manifest = runtimeState?.source_manifest;
+  if (!Array.isArray(manifest) || manifest.length === 0) {
+    return { fresh: false, status: 'manifest-unproven', diagnostics: [] };
+  }
+
+  const hashInput = [];
+  for (const source of manifest) {
+    if (!source || typeof source.path !== 'string' || typeof source.rolloutId !== 'string') {
+      return { fresh: false, status: 'manifest-unproven', diagnostics: [] };
+    }
+    let stat;
+    try { stat = statSource(source.path); } catch {
+      return {
+        fresh: false,
+        status: 'stale',
+        diagnostics: [{ code: 'STALE_FRONTIER', count: 1 }],
+      };
+    }
+    if (!stat.isFile() || stat.size !== Number(source.size)
+      || stat.mtimeMs !== Number(source.mtimeMs)) {
+      return {
+        fresh: false,
+        status: 'stale',
+        diagnostics: [{ code: 'STALE_FRONTIER', count: 1 }],
+      };
+    }
+    hashInput.push({ rolloutId: source.rolloutId, size: stat.size, mtimeMs: stat.mtimeMs });
+  }
+  hashInput.sort((left, right) =>
+    `${left.rolloutId}\u0000${left.size}\u0000${left.mtimeMs}`.localeCompare(
+      `${right.rolloutId}\u0000${right.size}\u0000${right.mtimeMs}`,
+    ));
+  const stale = stableHash(hashInput) !== checkpoint.frontier.source_manifest_hash
+    || !sameFrontier(runtimeState?.checkpoint_frontier, checkpoint.frontier)
+    || runtimeState?.observability_dirty !== false
+    || runtimeState?.observability_checkpoint_sequence !== runtimeState?.observability_signal_sequence
+    || runtimeState?.observability_checkpoint_sequence !== checkpoint.frontier.signal_sequence;
+  return stale
+    ? {
+      fresh: false,
+      status: 'stale',
+      diagnostics: [{ code: 'STALE_FRONTIER', count: 1 }],
+    }
+    : { fresh: true, status: 'fresh', diagnostics: [] };
+}

--- a/hooks/session-observability-state.mjs
+++ b/hooks/session-observability-state.mjs
@@ -1,0 +1,241 @@
+import { createHash } from 'node:crypto';
+
+export const OBSERVABILITY_SCHEMA = 2;
+
+export const OBSERVABILITY_DIAGNOSTIC_CODES = Object.freeze([
+  'CACHE_INVALID',
+  'CHILD_META_INVALID',
+  'CHILD_MISSING',
+  'DUPLICATE_ROLLOUT_ID',
+  'FALLBACK_LIMIT_EXCEEDED',
+  'GRAPH_LIMIT_EXCEEDED',
+  'LEGACY_CHAIN_UNPROVEN',
+  'LIVE_BYTE_BUDGET_EXCEEDED',
+  'LIVE_DEADLINE_EXCEEDED',
+  'MAIN_TRANSCRIPT_UNRESOLVED',
+  'PARENT_META_INVALID',
+  'ROOT_MISMATCH',
+  'SOURCE_CHANGED_DURING_SCAN',
+  'STALE_FRONTIER',
+]);
+
+const DIAGNOSTIC_CODE_SET = new Set(OBSERVABILITY_DIAGNOSTIC_CODES);
+const OBSERVABILITY_STATES = new Set(['complete', 'none', 'degraded']);
+const FRONTIER_STRING_FIELDS = [
+  'canonical_session_id',
+  'activation_id',
+  'roots_stat_hash',
+  'graph_cursor',
+  'source_manifest_hash',
+];
+const FRONTIER_SEQUENCE_FIELDS = [
+  'activation_epoch',
+  'turn_sequence',
+  'signal_sequence',
+];
+const FRONTMATTER_TO_FRONTIER = Object.freeze({
+  canonical_session_id: 'observability_session_id',
+  activation_id: 'observability_activation_id',
+  activation_epoch: 'observability_activation_epoch',
+  turn_sequence: 'observability_turn_sequence',
+  signal_sequence: 'observability_signal_sequence',
+  roots_stat_hash: 'observability_roots_stat_hash',
+  graph_cursor: 'observability_graph_cursor',
+  source_manifest_hash: 'observability_source_manifest_hash',
+});
+
+function diagnosticError() {
+  const error = new TypeError('diagnostic de observabilidade inválido');
+  error.code = 'OBSERVABILITY_DIAGNOSTIC_INVALID';
+  return error;
+}
+
+function frontierError() {
+  const error = new TypeError('frontier de observabilidade inválido');
+  error.code = 'OBSERVABILITY_FRONTIER_INVALID';
+  return error;
+}
+
+function checkpointError() {
+  const error = new TypeError('checkpoint de observabilidade inválido');
+  error.code = 'OBSERVABILITY_CHECKPOINT_INVALID';
+  return error;
+}
+
+function safeNonEmptyString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function safeSequence(value) {
+  if (typeof value === 'string' && /^\d+$/.test(value.trim())) value = Number(value);
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+/**
+ * Reduce diagnostics to the only shape that may cross the local runtime boundary.
+ * Values are never interpolated in thrown errors so rejected private data is not echoed.
+ */
+export function sanitizeObservabilityDiagnostics(diagnostics = []) {
+  if (!Array.isArray(diagnostics)) throw diagnosticError();
+  const counts = new Map();
+  for (const diagnostic of diagnostics) {
+    if (!diagnostic || typeof diagnostic !== 'object' || Array.isArray(diagnostic)) {
+      throw diagnosticError();
+    }
+    const keys = Object.keys(diagnostic).sort();
+    if (keys.length !== 2 || keys[0] !== 'code' || keys[1] !== 'count') {
+      throw diagnosticError();
+    }
+    if (!DIAGNOSTIC_CODE_SET.has(diagnostic.code)
+      || !Number.isSafeInteger(diagnostic.count)
+      || diagnostic.count <= 0) {
+      throw diagnosticError();
+    }
+    counts.set(diagnostic.code, (counts.get(diagnostic.code) || 0) + diagnostic.count);
+  }
+  return [...counts.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([code, count]) => ({ code, count }));
+}
+
+export function normalizeObservabilityFrontier(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) throw frontierError();
+  const frontier = {};
+  for (const field of FRONTIER_STRING_FIELDS) {
+    const value = safeNonEmptyString(input[field]);
+    if (value === null) throw frontierError();
+    frontier[field] = value;
+  }
+  for (const field of FRONTIER_SEQUENCE_FIELDS) {
+    const value = safeSequence(input[field]);
+    if (value === null) throw frontierError();
+    frontier[field] = value;
+  }
+  return {
+    canonical_session_id: frontier.canonical_session_id,
+    activation_id: frontier.activation_id,
+    activation_epoch: frontier.activation_epoch,
+    turn_sequence: frontier.turn_sequence,
+    signal_sequence: frontier.signal_sequence,
+    roots_stat_hash: frontier.roots_stat_hash,
+    graph_cursor: frontier.graph_cursor,
+    source_manifest_hash: frontier.source_manifest_hash,
+  };
+}
+
+export const buildObservabilityFrontier = normalizeObservabilityFrontier;
+
+export function hashObservabilityFrontier(input) {
+  const frontier = normalizeObservabilityFrontier(input);
+  return createHash('sha256').update(JSON.stringify(frontier)).digest('hex');
+}
+
+/**
+ * Compare a candidate frontier with the checkpoint already materialized.
+ * The argument order is deliberately (current, candidate), matching a CAS writer.
+ */
+export function compareObservabilityFrontiers(currentInput, candidateInput) {
+  if (!currentInput) {
+    normalizeObservabilityFrontier(candidateInput);
+    return 'newer';
+  }
+  const current = normalizeObservabilityFrontier(currentInput);
+  const candidate = normalizeObservabilityFrontier(candidateInput);
+  if (current.canonical_session_id !== candidate.canonical_session_id) return 'conflict';
+
+  for (const field of FRONTIER_SEQUENCE_FIELDS) {
+    if (candidate[field] < current[field]) return 'stale';
+    if (candidate[field] > current[field]) return 'newer';
+    if (field === 'activation_epoch' && candidate.activation_id !== current.activation_id) {
+      return 'conflict';
+    }
+  }
+
+  for (const field of ['roots_stat_hash', 'graph_cursor', 'source_manifest_hash']) {
+    if (candidate[field] !== current[field]) return 'conflict';
+  }
+  return 'same';
+}
+
+export const compareObservabilityFrontier = compareObservabilityFrontiers;
+
+function unquoteFrontmatterValue(raw) {
+  const value = String(raw ?? '').trim();
+  if (value.length >= 2 && value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replaceAll("''", "'");
+  }
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    try { return JSON.parse(value); } catch { return value.slice(1, -1); }
+  }
+  return value;
+}
+
+function checkpointFields(input) {
+  if (typeof input !== 'string') return input;
+  const normalized = input.replaceAll('\r\n', '\n');
+  const frontmatter = normalized.match(/^---\n([\s\S]*?)\n---(?:\n|$)/)?.[1] ?? normalized;
+  const fields = {};
+  for (const line of frontmatter.split('\n')) {
+    const match = line.match(/^([A-Za-z0-9_]+):\s*(.*)$/);
+    if (match) fields[match[1]] = unquoteFrontmatterValue(match[2]);
+  }
+  return fields;
+}
+
+export function renderObservabilityCheckpoint(frontierInput, {
+  state,
+  diagnostics = [],
+} = {}) {
+  const frontier = normalizeObservabilityFrontier(frontierInput);
+  if (!OBSERVABILITY_STATES.has(state)) throw checkpointError();
+  const safeDiagnostics = sanitizeObservabilityDiagnostics(diagnostics);
+  return {
+    observability_schema: OBSERVABILITY_SCHEMA,
+    subagents_observability_state: state,
+    observability_session_id: frontier.canonical_session_id,
+    observability_activation_id: frontier.activation_id,
+    observability_activation_epoch: frontier.activation_epoch,
+    observability_turn_sequence: frontier.turn_sequence,
+    observability_signal_sequence: frontier.signal_sequence,
+    observability_roots_stat_hash: frontier.roots_stat_hash,
+    observability_graph_cursor: frontier.graph_cursor,
+    observability_source_manifest_hash: frontier.source_manifest_hash,
+    subagents_diagnostics_json: JSON.stringify(safeDiagnostics),
+  };
+}
+
+function quoteFrontmatter(value) {
+  if (typeof value === 'number') return String(value);
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+export function renderObservabilityCheckpointLines(frontierInput, options = {}) {
+  const fields = renderObservabilityCheckpoint(frontierInput, options);
+  return Object.entries(fields).map(([key, value]) => `${key}: ${quoteFrontmatter(value)}`).join('\n');
+}
+
+export function parseObservabilityCheckpoint(input) {
+  const fields = checkpointFields(input);
+  if (!fields || typeof fields !== 'object') return null;
+  if (safeSequence(fields.observability_schema) !== OBSERVABILITY_SCHEMA) return null;
+  if (!OBSERVABILITY_STATES.has(fields.subagents_observability_state)) return null;
+  try {
+    const source = {};
+    for (const [field, frontmatterKey] of Object.entries(FRONTMATTER_TO_FRONTIER)) {
+      source[field] = unquoteFrontmatterValue(fields[frontmatterKey]);
+    }
+    const frontier = normalizeObservabilityFrontier(source);
+    const diagnosticsRaw = unquoteFrontmatterValue(fields.subagents_diagnostics_json ?? '[]');
+    const diagnostics = sanitizeObservabilityDiagnostics(JSON.parse(diagnosticsRaw));
+    return {
+      schema: OBSERVABILITY_SCHEMA,
+      state: fields.subagents_observability_state,
+      frontier,
+      diagnostics,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export const readObservabilityCheckpoint = parseObservabilityCheckpoint;

--- a/hooks/session-observability-store.mjs
+++ b/hooks/session-observability-store.mjs
@@ -1,0 +1,436 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  VAULT_LOCK_BUSY,
+  assertVaultPathSafe,
+  mkdirVaultPath,
+  withVaultPathLock,
+  writeVaultFileAtomic,
+} from './vault-path-safety.mjs';
+import { sanitizeObservabilityDiagnostics } from './session-observability-state.mjs';
+
+const STORE_SCHEMA_VERSION = 1;
+const STORE_DIR_PARTS = ['.brain', 'runtime', 'session-observability'];
+const STORE_PATH_CODE = 'OBSERVABILITY_STORE_PATH_UNSAFE';
+const DEFAULT_SIGNAL_LIMIT = 4_096;
+const SIGNAL_KINDS = new Set(['started', 'interacted', 'interrupted']);
+
+function storeError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function nonEmptyString(value, code = 'OBSERVABILITY_STORE_INVALID') {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw storeError(code, 'identificador de observabilidade inválido');
+  }
+  return value.trim();
+}
+
+function sequence(value, fallback = null) {
+  if (typeof value === 'string' && /^\d+$/.test(value.trim())) value = Number(value);
+  return Number.isSafeInteger(value) && value >= 0 ? value : fallback;
+}
+
+function timeValue(value, fallback) {
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function jsonClone(value) {
+  if (value === undefined) return null;
+  try { return JSON.parse(JSON.stringify(value)); }
+  catch { throw storeError('OBSERVABILITY_STORE_INVALID', 'estado de observabilidade inválido'); }
+}
+
+function defaultState(sessionId, {
+  reconstructed = false,
+  dirty = false,
+  diagnostics = [],
+} = {}) {
+  return {
+    schema_version: STORE_SCHEMA_VERSION,
+    session_id: sessionId,
+    observability_signal_sequence: 0,
+    observability_checkpoint_sequence: 0,
+    observability_dirty: dirty,
+    signals: [],
+    lease: null,
+    checkpoint_frontier: null,
+    source_manifest: null,
+    graph_cache: null,
+    diagnostics: sanitizeObservabilityDiagnostics(diagnostics),
+    reconstructed,
+  };
+}
+
+function normalizeSignal(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw storeError('OBSERVABILITY_SIGNAL_INVALID', 'sinal de observabilidade inválido');
+  }
+  const rolloutId = nonEmptyString(
+    input.rollout_id ?? input.rolloutId ?? input.agent_thread_id ?? input.agentThreadId,
+    'OBSERVABILITY_SIGNAL_INVALID',
+  );
+  const signal = { rollout_id: rolloutId };
+  const transcriptPath = input.transcript_path ?? input.transcriptPath;
+  if (typeof transcriptPath === 'string' && transcriptPath.trim()) {
+    signal.transcript_path = transcriptPath.trim();
+  }
+  const parentThreadId = input.parent_thread_id
+    ?? input.parentThreadId
+    ?? input.parent_rollout_id
+    ?? input.parentRolloutId;
+  if (typeof parentThreadId === 'string' && parentThreadId.trim()) {
+    signal.parent_thread_id = parentThreadId.trim();
+  }
+  const rawKind = input.kind ?? input.event_kind ?? input.eventKind ?? 'started';
+  if (typeof rawKind !== 'string' || !SIGNAL_KINDS.has(rawKind.trim().toLowerCase())) {
+    throw storeError('OBSERVABILITY_SIGNAL_INVALID', 'sinal de observabilidade inválido');
+  }
+  signal.kind = rawKind.trim().toLowerCase();
+  const timestamp = input.timestamp ?? input.started_at ?? input.startedAt;
+  if (typeof timestamp === 'string' && timestamp.trim()) {
+    signal.timestamp = timestamp.trim();
+  }
+  const agentPath = input.agent_path ?? input.agentPath;
+  if (typeof agentPath === 'string' && agentPath.trim()) {
+    signal.agent_path = agentPath.trim();
+  }
+  const activationId = input.activation_id ?? input.activationId;
+  if (typeof activationId === 'string' && activationId.trim()) {
+    signal.activation_id = activationId.trim();
+  }
+  for (const [target, source] of [
+    ['activation_epoch', input.activation_epoch ?? input.activationEpoch],
+    ['turn_sequence', input.turn_sequence ?? input.turnSequence],
+    ['signal_sequence', input.signal_sequence ?? input.signalSequence],
+  ]) {
+    if (source !== undefined) {
+      const normalized = sequence(source);
+      if (normalized === null) {
+        throw storeError('OBSERVABILITY_SIGNAL_INVALID', 'sinal de observabilidade inválido');
+      }
+      signal[target] = normalized;
+    }
+  }
+  if (typeof input.observed_at === 'string' && input.observed_at.trim()) {
+    signal.observed_at = input.observed_at.trim();
+  }
+  return signal;
+}
+
+function normalizeLease(input) {
+  if (input == null) return null;
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw storeError('OBSERVABILITY_STORE_CORRUPT', 'lease de observabilidade corrompida');
+  }
+  const signalSequence = sequence(input.signal_sequence);
+  const expiresAt = timeValue(input.expires_at, null);
+  if (signalSequence === null || expiresAt === null) {
+    throw storeError('OBSERVABILITY_STORE_CORRUPT', 'lease de observabilidade corrompida');
+  }
+  return {
+    owner_token: nonEmptyString(input.owner_token, 'OBSERVABILITY_STORE_CORRUPT'),
+    signal_sequence: signalSequence,
+    acquired_at: timeValue(input.acquired_at, expiresAt),
+    expires_at: expiresAt,
+  };
+}
+
+function normalizeStoreState(input, sessionId) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)
+    || input.schema_version !== STORE_SCHEMA_VERSION
+    || input.session_id !== sessionId) {
+    throw storeError('OBSERVABILITY_STORE_CORRUPT', 'store de observabilidade corrompido');
+  }
+  const signalSequence = sequence(input.observability_signal_sequence);
+  const checkpointSequence = sequence(input.observability_checkpoint_sequence);
+  if (signalSequence === null || checkpointSequence === null
+    || checkpointSequence > signalSequence
+    || typeof input.observability_dirty !== 'boolean'
+    || !Array.isArray(input.signals)) {
+    throw storeError('OBSERVABILITY_STORE_CORRUPT', 'store de observabilidade corrompido');
+  }
+  const seen = new Set();
+  const signals = input.signals.map(normalizeSignal);
+  let previousSignalSequence = 0;
+  for (const signal of signals) {
+    if (seen.has(signal.rollout_id)
+      || !Number.isSafeInteger(signal.signal_sequence)
+      || signal.signal_sequence <= previousSignalSequence
+      || signal.signal_sequence > signalSequence) {
+      throw storeError('OBSERVABILITY_STORE_CORRUPT', 'store de observabilidade corrompido');
+    }
+    seen.add(signal.rollout_id);
+    previousSignalSequence = signal.signal_sequence;
+  }
+  return {
+    schema_version: STORE_SCHEMA_VERSION,
+    session_id: sessionId,
+    observability_signal_sequence: signalSequence,
+    observability_checkpoint_sequence: checkpointSequence,
+    observability_dirty: input.observability_dirty,
+    signals,
+    lease: normalizeLease(input.lease),
+    checkpoint_frontier: jsonClone(input.checkpoint_frontier),
+    source_manifest: jsonClone(input.source_manifest),
+    graph_cache: jsonClone(input.graph_cache),
+    diagnostics: sanitizeObservabilityDiagnostics(input.diagnostics ?? []),
+    reconstructed: Boolean(input.reconstructed),
+  };
+}
+
+function serializableState(input) {
+  return {
+    schema_version: input.schema_version,
+    session_id: input.session_id,
+    observability_signal_sequence: input.observability_signal_sequence,
+    observability_checkpoint_sequence: input.observability_checkpoint_sequence,
+    observability_dirty: input.observability_dirty,
+    signals: input.signals,
+    lease: input.lease,
+    checkpoint_frontier: input.checkpoint_frontier,
+    source_manifest: input.source_manifest,
+    graph_cache: input.graph_cache,
+    diagnostics: input.diagnostics,
+  };
+}
+
+function serialized(input) {
+  return `${JSON.stringify(serializableState(input), null, 2)}\n`;
+}
+
+function storeDirectory(vaultBase) {
+  return join(vaultBase, ...STORE_DIR_PARTS);
+}
+
+function ensureStoreDirectory(vaultBase) {
+  return mkdirVaultPath(vaultBase, storeDirectory(vaultBase), {
+    recursive: true,
+    label: 'runtime de observabilidade de sessão',
+    code: STORE_PATH_CODE,
+  });
+}
+
+export function observabilityStorePath(vaultBase, sessionId) {
+  const id = nonEmptyString(sessionId);
+  const digest = createHash('sha256').update(id).digest('hex');
+  return join(vaultBase, ...STORE_DIR_PARTS, `${digest}.json`);
+}
+
+function readStorePath(vaultBase, sessionId, path) {
+  const checked = assertVaultPathSafe(vaultBase, path, {
+    expectedType: 'file',
+    label: 'store de observabilidade de sessão',
+    code: STORE_PATH_CODE,
+  });
+  if (!checked.exists) return defaultState(sessionId);
+  try {
+    const raw = readFileSync(checked.target, 'utf8');
+    assertVaultPathSafe(vaultBase, checked.target, {
+      allowMissing: false,
+      expectedType: 'file',
+      label: 'store de observabilidade de sessão',
+      code: STORE_PATH_CODE,
+    });
+    return normalizeStoreState(JSON.parse(raw), sessionId);
+  } catch (error) {
+    if (error?.code === STORE_PATH_CODE) throw error;
+    return defaultState(sessionId, {
+      reconstructed: true,
+      dirty: true,
+      diagnostics: [{ code: 'CACHE_INVALID', count: 1 }],
+    });
+  }
+}
+
+export function readObservabilityStore(vaultBase, sessionId) {
+  const id = nonEmptyString(sessionId);
+  return readStorePath(vaultBase, id, observabilityStorePath(vaultBase, id));
+}
+
+/**
+ * Serialize a small store transition under the hardened Vault path lock.
+ * The mutator may return `{ state, value }`; its `value` is returned without persistence.
+ */
+export function mutateObservabilityStore(vaultBase, sessionId, mutator, {
+  lockTimeoutMs = 2_000,
+  lockStaleMs = 10_000,
+} = {}) {
+  const id = nonEmptyString(sessionId);
+  if (typeof mutator !== 'function') {
+    throw storeError('OBSERVABILITY_STORE_INVALID', 'mutator de observabilidade inválido');
+  }
+  ensureStoreDirectory(vaultBase);
+  const path = observabilityStorePath(vaultBase, id);
+  const outcome = withVaultPathLock(vaultBase, path, () => {
+    const current = readStorePath(vaultBase, id, path);
+    const transition = mutator(jsonClone(current));
+    if (transition == null) {
+      return { state: current, changed: false, value: null, reconstructed: current.reconstructed };
+    }
+    const nextInput = Object.hasOwn(transition, 'state') ? transition.state : transition;
+    const value = Object.hasOwn(transition, 'state') ? transition.value : null;
+    const next = normalizeStoreState({
+      ...nextInput,
+      schema_version: STORE_SCHEMA_VERSION,
+      session_id: id,
+    }, id);
+    next.reconstructed = false;
+    const before = serialized(current);
+    const after = serialized(next);
+    if (before !== after || current.reconstructed) {
+      writeVaultFileAtomic(vaultBase, path, after, 'utf8', {
+        label: 'store de observabilidade de sessão',
+        code: STORE_PATH_CODE,
+      });
+    }
+    return {
+      state: next,
+      changed: before !== after || current.reconstructed,
+      value,
+      reconstructed: current.reconstructed,
+    };
+  }, {
+    timeoutMs: lockTimeoutMs,
+    staleMs: lockStaleMs,
+    code: STORE_PATH_CODE,
+  });
+  if (outcome === VAULT_LOCK_BUSY) {
+    return { state: null, changed: false, value: null, busy: true, reconstructed: false };
+  }
+  return { ...outcome, busy: false };
+}
+
+export function recordObservabilitySignal(vaultBase, sessionId, signalInput, {
+  maxSignals = DEFAULT_SIGNAL_LIMIT,
+  ...storeOptions
+} = {}) {
+  const signal = normalizeSignal(signalInput);
+  if (!Number.isSafeInteger(maxSignals) || maxSignals <= 0) {
+    throw storeError('OBSERVABILITY_STORE_INVALID', 'limite de sinais inválido');
+  }
+  const outcome = mutateObservabilityStore(vaultBase, sessionId, (state) => {
+    const duplicate = state.signals.some((entry) => entry.rollout_id === signal.rollout_id);
+    if (duplicate) return { state, value: { duplicate: true } };
+    const nextSequence = state.observability_signal_sequence + 1;
+    state.observability_signal_sequence = nextSequence;
+    state.observability_dirty = true;
+    state.signals = [...state.signals, { ...signal, signal_sequence: nextSequence }]
+      .slice(-maxSignals);
+    return { state, value: { duplicate: false } };
+  }, storeOptions);
+  if (outcome.busy) {
+    return { recorded: false, duplicate: false, sequence: null, state: null, reason: 'store-busy' };
+  }
+  return {
+    recorded: !outcome.value.duplicate,
+    duplicate: outcome.value.duplicate,
+    sequence: outcome.state.observability_signal_sequence,
+    state: outcome.state,
+    reason: outcome.value.duplicate ? 'duplicate' : 'recorded',
+  };
+}
+
+export function tryAcquireObservabilityLease(vaultBase, sessionId, {
+  signalSequence,
+  ownerToken = randomUUID(),
+  now = Date.now(),
+  ttlMs = 20_000,
+  ...storeOptions
+} = {}) {
+  const requestedSequence = sequence(signalSequence);
+  const token = nonEmptyString(ownerToken, 'OBSERVABILITY_LEASE_INVALID');
+  const nowMs = timeValue(now, null);
+  if (requestedSequence === null || nowMs === null || !Number.isFinite(ttlMs) || ttlMs <= 0) {
+    throw storeError('OBSERVABILITY_LEASE_INVALID', 'lease de observabilidade inválida');
+  }
+  const outcome = mutateObservabilityStore(vaultBase, sessionId, (state) => {
+    const latest = state.observability_signal_sequence;
+    if (requestedSequence < latest) {
+      return { state, value: { acquired: false, reason: 'stale-signal' } };
+    }
+    if (requestedSequence > latest) {
+      return { state, value: { acquired: false, reason: 'future-signal' } };
+    }
+    const lease = state.lease;
+    if (lease && lease.expires_at > nowMs
+      && lease.signal_sequence === requestedSequence
+      && lease.owner_token !== token) {
+      return { state, value: { acquired: false, reason: 'lease-busy' } };
+    }
+    if (lease && lease.expires_at > nowMs
+      && lease.signal_sequence === requestedSequence
+      && lease.owner_token === token) {
+      return { state, value: { acquired: true, reason: 'already-owned' } };
+    }
+    state.lease = {
+      owner_token: token,
+      signal_sequence: requestedSequence,
+      acquired_at: nowMs,
+      expires_at: nowMs + ttlMs,
+    };
+    return { state, value: { acquired: true, reason: lease ? 'superseded' : 'acquired' } };
+  }, storeOptions);
+  if (outcome.busy) {
+    return { acquired: false, reason: 'store-busy', state: null, ownerToken: token };
+  }
+  return { ...outcome.value, state: outcome.state, ownerToken: token };
+}
+
+export function releaseObservabilityLease(vaultBase, sessionId, {
+  ownerToken,
+  signalSequence,
+  ...storeOptions
+} = {}) {
+  const token = nonEmptyString(ownerToken, 'OBSERVABILITY_LEASE_INVALID');
+  const expectedSequence = signalSequence === undefined ? null : sequence(signalSequence);
+  if (signalSequence !== undefined && expectedSequence === null) {
+    throw storeError('OBSERVABILITY_LEASE_INVALID', 'lease de observabilidade inválida');
+  }
+  const outcome = mutateObservabilityStore(vaultBase, sessionId, (state) => {
+    const owned = state.lease?.owner_token === token
+      && (expectedSequence === null || state.lease.signal_sequence === expectedSequence);
+    if (!owned) return { state, value: { released: false, reason: 'not-owner' } };
+    state.lease = null;
+    return { state, value: { released: true, reason: 'released' } };
+  }, storeOptions);
+  if (outcome.busy) return { released: false, reason: 'store-busy', state: null };
+  return { ...outcome.value, state: outcome.state };
+}
+
+export function markObservabilityCheckpoint(vaultBase, sessionId, {
+  checkpointSequence,
+  frontier = null,
+  sourceManifest,
+  graphCache,
+  diagnostics,
+  ...storeOptions
+} = {}) {
+  const nextCheckpoint = sequence(checkpointSequence);
+  if (nextCheckpoint === null) {
+    throw storeError('OBSERVABILITY_CHECKPOINT_INVALID', 'checkpoint de observabilidade inválido');
+  }
+  const outcome = mutateObservabilityStore(vaultBase, sessionId, (state) => {
+    if (nextCheckpoint > state.observability_signal_sequence) {
+      throw storeError('OBSERVABILITY_CHECKPOINT_INVALID', 'checkpoint de observabilidade inválido');
+    }
+    if (nextCheckpoint < state.observability_checkpoint_sequence) {
+      return { state, value: { accepted: false, reason: 'stale-checkpoint' } };
+    }
+    state.observability_checkpoint_sequence = nextCheckpoint;
+    state.observability_dirty = nextCheckpoint < state.observability_signal_sequence;
+    state.checkpoint_frontier = jsonClone(frontier);
+    if (sourceManifest !== undefined) state.source_manifest = jsonClone(sourceManifest);
+    if (graphCache !== undefined) state.graph_cache = jsonClone(graphCache);
+    if (diagnostics !== undefined) {
+      state.diagnostics = sanitizeObservabilityDiagnostics(diagnostics);
+    }
+    if (state.lease && state.lease.signal_sequence <= nextCheckpoint) state.lease = null;
+    return { state, value: { accepted: true, reason: 'checkpointed' } };
+  }, storeOptions);
+  if (outcome.busy) return null;
+  return outcome.state;
+}

--- a/hooks/session-observability.mjs
+++ b/hooks/session-observability.mjs
@@ -1,9 +1,20 @@
 // Single atomic writer for session usage, models, reasoning/effort and subagents.
-import { existsSync } from 'node:fs';
-import { collectSessionUsage } from './token-usage.mjs';
-import { collectSubagentUsage, collectCodexSubagentUsage, sessionDirFromTranscript } from './subagent-usage.mjs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { collectSessionUsage, collectSessionUsageForRoots } from './token-usage.mjs';
+import { collectClaudeSubagentUsageState, collectCodexSubagentUsage, sessionDirFromTranscript } from './subagent-usage.mjs';
 import { inspectTranscriptIdentity } from './session-identity.mjs';
 import { hasSessionFrontmatter, mutateSessionNote } from './session-note-io.mjs';
+import { composeCodexSubagentGraph } from './codex-subagent-graph.mjs';
+import { resolveObservabilityRoots } from './session-observability-lifecycle.mjs';
+import { markObservabilityCheckpoint, readObservabilityStore } from './session-observability-store.mjs';
+import { mutateSessionRegistry } from './obsidian-common.mjs';
+import {
+  compareObservabilityFrontiers,
+  normalizeObservabilityFrontier,
+  parseObservabilityCheckpoint,
+  renderObservabilityCheckpoint,
+  sanitizeObservabilityDiagnostics,
+} from './session-observability-state.mjs';
 
 const HEADING = '## Agentes, tokens e custos';
 const LEGACY_HEADINGS = ['## Uso de tokens e custos', '## Subagents & Workflows'];
@@ -49,13 +60,14 @@ export function upsertObservabilitySection(content, section) {
 }
 
 function mainLedger(main) {
-  return (main.summary.modelRows || []).map((row) => ({
+  const summaries = main.summary ? [main.summary] : (main.summaries || []);
+  return summaries.flatMap((summary) => (summary.modelRows || []).map((row) => ({
     provider: row.provider || 'unknown', model: row.model || 'unknown', source: 'main',
-    effort: effort(main.summary.pensamento), calls: row.calls || 0,
+    effort: effort(summary.pensamento), calls: row.calls || 0,
     input: row.usage.input || 0, cacheWrite: row.usage.cacheWrite || 0, cached: row.usage.cached || 0,
     output: row.usage.output || 0, reasoning: row.usage.reasoning || 0, total: usageTotal(row.usage),
     cost: round4(row.costs?.model || 0),
-  }));
+  })));
 }
 
 function subagentLedger(collected) {
@@ -85,7 +97,9 @@ function renderHistory(entries) {
 }
 
 function renderSubagents(collected) {
-  if (!collected) return '### Subagents e workflows\n\nNenhum subagent registrado.';
+  if (!collected || collected.state === 'none') {
+    return '### Subagents e workflows\n\nNenhum subagent registrado.';
+  }
   const a = collected.aggregate;
   const workflows = collected.workflows.length
     ? collected.workflows.map((w) => `${w.name} (${w.runId}${w.status ? ` · ${w.status}` : ''} · ${w.agents} agentes · ${usd(w.cost)})`).join('; ')
@@ -135,16 +149,206 @@ ${renderHistory(main.entries)}
 ${renderSubagents(subagents)}`;
 }
 
-export function buildSessionObservability({ sessionContent, transcriptPath }) {
-  const main = collectSessionUsage({ sessionContent, transcriptPath });
-  if (!main) return null;
-  // Claude layout first (<transcript>/subagents/); when absent, the Codex layout — sibling
-  // rollouts linked by parent_thread_id. The Codex collector self-gates: a Claude transcript
-  // has no session_meta line, so it returns null and this stays a strict fallback.
-  const subagents = collectSubagentUsage(sessionDirFromTranscript(transcriptPath))
-    || collectCodexSubagentUsage(transcriptPath);
+function quoteFrontmatter(value) {
+  if (typeof value === 'number') return String(value);
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function applyCheckpoint(content, frontier, state, diagnostics) {
+  let next = content;
+  for (const [key, value] of Object.entries(renderObservabilityCheckpoint(frontier, { state, diagnostics }))) {
+    next = setFrontmatterField(next, key, quoteFrontmatter(value));
+  }
+  return next;
+}
+
+function rootIds(roots = {}) {
+  return new Set((roots.rootPaths || []).map((value) => String(value || '')
+    .split(/[\\/]/).pop().replace(/\.jsonl?$/i, '').toLowerCase()).filter(Boolean));
+}
+
+function subagentIds(collected) {
+  return new Set((collected?.subagents || []).map((entry) => String(entry?.id || entry?.rollout_id || '')
+    .trim().toLowerCase()).filter(Boolean));
+}
+
+function combineDiagnostics(...groups) {
+  return sanitizeObservabilityDiagnostics(groups.flatMap((group) => group || []));
+}
+
+function zeroSubagentAggregate() {
+  return {
+    count: 0, calls: 0, tokens: 0, cost: 0, wasted: 0, tools: [],
+    usage: { input: 0, cached: 0, cacheWrite: 0, output: 0, reasoning: 0 },
+    modelRows: [],
+  };
+}
+
+function legacySubagentScan(transcriptPath) {
+  const claude = collectClaudeSubagentUsageState(sessionDirFromTranscript(transcriptPath));
+  if (claude.state === 'complete' || claude.state === 'degraded') return claude;
+  const codex = collectCodexSubagentUsage(transcriptPath);
+  return codex
+    ? { ...codex, state: 'complete', diagnostics: [] }
+    : { state: 'none', diagnostics: [], aggregate: zeroSubagentAggregate(), subagents: [], workflows: [] };
+}
+
+function graphSubagentScan({
+  rootPaths,
+  frontier,
+  signals,
+  cache,
+  mode,
+  limits,
+  deadlineAt,
+  now,
+}) {
+  if (!rootPaths?.length) return legacySubagentScan('');
+  return composeCodexSubagentGraph({
+    rootPaths,
+    canonicalSessionId: frontier?.canonical_session_id || '',
+    signals,
+    cache,
+    mode,
+    limits,
+    deadlineAt,
+    now,
+  });
+}
+
+/**
+ * Pure, lock-free composition. Callers may inject the graph/main collectors so the same
+ * merge logic is shared by live hooks, import and rebuild without coupling their scanners.
+ */
+export function composeSessionObservability({
+  sessionContent,
+  frontier: frontierInput,
+  roots = {},
+  transcriptPath = '',
+  sessionEntry,
+  canonicalConversationId = '',
+  runtimeState,
+  mainResult,
+  subagentsResult,
+  previousSnapshot = null,
+  allowNone = true,
+  signals = [],
+  cache = null,
+  mode = 'live',
+  limits = {},
+  deadlineAt = Number.POSITIVE_INFINITY,
+  now,
+} = {}, {
+  collectMain = ({ sessionContent: content, rootPaths, descendantIds, transcriptPath: scanTranscriptPath }) => (
+    rootPaths?.length
+      ? collectSessionUsageForRoots({ sessionContent: content, rootPaths, descendantIds })
+      : collectSessionUsage({ sessionContent: content, transcriptPath: scanTranscriptPath })
+  ),
+  collectSubagents = ({ rootPaths, transcriptPath: scanTranscriptPath, ...input }) => (rootPaths?.length
+    ? graphSubagentScan({ rootPaths, ...input })
+    : legacySubagentScan(scanTranscriptPath)),
+} = {}) {
+  if (sessionEntry) {
+    return composeRegisteredSessionObservability({
+      sessionContent,
+      sessionEntry,
+      canonicalConversationId,
+      runtimeState,
+      frontier: frontierInput,
+      allowNone,
+      mode,
+      limits,
+      deadlineAt,
+      now,
+    }, { collectMain, collectSubagents });
+  }
+  const original = String(sessionContent || '');
+  if (!hasSessionFrontmatter(original)) {
+    const frontier = normalizeObservabilityFrontier(frontierInput);
+    return {
+      state: 'degraded', frontier,
+      diagnostics: [{ code: 'MAIN_TRANSCRIPT_UNRESOLVED', count: 1 }],
+      snapshot: previousSnapshot, content: original,
+    };
+  }
+
+  const collectedSubagents = subagentsResult ?? collectSubagents({
+    roots,
+    rootPaths: roots.rootPaths || [],
+    descendantIds: roots.descendantIds || [],
+    frontier: frontierInput,
+    signals,
+    cache,
+    mode,
+    limits,
+    deadlineAt,
+    now,
+    transcriptPath,
+  });
+  const frontier = normalizeObservabilityFrontier({
+    ...frontierInput,
+    ...(collectedSubagents?.frontier?.rootsStatHash
+      ? { roots_stat_hash: collectedSubagents.frontier.rootsStatHash }
+      : {}),
+    ...(collectedSubagents?.frontier?.graphCursor
+      ? { graph_cursor: collectedSubagents.frontier.graphCursor }
+      : {}),
+    ...(collectedSubagents?.frontier?.sourceManifestHash
+      ? { source_manifest_hash: collectedSubagents.frontier.sourceManifestHash }
+      : {}),
+  });
+  const descendantIds = collectedSubagents?.descendantIds || roots.descendantIds || [];
+  const preliminarySubagentState = collectedSubagents?.state || (collectedSubagents ? 'complete' : 'degraded');
+  const preliminaryState = preliminarySubagentState === 'none' && allowNone
+    ? 'none'
+    : (preliminarySubagentState === 'complete' ? 'complete' : 'degraded');
+  const preliminaryDiagnostics = combineDiagnostics(
+    collectedSubagents?.diagnostics,
+    !collectedSubagents ? [{ code: 'SOURCE_CHANGED_DURING_SCAN', count: 1 }] : [],
+    preliminarySubagentState === 'none' && !allowNone ? [{ code: 'STALE_FRONTIER', count: 1 }] : [],
+  );
+  // Seed the checkpoint before the main frontmatter collector canonicalizes managed fields.
+  // This makes the first materialization use the same ordering as every subsequent replay.
+  const mainInputContent = preliminaryState === 'degraded'
+    ? original
+    : applyCheckpoint(original, frontier, preliminaryState, preliminaryDiagnostics);
+  const main = mainResult ?? collectMain({
+    sessionContent: mainInputContent,
+    rootPaths: roots.rootPaths || [],
+    descendantIds,
+    roots,
+    frontier,
+    transcriptPath,
+  });
+
+  const mainState = main?.state || (main ? 'complete' : 'degraded');
+  const subagentsState = preliminarySubagentState;
+  const diagnostics = combineDiagnostics(
+    main?.diagnostics,
+    collectedSubagents?.diagnostics,
+    !main ? [{ code: 'MAIN_TRANSCRIPT_UNRESOLVED', count: 1 }] : [],
+    !collectedSubagents ? [{ code: 'SOURCE_CHANGED_DURING_SCAN', count: 1 }] : [],
+    subagentsState === 'none' && !allowNone ? [{ code: 'STALE_FRONTIER', count: 1 }] : [],
+  );
+  const overlap = [...rootIds(roots)].filter((id) => subagentIds(collectedSubagents).has(id));
+  const safeDiagnostics = overlap.length
+    ? combineDiagnostics(diagnostics, [{ code: 'ROOT_MISMATCH', count: overlap.length }])
+    : diagnostics;
+
+  if (mainState === 'degraded' || subagentsState === 'degraded'
+    || (subagentsState === 'none' && !allowNone) || overlap.length) {
+    return {
+      state: 'degraded', frontier, diagnostics: safeDiagnostics,
+      snapshot: previousSnapshot, content: original,
+    };
+  }
+
+  const state = subagentsState === 'none' ? 'none' : 'complete';
+  // A proven empty graph still carries its source manifest/cache. Dropping that proof made
+  // the next import/doctor run classify a genuinely fresh `none` snapshot as unprovable.
+  const subagents = collectedSubagents;
   const ledger = [...mainLedger(main), ...subagentLedger(subagents)];
-  const sub = subagents?.aggregate || { count: 0, tokens: 0, cost: 0, wasted: 0, tools: [] };
+  const sub = subagents?.aggregate || zeroSubagentAggregate();
   let content = main.content;
   content = setFrontmatterField(content, 'subagents_count', sub.count || 0);
   content = setFrontmatterField(content, 'subagents_tokens_total', sub.tokens || 0);
@@ -153,10 +357,425 @@ export function buildSessionObservability({ sessionContent, transcriptPath }) {
   content = setFrontmatterField(content, 'subagents_wasted_usd', sub.wasted || 0);
   content = setFrontmatterField(content, 'tokens_total_incl_subagents', main.aggregate.total + (sub.tokens || 0));
   content = setFrontmatterField(content, 'custo_total_incl_subagents_usd', round4(main.aggregate.custo + (sub.cost || 0)));
-  content = setFrontmatterField(content, 'observability_schema', 1);
   content = setFrontmatterField(content, 'custo_por_modelo_json', `'${JSON.stringify(ledger).replaceAll("'", "''")}'`);
-  const snapshot = { version: 1, main, subagents, ledger };
-  return { snapshot, content: upsertObservabilitySection(content, renderSessionObservability(snapshot)) };
+  content = applyCheckpoint(content, frontier, state, safeDiagnostics);
+  const snapshot = {
+    version: 2, state, frontier, diagnostics: safeDiagnostics,
+    main, subagents, ledger,
+    roots: {
+      rootPaths: [...(roots.rootPaths || [])].sort(),
+      descendantIds: [...descendantIds].sort(),
+    },
+  };
+  return {
+    state, frontier, diagnostics: safeDiagnostics, snapshot,
+    content: upsertObservabilitySection(content, renderSessionObservability(snapshot)),
+  };
+}
+
+function causalFieldsFromEntry(entry = {}, runtimeState = {}, canonicalConversationId = '') {
+  const activationId = String(entry.active_activation_id || entry.activation_id || 'offline');
+  const activation = entry.activations?.[activationId] || {};
+  return {
+    canonical_session_id: canonicalConversationId || entry.canonical_session_id || entry.session_id || 'offline-session',
+    activation_id: activationId,
+    activation_epoch: Number(activation.epoch ?? entry.activation_epoch ?? 0) || 0,
+    turn_sequence: Number(entry.last_turn_sequence ?? activation.last_turn_sequence ?? 0) || 0,
+    signal_sequence: Number(runtimeState.observability_signal_sequence ?? entry.observability_signal_sequence ?? 0) || 0,
+    roots_stat_hash: runtimeState.checkpoint_frontier?.roots_stat_hash || 'pending-roots',
+    graph_cursor: runtimeState.checkpoint_frontier?.graph_cursor || 'pending-graph',
+    source_manifest_hash: runtimeState.checkpoint_frontier?.source_manifest_hash || 'pending-manifest',
+  };
+}
+
+/** Pure registered-session composition used by import/rebuild previews. No writer is reachable. */
+export function composeRegisteredSessionObservability({
+  sessionContent,
+  sessionEntry = {},
+  canonicalConversationId = '',
+  runtimeState = {},
+  frontier: frontierInput,
+  allowNone = true,
+  mode = 'offline',
+  limits = {},
+  deadlineAt = Number.POSITIVE_INFINITY,
+  now,
+} = {}, dependencies = {}) {
+  const provider = String(sessionEntry.provider || '').trim().toLowerCase();
+  const transcriptPath = sessionEntry.transcript_path
+    || sessionEntry.transcript_paths?.[0]
+    || '';
+  const resolution = provider === 'claude'
+    ? { state: 'complete', rootPaths: [], descendantPaths: [], diagnostics: [] }
+    : resolveObservabilityRoots(sessionEntry);
+  const roots = {
+    rootPaths: resolution.rootPaths || [],
+    descendantPaths: resolution.descendantPaths || [],
+    descendantIds: sessionEntry.descendant_ids || [],
+  };
+  const missingCodexRoot = provider !== 'claude' && roots.rootPaths.length === 0;
+  const subagentsResult = resolution.state === 'degraded' || missingCodexRoot
+    ? {
+      state: 'degraded',
+      diagnostics: resolution.diagnostics?.length
+        ? resolution.diagnostics
+        : [{ code: 'MAIN_TRANSCRIPT_UNRESOLVED', count: 1 }],
+    }
+    : undefined;
+  return composeSessionObservability({
+    sessionContent,
+    transcriptPath,
+    frontier: {
+      ...causalFieldsFromEntry(sessionEntry, runtimeState, canonicalConversationId),
+      ...(frontierInput || {}),
+    },
+    roots,
+    subagentsResult,
+    allowNone,
+    signals: runtimeState.signals || [],
+    cache: runtimeState.graph_cache || null,
+    mode,
+    limits,
+    deadlineAt,
+    now,
+  }, dependencies);
+}
+
+function candidateRelation(current, candidate) {
+  if (!current) return 'newer';
+  const frontier = current.frontier || current;
+  return compareObservabilityFrontiers(frontier, candidate);
+}
+
+function sameSortedStrings(left = [], right = []) {
+  const a = [...new Set(left.filter(Boolean))].sort();
+  const b = [...new Set(right.filter(Boolean))].sort();
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+const CAUSAL_FRONTIER_FIELDS = [
+  'canonical_session_id',
+  'activation_id',
+  'activation_epoch',
+  'turn_sequence',
+  'signal_sequence',
+];
+
+function sameCausalAuthority(leftInput, rightInput) {
+  const left = leftInput?.frontier || leftInput;
+  const right = rightInput?.frontier || rightInput;
+  return Boolean(left && right
+    && CAUSAL_FRONTIER_FIELDS.every((field) => left[field] === right[field]));
+}
+
+function candidateManifestIsCurrent(snapshot) {
+  const manifest = snapshot?.subagents?.sourceManifest;
+  if (!Array.isArray(manifest) || manifest.length === 0) return false;
+  return manifest.every((source) => {
+    try {
+      const stat = statSync(source.path);
+      return stat.isFile() && stat.size === Number(source.size)
+        && stat.mtimeMs === Number(source.mtimeMs);
+    } catch {
+      return false;
+    }
+  });
+}
+
+function registeredRootsAreCurrent(context, snapshot) {
+  const candidateRoots = snapshot?.roots?.rootPaths || [];
+  if (!context?.entry || !candidateRoots.length) return false;
+  const resolution = resolveObservabilityRoots(context.entry);
+  return resolution.state === 'complete'
+    && sameSortedStrings(resolution.rootPaths, candidateRoots);
+}
+
+function canRefreshSourceFrontier(current, candidate, context, snapshot, enabled) {
+  return Boolean(enabled
+    && sameCausalAuthority(current, candidate)
+    && registeredRootsAreCurrent(context, snapshot)
+    && candidateManifestIsCurrent(snapshot));
+}
+
+function currentFrontierUnderGuard(candidate, context, snapshot) {
+  if (!context) return candidate;
+  const entry = context.entry;
+  if (!entry) return { ...candidate, canonical_session_id: 'registry-session-missing' };
+  const activationId = String(entry.active_activation_id || entry.activation_id || candidate.activation_id);
+  const activation = entry.activations?.[activationId] || {};
+  const current = {
+    ...candidate,
+    activation_id: activationId,
+    activation_epoch: Number(activation.epoch ?? entry.activation_epoch ?? candidate.activation_epoch) || 0,
+    turn_sequence: Number(entry.last_turn_sequence ?? activation.last_turn_sequence ?? candidate.turn_sequence) || 0,
+    signal_sequence: Number(
+      context.runtimeState?.observability_signal_sequence
+      ?? entry.observability_signal_sequence
+      ?? candidate.signal_sequence,
+    ) || 0,
+  };
+  const candidateRoots = snapshot?.roots?.rootPaths || [];
+  if (candidateRoots.length && String(entry.provider || '').toLowerCase() !== 'claude') {
+    const resolution = resolveObservabilityRoots(entry);
+    if (resolution.state !== 'complete'
+      || !sameSortedStrings(resolution.rootPaths, candidateRoots)) {
+      current.roots_stat_hash = `${candidate.roots_stat_hash}-registry-changed`;
+    }
+  }
+  return current;
+}
+
+function updateGuardedRegistryCheckpoint(context, sessionId, checkpoint) {
+  const registry = context?.registry;
+  const current = registry?.sessions?.[sessionId];
+  if (!current) return;
+  const frontier = checkpoint.frontier;
+  const signalSequence = Math.max(
+    Number(current.observability_signal_sequence || 0),
+    frontier.signal_sequence,
+  );
+  registry.sessions[sessionId] = {
+    ...current,
+    observability_schema: 2,
+    subagents_observability_state: checkpoint.state,
+    observability_signal_sequence: signalSequence,
+    observability_checkpoint_sequence: frontier.signal_sequence,
+    observability_dirty: signalSequence > frontier.signal_sequence,
+    observability_checkpoint_frontier: frontier,
+    subagents_diagnostics: checkpoint.diagnostics || [],
+  };
+}
+
+/**
+ * Causal publisher. Composition is deliberately completed before the note writer is entered;
+ * the writer only validates the latest checkpoint and swaps complete bytes.
+ */
+export function publishSessionObservability({
+  sessionPath,
+  frontier: frontierInput,
+  candidate: providedCandidate,
+  compose,
+  composeInput,
+  readRuntimeFrontier,
+  writeRegistryCheckpoint,
+  withPublicationGuard,
+  canonicalConversationId = '',
+  vaultBase = '',
+  allowSourceRefresh = false,
+  allowDegradedRecovery = false,
+  lockTimeoutMs,
+} = {}, {
+  mutateNote = mutateSessionNote,
+  composeObservability = composeSessionObservability,
+} = {}) {
+  const candidate = providedCandidate
+    ?? (compose ? compose() : composeObservability(composeInput));
+  if (!candidate) return { status: 'missing', state: 'degraded', candidate: null };
+  if (candidate.state === 'degraded') {
+    return { status: 'degraded', state: 'degraded', candidate };
+  }
+
+  const frontier = normalizeObservabilityFrontier(candidate.frontier || frontierInput);
+  const sessionId = canonicalConversationId || frontier.canonical_session_id;
+  const guardedByDefault = Boolean(vaultBase && sessionId);
+  const effectiveGuard = withPublicationGuard || (guardedByDefault
+    ? (_candidateFrontier, publishGuarded) => mutateSessionRegistry(vaultBase, (registry) => {
+      const entry = registry.sessions?.[sessionId] || null;
+      const runtimeState = readObservabilityStore(vaultBase, sessionId);
+      return publishGuarded({ registry, entry, runtimeState });
+    }, { ...(lockTimeoutMs ? { timeoutMs: lockTimeoutMs } : {}) })
+    : null);
+  const effectiveReadFrontier = readRuntimeFrontier
+    || (guardedByDefault
+      ? (candidateFrontier, context) => currentFrontierUnderGuard(
+        candidateFrontier,
+        context,
+        candidate.snapshot,
+      )
+      : null);
+  const effectiveCheckpointWriter = writeRegistryCheckpoint
+    || (guardedByDefault
+      ? (checkpoint, context) => {
+        updateGuardedRegistryCheckpoint(context, sessionId, checkpoint);
+        return markObservabilityCheckpoint(vaultBase, sessionId, {
+          checkpointSequence: checkpoint.frontier.signal_sequence,
+          frontier: checkpoint.frontier,
+          sourceManifest: checkpoint.snapshot?.subagents?.sourceManifest,
+          graphCache: checkpoint.snapshot?.subagents?.cache,
+          diagnostics: checkpoint.diagnostics,
+        });
+      }
+      : null);
+  const publishGuarded = (guardContext) => {
+    const live = effectiveReadFrontier?.(frontier, guardContext);
+    const liveRelation = candidateRelation(live, frontier);
+    if ((liveRelation === 'stale' || liveRelation === 'conflict')
+      && !canRefreshSourceFrontier(
+        live,
+        frontier,
+        guardContext,
+        candidate.snapshot,
+        allowSourceRefresh,
+      )) {
+      return { status: liveRelation, state: candidate.state, candidate };
+    }
+
+    let rejection = '';
+    const outcome = mutateNote(sessionPath, (original) => {
+      if (!hasSessionFrontmatter(original)) {
+        rejection = 'degraded';
+        return null;
+      }
+      const checkpoint = parseObservabilityCheckpoint(original);
+      const relation = candidateRelation(checkpoint, frontier);
+      if ((relation === 'stale' || relation === 'conflict')
+        && !canRefreshSourceFrontier(
+          checkpoint,
+          frontier,
+          guardContext,
+          candidate.snapshot,
+          allowSourceRefresh,
+        )) {
+        rejection = relation;
+        return null;
+      }
+      const recoveringDegraded = allowDegradedRecovery
+        && checkpoint?.state === 'degraded'
+        && candidate.state !== 'degraded';
+      if (relation === 'same' && original !== candidate.content && !recoveringDegraded) {
+        rejection = 'conflict';
+        return null;
+      }
+      return candidate.content;
+    }, { ...(lockTimeoutMs ? { timeoutMs: lockTimeoutMs } : {}), vaultBase });
+
+    if (rejection) return { status: rejection, state: candidate.state, candidate, outcome };
+    if (!outcome?.written && outcome?.reason !== 'unchanged') {
+      return { status: outcome?.reason || 'missing', state: candidate.state, candidate, outcome };
+    }
+
+    // A crash here leaves a fully checkpointed note. Retrying observes the same bytes and
+    // executes only this registry reconciliation, so publication remains idempotent.
+    effectiveCheckpointWriter?.({
+      frontier,
+      state: candidate.state,
+      diagnostics: candidate.diagnostics || [],
+      snapshot: candidate.snapshot,
+    }, guardContext);
+    return {
+      status: outcome.written ? 'published' : 'unchanged',
+      state: candidate.state,
+      candidate,
+      snapshot: candidate.snapshot,
+      outcome,
+    };
+  };
+  return effectiveGuard
+    ? effectiveGuard(frontier, publishGuarded)
+    : publishGuarded(undefined);
+}
+
+/**
+ * Hook-friendly facade: resolve registered roots, scan/compose outside the note lock and
+ * causally publish the resulting candidate. Live hooks pass allowNone=false for an isolated
+ * SubagentStop signal and true only for a causally eligible SessionStop.
+ */
+export function materializeSessionObservability({
+  vaultBase = '',
+  sessionPath,
+  entry = {},
+  transcriptPath = entry.transcript_path || '',
+  frontier: frontierInput,
+  canonicalConversationId = '',
+  allowNone = true,
+  signals = [],
+  cache = null,
+  mode = 'live',
+  limits = {},
+  deadlineAt = Number.POSITIVE_INFINITY,
+  now,
+  lockTimeoutMs,
+  readRuntimeFrontier,
+  writeRegistryCheckpoint,
+  withPublicationGuard,
+} = {}, {
+  readSessionContent = (path) => readFileSync(path, 'utf8'),
+  resolveRoots = resolveObservabilityRoots,
+  mutateNote = mutateSessionNote,
+  composeObservability = composeSessionObservability,
+} = {}) {
+  if (!sessionPath || !existsSync(sessionPath)) {
+    return { status: 'missing', state: 'degraded', candidate: null };
+  }
+  const sessionContent = readSessionContent(sessionPath);
+  const identity = inspectTranscriptIdentity(transcriptPath);
+  const provider = String(entry.provider || '').trim().toLowerCase();
+  const rootResolution = provider === 'claude'
+    ? { state: 'complete', rootPaths: [], descendantPaths: [], diagnostics: [] }
+    : resolveRoots(entry);
+  const compatibility = compatibilityFrontier(
+    transcriptPath,
+    identity,
+    canonicalConversationId || entry.canonical_session_id || entry.session_id || '',
+  );
+  const frontier = { ...compatibility, ...(frontierInput || {}) };
+  const roots = {
+    rootPaths: rootResolution.rootPaths || [],
+    descendantPaths: rootResolution.descendantPaths || [],
+    descendantIds: entry.descendant_ids || [],
+  };
+  const subagentsResult = rootResolution.state === 'degraded'
+    ? { state: 'degraded', diagnostics: rootResolution.diagnostics || [] }
+    : undefined;
+  const candidate = composeObservability({
+    sessionContent,
+    frontier,
+    roots,
+    transcriptPath,
+    subagentsResult,
+    allowNone,
+    signals,
+    cache,
+    mode,
+    limits,
+    deadlineAt,
+    now,
+  });
+  return publishSessionObservability({
+    sessionPath,
+    candidate,
+    canonicalConversationId: candidate.frontier?.canonical_session_id || frontier.canonical_session_id,
+    readRuntimeFrontier,
+    writeRegistryCheckpoint,
+    withPublicationGuard,
+    vaultBase,
+    lockTimeoutMs,
+  }, { mutateNote, composeObservability });
+}
+
+function compatibilityFrontier(transcriptPath, identity, canonicalConversationId = '') {
+  const transcriptId = identity.transcriptId || String(transcriptPath || '').split(/[\\/]/).pop().replace(/\.jsonl?$/i, '') || 'legacy';
+  return normalizeObservabilityFrontier({
+    canonical_session_id: canonicalConversationId || identity.canonicalConversationId || transcriptId,
+    activation_id: 'legacy',
+    activation_epoch: 0,
+    turn_sequence: 0,
+    signal_sequence: 0,
+    roots_stat_hash: `legacy-${transcriptId}`,
+    graph_cursor: 'legacy',
+    source_manifest_hash: `legacy-${transcriptId}`,
+  });
+}
+
+export function buildSessionObservability({ sessionContent, transcriptPath, frontier, canonicalConversationId = '', allowNone = true }) {
+  const identity = inspectTranscriptIdentity(transcriptPath);
+  const result = composeSessionObservability({
+    sessionContent,
+    transcriptPath,
+    frontier: frontier || compatibilityFrontier(transcriptPath, identity, canonicalConversationId),
+    allowNone,
+  });
+  return result.state === 'degraded' ? null : result;
 }
 
 export function updateSessionObservability({
@@ -176,13 +795,20 @@ export function updateSessionObservability({
       || (noteProvider === 'claude' && identity.transcriptProvider !== 'anthropic')) {
       throw new Error(`observability provider mismatch: note=${noteProvider}, transcript=${identity.transcriptProvider}`);
     }
-    let annotated = setFrontmatterField(sessionContent, 'observability_caller', `"${caller}"`);
+    let annotated = sessionContent;
+    if (!/^observability_caller:/m.test(annotated)) {
+      annotated = setFrontmatterField(annotated, 'observability_caller', `"${caller}"`);
+    }
     annotated = setFrontmatterField(annotated, 'observability_session_id', `"${canonicalConversationId || identity.canonicalConversationId || ''}"`);
     annotated = setFrontmatterField(annotated, 'observability_transcript_id', `"${identity.transcriptId || ''}"`);
     if (!/^observability_updated_at:/m.test(annotated)) {
       annotated = setFrontmatterField(annotated, 'observability_updated_at', `"${new Date().toISOString()}"`);
     }
-    const result = buildSessionObservability({ sessionContent: annotated, transcriptPath });
+    const result = buildSessionObservability({
+      sessionContent: annotated,
+      transcriptPath,
+      canonicalConversationId: canonicalConversationId || identity.canonicalConversationId || '',
+    });
     if (!result) return null;
     snapshot = result.snapshot;
     return result.content;

--- a/hooks/session-stop.mjs
+++ b/hooks/session-stop.mjs
@@ -8,8 +8,13 @@ import { addUsage, costBreakdown, emptyTokenUsage, normalizeClaudeUsage, normali
 import { buildBrainDigest, buildBrainIndex } from './brain-core.mjs';
 import { activeChangeLink, pruneChangeSentinels } from './change-core.mjs';
 import { getLocale } from './locale.mjs';
-import { updateSessionObservability } from './session-observability.mjs';
+import { materializeSessionObservability } from './session-observability.mjs';
 import { resolveSessionEntry } from './session-identity.mjs';
+import { resolveObservabilityRoots } from './session-observability-lifecycle.mjs';
+import {
+  markObservabilityCheckpoint,
+  readObservabilityStore,
+} from './session-observability-store.mjs';
 import { mutateSessionNote } from './session-note-io.mjs';
 import { applyDerivedSections, provenanceSessions } from './derived-sections.mjs';
 import { buildSessionMemoryEvents, collectLifecycleEvidence } from './memory-handoff.mjs';
@@ -794,7 +799,206 @@ export function shouldAbortStopAfterStaging(causalStop, memoryAttempt) {
   );
 }
 
-export function main({ stageMemory = stageStopMemoryAttempt } = {}) {
+const STOP_OBSERVABILITY_DEADLINE_MS = 45_000;
+
+function stopEntryCausalSnapshot(entry) {
+  const activationId = String(entry?.active_activation_id || '');
+  const activation = entry?.activations?.[activationId] || {};
+  return {
+    activationId,
+    activationEpoch: Number(activation.epoch || entry?.activation_epoch || 0),
+    turnSequence: Number(entry?.last_turn_sequence || activation.last_turn_sequence || 0),
+  };
+}
+
+function expectedStopCausalSnapshot(entry, causalStop, turnSequence) {
+  if (!causalStop) return stopEntryCausalSnapshot(entry);
+  return {
+    activationId: String(causalStop.activationId || ''),
+    activationEpoch: Number(causalStop.activation?.epoch || entry?.activation_epoch || 0),
+    turnSequence: Number(turnSequence || 0),
+  };
+}
+
+function sameStopCausalSnapshot(left, right) {
+  return left.activationId === right.activationId
+    && left.activationEpoch === right.activationEpoch
+    && left.turnSequence === right.turnSequence;
+}
+
+function stopClaudeRoots(entry) {
+  const paths = new Set();
+  const add = (value) => {
+    if (typeof value === 'string' && value.trim()) paths.add(value.trim());
+  };
+  add(entry?.transcript_path);
+  for (const path of entry?.transcript_paths || []) add(path);
+  for (const activation of Object.values(entry?.activations || {})) {
+    add(activation?.transcript_path);
+    for (const path of activation?.transcript_paths || []) add(path);
+  }
+  return { state: 'complete', rootPaths: [...paths], descendantPaths: [], diagnostics: [] };
+}
+
+function materializeStopObservability(request) {
+  return materializeSessionObservability({
+    vaultBase: request.vaultBase,
+    sessionPath: request.sessionPath,
+    transcriptPath: request.transcriptPath,
+    entry: request.entry,
+    canonicalConversationId: request.canonicalConversationId,
+    frontier: request.frontier,
+    signals: request.signals,
+    cache: request.cache,
+    mode: 'live',
+    deadlineAt: request.deadlineAt,
+    now: request.now,
+    allowNone: request.allowNone,
+    readRuntimeFrontier: request.readRuntimeFrontier,
+    withPublicationGuard: request.withPublicationGuard,
+    writeRegistryCheckpoint: request.writeRegistryCheckpoint,
+  });
+}
+
+export async function refreshStopObservability({
+  vaultBase,
+  input,
+  sessionPath,
+  sessionId,
+  entry,
+  causalStop,
+  turnSequence,
+  hookStartedAt,
+  expectedSignalSequence,
+}, {
+  now = Date.now,
+  resolveEntry = resolveSessionEntry,
+  mutateRegistry = mutateSessionRegistry,
+  readStore = readObservabilityStore,
+  resolveRoots = resolveObservabilityRoots,
+  materialize = materializeStopObservability,
+} = {}) {
+  if (causalStop && !causalStop.canPromoteMemory) return false;
+  const deadlineAt = hookStartedAt + STOP_OBSERVABILITY_DEADLINE_MS;
+  if (now() >= deadlineAt) return false;
+
+  const expected = expectedStopCausalSnapshot(entry, causalStop, turnSequence);
+  const fresh = resolveEntry(vaultBase, input, entry?.provider);
+  if (fresh.identity?.state !== 'resolved'
+    || fresh.identity.canonicalConversationId !== sessionId
+    || !fresh.entry?.session_file
+    || fresh.entry.session_file !== entry?.session_file
+    || !sameStopCausalSnapshot(expected, stopEntryCausalSnapshot(fresh.entry))) return false;
+
+  const runtime = readStore(vaultBase, sessionId);
+  const signalSequence = Number(runtime?.observability_signal_sequence || 0);
+  if (expectedSignalSequence !== undefined
+    && signalSequence !== Number(expectedSignalSequence)) return false;
+  if (now() >= deadlineAt) return false;
+
+  const roots = fresh.identity.provider === 'codex'
+    ? resolveRoots(fresh.entry)
+    : stopClaudeRoots(fresh.entry);
+  if (roots?.state !== 'complete' || !roots.rootPaths?.length) return false;
+
+  const frontier = {
+    canonical_session_id: sessionId,
+    activation_id: expected.activationId || 'legacy',
+    activation_epoch: expected.activationEpoch,
+    turn_sequence: expected.turnSequence,
+    signal_sequence: signalSequence,
+    roots_stat_hash: 'pending',
+    graph_cursor: 'pending',
+    source_manifest_hash: 'pending',
+  };
+  const readRuntimeFrontier = (candidateFrontier, guardContext) => {
+    const currentEntry = guardContext?.entry;
+    const current = currentEntry
+      ? { identity: { state: 'resolved', canonicalConversationId: sessionId }, entry: currentEntry }
+      : resolveEntry(vaultBase, input, entry?.provider);
+    if (current.identity?.state !== 'resolved'
+      || current.identity.canonicalConversationId !== sessionId
+      || !current.entry) {
+      return { ...candidateFrontier, canonical_session_id: 'unresolved' };
+    }
+    const currentCausal = stopEntryCausalSnapshot(current.entry);
+    const currentRuntime = readStore(vaultBase, sessionId);
+    return {
+      ...candidateFrontier,
+      activation_id: currentCausal.activationId || 'legacy',
+      activation_epoch: currentCausal.activationEpoch,
+      turn_sequence: currentCausal.turnSequence,
+      signal_sequence: Math.max(
+        Number(currentRuntime?.observability_signal_sequence || 0),
+        Number(current.entry.observability_signal_sequence || 0),
+      ),
+    };
+  };
+  const withPublicationGuard = (_candidateFrontier, publishGuarded) => (
+    mutateRegistry(vaultBase, (registry) => publishGuarded({
+      registry,
+      entry: registry.sessions?.[sessionId] || null,
+    }))
+  );
+  const writeRegistryCheckpoint = ({
+    frontier: checkpointFrontier,
+    state,
+    diagnostics,
+    snapshot,
+  }, guardContext) => {
+    const registry = guardContext?.registry;
+    const current = registry?.sessions?.[sessionId];
+    if (!current) return null;
+    const currentSignal = Number(current.observability_signal_sequence || checkpointFrontier.signal_sequence);
+    registry.sessions[sessionId] = {
+      ...current,
+      observability_signal_sequence: currentSignal,
+      observability_checkpoint_sequence: checkpointFrontier.signal_sequence,
+      observability_dirty: currentSignal > checkpointFrontier.signal_sequence,
+      observability_checkpoint_frontier: checkpointFrontier,
+      subagents_observability_state: state,
+      subagents_diagnostics: diagnostics || [],
+    };
+    return markObservabilityCheckpoint(vaultBase, sessionId, {
+      checkpointSequence: checkpointFrontier.signal_sequence,
+      frontier: checkpointFrontier,
+      sourceManifest: snapshot?.subagents?.sourceManifest,
+      graphCache: snapshot?.subagents?.cache,
+      diagnostics,
+    });
+  };
+
+  const result = await Promise.resolve(materialize({
+    vaultBase,
+    sessionPath,
+    entry: fresh.entry,
+    rootPaths: roots.rootPaths,
+    transcriptPath: roots.rootPaths[0],
+    caller: 'stop',
+    canonicalConversationId: sessionId,
+    activationId: expected.activationId,
+    activationEpoch: expected.activationEpoch,
+    turnSequence: expected.turnSequence,
+    signalSequence,
+    deadlineAt,
+    allowNone: true,
+    frontier,
+    signals: runtime?.signals || [],
+    cache: runtime?.graph_cache || null,
+    now,
+    readRuntimeFrontier,
+    withPublicationGuard,
+    writeRegistryCheckpoint,
+  }));
+  return !['stale', 'conflict', 'degraded', 'missing'].includes(result?.status);
+}
+
+export async function main({
+  stageMemory = stageStopMemoryAttempt,
+  clock = Date.now,
+  refreshObservability = refreshStopObservability,
+} = {}) {
+  const hookStartedAt = clock();
   const input = readHookInput();
   if (input.stop_hook_active) {
     writeHookOutput({});
@@ -961,8 +1165,17 @@ export function main({ stageMemory = stageStopMemoryAttempt } = {}) {
   }
 
   try {
-    updateSessionObservability({
-      vaultBase, sessionPath, transcriptPath, caller: 'stop', canonicalConversationId: sessionId,
+    await refreshObservability({
+      vaultBase,
+      input,
+      sessionPath,
+      sessionId,
+      entry,
+      causalStop,
+      turnSequence: stopTurnSequence,
+      hookStartedAt,
+    }, {
+      now: clock,
     });
   } catch (error) {
     process.stderr.write(`[wendkeep] Token usage falhou: ${error.message}\n`);
@@ -1062,7 +1275,7 @@ export function main({ stageMemory = stageStopMemoryAttempt } = {}) {
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {
-    main();
+    await main();
   } catch (error) {
     process.stderr.write(`[wendkeep] Stop falhou: ${error.message}\n`);
     // Same reasoning as the identity bail: stderr is discarded by Codex. Exit stays 0 —

--- a/hooks/subagent-stop.mjs
+++ b/hooks/subagent-stop.mjs
@@ -8,29 +8,283 @@
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
-import { readHookInput, writeHookOutput, getVaultBase, providerMeta } from './obsidian-common.mjs';
-import { updateSessionObservability } from './session-observability.mjs';
+import {
+  getVaultBase,
+  mutateSessionRegistry,
+  providerMeta,
+  readHookInput,
+  writeHookOutput,
+} from './obsidian-common.mjs';
+import { materializeSessionObservability } from './session-observability.mjs';
 import { resolveSessionEntry } from './session-identity.mjs';
+import { readCodexRolloutMeta } from './codex-rollout-meta.mjs';
+import { resolveObservabilityRoots } from './session-observability-lifecycle.mjs';
+import {
+  readObservabilityStore,
+  markObservabilityCheckpoint,
+  recordObservabilitySignal,
+  releaseObservabilityLease,
+  tryAcquireObservabilityLease,
+} from './session-observability-store.mjs';
 
-export function refreshSubagents(vaultBase, input) {
-  const { identity, entry } = resolveSessionEntry(vaultBase, input, providerMeta(input.provider).id);
+const SUBAGENT_COALESCE_MS = 250;
+const SUBAGENT_DEADLINE_MS = 15_000;
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function causalSnapshot(entry) {
+  const activationId = String(entry?.active_activation_id || '');
+  const activation = entry?.activations?.[activationId] || {};
+  return {
+    activationId,
+    activationEpoch: Number(activation.epoch || entry?.activation_epoch || 0),
+    turnSequence: Number(entry?.last_turn_sequence || activation.last_turn_sequence || 0),
+  };
+}
+
+function sameCausalSnapshot(left, right) {
+  return left.activationId === right.activationId
+    && left.activationEpoch === right.activationEpoch
+    && left.turnSequence === right.turnSequence;
+}
+
+function defaultMaterialize(request) {
+  return materializeSessionObservability({
+    vaultBase: request.vaultBase,
+    sessionPath: request.sessionPath,
+    transcriptPath: request.transcriptPath,
+    entry: request.entry,
+    canonicalConversationId: request.canonicalConversationId,
+    frontier: request.frontier,
+    signals: request.signals,
+    cache: request.cache,
+    mode: 'live',
+    deadlineAt: request.deadlineAt,
+    now: request.now,
+    allowNone: request.allowNone,
+    readRuntimeFrontier: request.readRuntimeFrontier,
+    withPublicationGuard: request.withPublicationGuard,
+    writeRegistryCheckpoint: request.writeRegistryCheckpoint,
+  });
+}
+
+function claudeRoots(entry) {
+  const paths = new Set();
+  const add = (value) => {
+    if (typeof value === 'string' && value.trim()) paths.add(value.trim());
+  };
+  add(entry?.transcript_path);
+  for (const path of entry?.transcript_paths || []) add(path);
+  for (const activation of Object.values(entry?.activations || {})) {
+    add(activation?.transcript_path);
+    for (const path of activation?.transcript_paths || []) add(path);
+  }
+  return { state: 'complete', rootPaths: [...paths], descendantPaths: [], diagnostics: [] };
+}
+
+export async function refreshSubagents(vaultBase, input, {
+  now = Date.now,
+  hookStartedAt = now(),
+  sleep = wait,
+  coalesceMs = SUBAGENT_COALESCE_MS,
+  deadlineMs = SUBAGENT_DEADLINE_MS,
+  resolveEntry = resolveSessionEntry,
+  readMeta = readCodexRolloutMeta,
+  mutateRegistry = mutateSessionRegistry,
+  recordSignal = recordObservabilitySignal,
+  readStore = readObservabilityStore,
+  acquireLease = tryAcquireObservabilityLease,
+  releaseLease = releaseObservabilityLease,
+  resolveRoots = resolveObservabilityRoots,
+  materialize = defaultMaterialize,
+} = {}) {
+  const deadlineAt = hookStartedAt + deadlineMs;
+  const provider = providerMeta(input.provider).id;
+  const { identity, entry } = resolveEntry(vaultBase, input, provider);
   if (identity.state !== 'resolved') return false;
-  const transcriptPath = identity.transcriptPath;
+  const childTranscriptPath = identity.transcriptPath;
   const sessionRel = entry?.session_file || '';
   if (!sessionRel) return false;
-  const sessionPath = join(vaultBase, sessionRel);
-  if (!existsSync(sessionPath)) return false;
-  updateSessionObservability({
-    vaultBase, sessionPath, transcriptPath, caller: 'subagent-stop',
-    canonicalConversationId: identity.canonicalConversationId,
+
+  let childParentThreadId = '';
+  if (identity.provider === 'codex') {
+    const childMeta = readMeta(childTranscriptPath);
+    if (!childMeta?.ok || !childMeta.meta?.source?.subagent) return false;
+    if (!childMeta.meta.id || childMeta.meta.id !== identity.transcriptId) return false;
+    if (childMeta.meta.session_id
+      && childMeta.meta.session_id !== identity.canonicalConversationId) return false;
+    childParentThreadId = String(
+      childMeta.meta.parent_thread_id
+      || childMeta.meta.source?.subagent?.thread_spawn?.parent_thread_id
+      || '',
+    );
+  }
+
+  const observed = causalSnapshot(entry);
+  const signal = mutateRegistry(vaultBase, (registry) => {
+    const current = registry.sessions?.[identity.canonicalConversationId];
+    if (!current || current.session_file !== sessionRel
+      || !sameCausalSnapshot(observed, causalSnapshot(current))) return null;
+    const recorded = recordSignal(vaultBase, identity.canonicalConversationId, {
+      rollout_id: identity.transcriptId,
+      transcript_path: childTranscriptPath,
+      parent_thread_id: childParentThreadId,
+      kind: 'started',
+      activation_id: observed.activationId,
+      activation_epoch: observed.activationEpoch,
+      turn_sequence: observed.turnSequence,
+    });
+    if (!recorded?.state) return recorded;
+    registry.sessions[identity.canonicalConversationId] = {
+      ...current,
+      observability_signal_sequence: recorded.sequence,
+      observability_checkpoint_sequence: Number(
+        recorded.state.observability_checkpoint_sequence
+        ?? current.observability_checkpoint_sequence
+        ?? 0,
+      ),
+      observability_dirty: Boolean(recorded.state.observability_dirty),
+    };
+    return recorded;
   });
-  return true;
+  if (!signal?.state) return false;
+  if (!signal.state.observability_dirty) return true;
+
+  await sleep(coalesceMs);
+  if (now() >= deadlineAt) return true;
+
+  const latest = readStore(vaultBase, identity.canonicalConversationId);
+  if (!latest?.observability_dirty
+    || latest.observability_signal_sequence !== signal.sequence) return true;
+
+  const leaseNow = now();
+  if (leaseNow >= deadlineAt) return true;
+  const lease = acquireLease(vaultBase, identity.canonicalConversationId, {
+    signalSequence: signal.sequence,
+    now: leaseNow,
+    ttlMs: Math.max(1, deadlineAt - leaseNow),
+  });
+  if (!lease?.acquired) return true;
+
+  try {
+    if (now() >= deadlineAt) return true;
+    const fresh = resolveEntry(vaultBase, input, provider);
+    if (fresh.identity?.state !== 'resolved'
+      || fresh.identity.canonicalConversationId !== identity.canonicalConversationId
+      || !fresh.entry?.session_file
+      || !sameCausalSnapshot(observed, causalSnapshot(fresh.entry))) return true;
+
+    const sessionPath = join(vaultBase, fresh.entry.session_file);
+    if (!existsSync(sessionPath)) return true;
+    const roots = identity.provider === 'codex'
+      ? resolveRoots(fresh.entry)
+      : claudeRoots(fresh.entry);
+    if (roots?.state !== 'complete' || !roots.rootPaths?.length) return true;
+
+    const runtimeState = lease.state || latest;
+    const frontier = {
+      canonical_session_id: identity.canonicalConversationId,
+      activation_id: observed.activationId || 'legacy',
+      activation_epoch: observed.activationEpoch,
+      turn_sequence: observed.turnSequence,
+      signal_sequence: signal.sequence,
+      roots_stat_hash: 'pending',
+      graph_cursor: 'pending',
+      source_manifest_hash: 'pending',
+    };
+    const readRuntimeFrontier = (candidateFrontier, guardContext) => {
+      const currentRuntime = readStore(vaultBase, identity.canonicalConversationId);
+      const currentEntry = guardContext?.entry;
+      const currentResolved = currentEntry
+        ? { identity: { state: 'resolved', canonicalConversationId: identity.canonicalConversationId }, entry: currentEntry }
+        : resolveEntry(vaultBase, input, provider);
+      if (currentResolved.identity?.state !== 'resolved'
+        || currentResolved.identity.canonicalConversationId !== identity.canonicalConversationId
+        || !currentResolved.entry) {
+        return { ...candidateFrontier, canonical_session_id: 'unresolved' };
+      }
+      const currentCausal = causalSnapshot(currentResolved.entry);
+      return {
+        ...candidateFrontier,
+        activation_id: currentCausal.activationId || 'legacy',
+        activation_epoch: currentCausal.activationEpoch,
+        turn_sequence: currentCausal.turnSequence,
+        signal_sequence: Math.max(
+          Number(currentRuntime?.observability_signal_sequence || 0),
+          Number(currentResolved.entry.observability_signal_sequence || 0),
+        ),
+      };
+    };
+    const withPublicationGuard = (_candidateFrontier, publishGuarded) => (
+      mutateRegistry(vaultBase, (registry) => publishGuarded({
+        registry,
+        entry: registry.sessions?.[identity.canonicalConversationId] || null,
+      }))
+    );
+    const writeRegistryCheckpoint = ({
+      frontier: checkpointFrontier,
+      state,
+      diagnostics,
+      snapshot,
+    }, guardContext) => {
+      const registry = guardContext?.registry;
+      const current = registry?.sessions?.[identity.canonicalConversationId];
+      if (!current) return null;
+      const currentSignal = Number(current.observability_signal_sequence || checkpointFrontier.signal_sequence);
+      registry.sessions[identity.canonicalConversationId] = {
+        ...current,
+        observability_signal_sequence: currentSignal,
+        observability_checkpoint_sequence: checkpointFrontier.signal_sequence,
+        observability_dirty: currentSignal > checkpointFrontier.signal_sequence,
+        observability_checkpoint_frontier: checkpointFrontier,
+        subagents_observability_state: state,
+        subagents_diagnostics: diagnostics || [],
+      };
+      return markObservabilityCheckpoint(vaultBase, identity.canonicalConversationId, {
+        checkpointSequence: checkpointFrontier.signal_sequence,
+        frontier: checkpointFrontier,
+        sourceManifest: snapshot?.subagents?.sourceManifest,
+        graphCache: snapshot?.subagents?.cache,
+        diagnostics,
+      });
+    };
+
+    await Promise.resolve(materialize({
+      vaultBase,
+      sessionPath,
+      entry: fresh.entry,
+      rootPaths: roots.rootPaths,
+      transcriptPath: roots.rootPaths[0],
+      caller: 'subagent-stop',
+      canonicalConversationId: identity.canonicalConversationId,
+      activationId: observed.activationId,
+      activationEpoch: observed.activationEpoch,
+      turnSequence: observed.turnSequence,
+      signalSequence: signal.sequence,
+      deadlineAt,
+      allowNone: false,
+      frontier,
+      signals: runtimeState.signals || [],
+      cache: runtimeState.graph_cache || null,
+      now,
+      readRuntimeFrontier,
+      withPublicationGuard,
+      writeRegistryCheckpoint,
+    }));
+    return true;
+  } finally {
+    releaseLease(vaultBase, identity.canonicalConversationId, {
+      ownerToken: lease.ownerToken,
+      signalSequence: signal.sequence,
+    });
+  }
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {
+    const hookStartedAt = Date.now();
     const input = readHookInput();
-    refreshSubagents(getVaultBase(input), input);
+    await refreshSubagents(getVaultBase(input), input, { hookStartedAt });
     writeHookOutput({});
   } catch (error) {
     process.stderr.write(`[wendkeep] subagent-stop falhou: ${error.message}\n`);

--- a/hooks/subagent-usage.mjs
+++ b/hooks/subagent-usage.mjs
@@ -29,6 +29,49 @@ function walkAgentJsonl(dir) {
   return out;
 }
 
+function inspectAgentJsonlDirectory(dir) {
+  let names;
+  try {
+    names = readdirSync(dir);
+  } catch (error) {
+    return { state: error?.code === 'ENOENT' ? 'absent' : 'error', files: [] };
+  }
+  const files = [];
+  for (const name of names) {
+    const path = join(dir, name);
+    let stat;
+    try {
+      stat = statSync(path);
+    } catch {
+      return { state: 'error', files: [] };
+    }
+    if (stat.isDirectory()) {
+      const nested = inspectAgentJsonlDirectory(path);
+      if (nested.state === 'error' || nested.state === 'absent') return { state: 'error', files: [] };
+      files.push(...nested.files);
+    } else if (name.startsWith('agent-') && name.endsWith('.jsonl')) {
+      files.push(path);
+    }
+  }
+  return { state: 'ok', files };
+}
+
+function validJsonl(path) {
+  let lines;
+  try {
+    lines = readFileSync(path, 'utf8').split(/\r?\n/).filter((line) => line.trim());
+  } catch {
+    return false;
+  }
+  if (!lines.length) return false;
+  try {
+    for (const line of lines) JSON.parse(line);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // workflows/scripts/<name>-wf_<rid>.js  ->  { wf_<rid>: <name> }
 function workflowNameMap(sessionDir) {
   const map = {};
@@ -274,6 +317,28 @@ export function collectSubagentUsage(sessionDir) {
       modelRows: [...modelMap.values()].map((r) => ({ ...r, cost: round4(r.cost), source: 'subagent' })),
     },
   };
+}
+
+// Schema-2 callers need to distinguish proven absence from read/parse failure. Keep the
+// legacy aggregate API above intact while exposing a fail-closed state for observability.
+export function collectClaudeSubagentUsageState(sessionDir) {
+  const scan = inspectAgentJsonlDirectory(join(sessionDir, 'subagents'));
+  if (scan.state === 'absent' || (scan.state === 'ok' && scan.files.length === 0)) {
+    return { state: 'none', diagnostics: [] };
+  }
+  if (scan.state !== 'ok' || scan.files.some((path) => !validJsonl(path))) {
+    return {
+      state: 'degraded',
+      diagnostics: [{ code: 'CHILD_META_INVALID', count: 1 }],
+    };
+  }
+  const collected = collectSubagentUsage(sessionDir);
+  return collected
+    ? { ...collected, state: 'complete', diagnostics: [] }
+    : {
+      state: 'degraded',
+      diagnostics: [{ code: 'CHILD_META_INVALID', count: 1 }],
+    };
 }
 
 function workflowLine(w) {

--- a/hooks/token-usage.mjs
+++ b/hooks/token-usage.mjs
@@ -510,14 +510,17 @@ function detectTranscriptFormat(lines) {
   return 'codex';
 }
 
-export function parseTokenUsageFromTranscript(transcriptPath) {
+export function parseTokenUsageFromContent(content, { transcriptPath = '' } = {}) {
   const result = emptyParseResult(transcriptPath);
-  if (!transcriptPath || !existsSync(transcriptPath)) return result;
-
-  const lines = readFileSync(transcriptPath, 'utf-8').split('\n').filter(Boolean);
+  const lines = String(content || '').split('\n').filter(Boolean);
   return detectTranscriptFormat(lines) === 'claude'
     ? parseClaudeLines(lines, result)
     : parseCodexLines(lines, result);
+}
+
+export function parseTokenUsageFromTranscript(transcriptPath) {
+  if (!transcriptPath || !existsSync(transcriptPath)) return emptyParseResult(transcriptPath);
+  return parseTokenUsageFromContent(readFileSync(transcriptPath, 'utf-8'), { transcriptPath });
 }
 
 function modelCost(usage, model) {
@@ -932,6 +935,80 @@ export function collectSessionUsage({ sessionContent, transcriptPath }) {
     aggregate: agg,
     entries,
     content: withFrontmatter,
+  };
+}
+
+function normalizedTranscriptKey(value) {
+  return String(value || '').replace(/\.jsonl?$/i, '').trim().toLowerCase();
+}
+
+// Rebuild the main bucket from every validated top-level rollout. Existing history is used
+// only to preserve stable timestamps; an entry that is neither a known root nor a proven
+// descendant makes the reconstruction fail closed instead of silently deleting a legitimate
+// reopening.
+export function collectSessionUsageForRoots({
+  sessionContent,
+  rootPaths = [],
+  descendantIds = [],
+} = {}) {
+  const fmMatch = String(sessionContent || '').match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) return null;
+
+  const roots = [...new Set(rootPaths.filter(Boolean))].sort((a, b) => String(a).localeCompare(String(b)));
+  const rootKeys = new Set(roots.map((path) => normalizedTranscriptKey(transcriptIdFromPath(path))));
+  const descendantKeys = new Set(descendantIds.map(normalizedTranscriptKey).filter(Boolean));
+  const existingEntries = parseUsageHistory(fmMatch[1]);
+  const unresolved = existingEntries.filter((entry) => {
+    const key = normalizedTranscriptKey(entry.transcript_id);
+    return key && !rootKeys.has(key) && !descendantKeys.has(key);
+  });
+  if (unresolved.length) {
+    return {
+      state: 'degraded',
+      diagnostics: [{ code: 'MAIN_TRANSCRIPT_UNRESOLVED', count: unresolved.length }],
+      entries: existingEntries,
+      content: sessionContent,
+    };
+  }
+
+  const entries = [];
+  const summaries = [];
+  for (const transcriptPath of roots) {
+    if (!existsSync(transcriptPath)) {
+      return {
+        state: 'degraded',
+        diagnostics: [{ code: 'MAIN_TRANSCRIPT_UNRESOLVED', count: 1 }],
+        entries: existingEntries,
+        content: sessionContent,
+      };
+    }
+    const summary = summarizeTokenUsage(parseTokenUsageFromTranscript(transcriptPath));
+    if (!summary.calls) {
+      return {
+        state: 'degraded',
+        diagnostics: [{ code: 'MAIN_TRANSCRIPT_UNRESOLVED', count: 1 }],
+        entries: existingEntries,
+        content: sessionContent,
+      };
+    }
+    const transcriptId = transcriptIdFromPath(transcriptPath);
+    const current = entryFromSummary(summary, transcriptId);
+    const previous = existingEntries.find((entry) => normalizedTranscriptKey(entry.transcript_id) === normalizedTranscriptKey(transcriptId));
+    if (previous && sameUsageData(previous, current)) current.atualizado_em = previous.atualizado_em;
+    entries.push(current);
+    summaries.push(summary);
+  }
+
+  const agg = aggregateEntries(entries);
+  const content = upsertSessionFrontmatter(sessionContent, agg, entries);
+  if (content === null) return null;
+  return {
+    state: 'complete',
+    diagnostics: [],
+    summaries,
+    aggregate: agg,
+    entries,
+    content,
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.66.4",
+  "version": "0.66.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.66.4",
+      "version": "0.66.5",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.66.4",
+  "version": "0.66.5",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [

--- a/scripts/privacy-hygiene.mjs
+++ b/scripts/privacy-hygiene.mjs
@@ -1,0 +1,383 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const OBSERVABILITY_DIAGNOSTIC_ALLOWLIST = new Set([
+  'PARENT_META_INVALID',
+  'CHILD_MISSING',
+  'CHILD_META_INVALID',
+  'ROOT_MISMATCH',
+  'LEGACY_CHAIN_UNPROVEN',
+  'DUPLICATE_ROLLOUT_ID',
+  'GRAPH_LIMIT_EXCEEDED',
+  'FALLBACK_LIMIT_EXCEEDED',
+  'LIVE_BYTE_BUDGET_EXCEEDED',
+  'LIVE_DEADLINE_EXCEEDED',
+  'SOURCE_CHANGED_DURING_SCAN',
+  'CACHE_INVALID',
+  'STALE_FRONTIER',
+  'MAIN_TRANSCRIPT_UNRESOLVED',
+]);
+
+const SENSITIVE_FIELDS = new Set([
+  'NOTE',
+  'SID',
+  'SUMMARY',
+  'canonicalConversationId',
+  'context',
+  'contexto',
+  'identifier',
+  'message',
+  'noteRel',
+  'objective',
+  'path',
+  'pedido',
+  'projectId',
+  'project_id',
+  'prompt',
+  'rawMessage',
+  'raw_message',
+  'sessionId',
+  'sessionRel',
+  'session_id',
+  'summary',
+  'title',
+  'transcriptId',
+  'transcript_id',
+  'vault',
+  'vaultName',
+]);
+
+const PROMPT_OR_MESSAGE_FIELDS = new Set([
+  'context',
+  'contexto',
+  'message',
+  'objective',
+  'pedido',
+  'prompt',
+  'rawMessage',
+  'raw_message',
+  'summary',
+  'title',
+]);
+
+const SAFE_RELATIVE_SEGMENTS = new Set([
+  '.brain',
+  '03-Sessões',
+  '03-Sessions',
+]);
+
+const MEMORY_FIXTURE_SOURCES = new Set([
+  'tests/memory-handoff.test.mjs',
+  'tests/memory-hybrid-e2e.test.mjs',
+  'tests/session-stop-memory.test.mjs',
+  'tests/fixtures/synthetic-memory-lifecycle.mjs',
+]);
+
+const CHANGE_PREFIX = '.WendKeep-vault/08-Mudanças/codex-subagent-observability/';
+const GENERATED_INTEGRITY_FIELDS = new Map([
+  ['tasksHash', 12],
+  ['effectiveSpecHash', 64],
+]);
+
+function normalizeRelativePath(path) {
+  return String(path).split(sep).join('/').replace(/^\.\//, '');
+}
+
+function finding(relativePath, line, category) {
+  return `${normalizeRelativePath(relativePath)}:${Math.max(1, Number(line) || 1)}:${category}`;
+}
+
+function decodeLiteral(raw, quote) {
+  if (quote === '"') {
+    try { return JSON.parse(`${quote}${raw}${quote}`); } catch { return raw; }
+  }
+  return raw
+    .replaceAll('\\\\', '\\')
+    .replaceAll(`\\${quote}`, quote)
+    .replaceAll('\\n', '\n')
+    .replaceAll('\\r', '\r')
+    .replaceAll('\\t', '\t');
+}
+
+function literalsOnLine(line) {
+  const literals = [];
+  const pattern = /(["'`])((?:\\.|(?!\1).)*)\1/g;
+  for (const match of line.matchAll(pattern)) {
+    literals.push({
+      column: match.index ?? 0,
+      value: decodeLiteral(match[2], match[1]),
+    });
+  }
+  return literals;
+}
+
+function allowedFixtureValue(value) {
+  if (!value) return true;
+  if (/^\[wk-fixture\]/.test(value)) return true;
+  if (/^\.?wk-fixture-[a-z0-9-]+(?:\.[a-z0-9]+)?$/i.test(value)) return true;
+
+  const segments = value.split(/[\\/]/).filter(Boolean);
+  return segments.length > 0 && segments.every((segment) => (
+    SAFE_RELATIVE_SEGMENTS.has(segment)
+    || /^\.?wk-fixture-[a-z0-9-]+(?:\.[a-z0-9]+)?$/i.test(segment)
+  ));
+}
+
+function fieldBefore(line, column) {
+  const prefix = line.slice(0, column);
+  const match = prefix.match(/(?:^\s*|[,{;]\s*|\bconst\s+)["']?([A-Za-z_][A-Za-z0-9_]*)["']?\s*[:=]\s*$/);
+  return match?.[1] ?? '';
+}
+
+function allowedGeneratedIntegrityHash(relativePath, field, value) {
+  const expectedLength = GENERATED_INTEGRITY_FIELDS.get(field);
+  if (!expectedLength) return false;
+  const path = normalizeRelativePath(relativePath);
+  return path.startsWith(CHANGE_PREFIX)
+    && /\/(?:verificacao|verdict)\.json$/i.test(path)
+    && String(value).length === expectedLength
+    && /^[0-9a-f]+$/i.test(String(value));
+}
+
+function allowedGeneratedEvidence(relativePath, field, value) {
+  const path = normalizeRelativePath(relativePath);
+  if (field !== 'evidence'
+    || !path.startsWith(CHANGE_PREFIX)
+    || !/\/verdict\.json$/i.test(path)) return false;
+  const references = String(value).split('; ');
+  return references.length > 0 && references.every((reference) => (
+    /^(?:tests|hooks|src|scripts|packages|docs)\/(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+\.(?:mjs|js|json|md):[1-9]\d*$/.test(reference)
+  ));
+}
+
+function allowedSyntheticLifecyclePath(relativePath, value) {
+  if (!MEMORY_FIXTURE_SOURCES.has(normalizeRelativePath(relativePath))) return false;
+  const expanded = String(value).replaceAll(
+    '${SYNTHETIC_MEMORY.changeSlug}',
+    'wk-fixture-example-change',
+  );
+  if (expanded.includes('${')) return false;
+  return /^04-Decisões\/ADR-\d{4}-wk-fixture-[a-z0-9-]+\.md$/i.test(expanded)
+    || /^08-Mudanças\/_arquivo\/wk-fixture-[a-z0-9-]+\/verdict\.json$/i.test(expanded);
+}
+
+function structuralCategories(value) {
+  const categories = [];
+  const text = String(value ?? '');
+  if (/^[A-Za-z]:[\\/]/.test(text)
+    || /^\/(?:Users|home)\//.test(text)
+    || /^\\\\[^\\/]+[\\/][^\\/]+/.test(text)) {
+    categories.push('absolute-local-path');
+  }
+  if (/\b[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\b/i.test(text)
+    || /\b[0-9a-f]{24,}\b/i.test(text)
+    || /\b[A-Za-z0-9_-]{32,}\b/.test(text)) {
+    if (!allowedFixtureValue(text)) categories.push('opaque-identifier');
+  }
+  return categories;
+}
+
+function categoriesForLiteral(value, field, relativePath) {
+  const categories = structuralCategories(value).filter((category) => (
+    category !== 'opaque-identifier'
+    || (!allowedGeneratedIntegrityHash(relativePath, field, value)
+      && !allowedGeneratedEvidence(relativePath, field, value))
+  ));
+  const approvedFixtureValue = allowedFixtureValue(value)
+    || allowedSyntheticLifecyclePath(relativePath, value);
+  if (SENSITIVE_FIELDS.has(field) && !approvedFixtureValue) {
+    categories.push('unapproved-fixture-value');
+    if (PROMPT_OR_MESSAGE_FIELDS.has(field)) categories.push('prompt-or-message-content');
+  }
+  return categories;
+}
+
+function unescapedBackticks(line) {
+  let found = 0;
+  for (let index = 0; index < line.length; index += 1) {
+    if (line[index] !== '`') continue;
+    let slashes = 0;
+    for (let cursor = index - 1; cursor >= 0 && line[cursor] === '\\'; cursor -= 1) slashes += 1;
+    if (slashes % 2 === 0) found += 1;
+  }
+  return found;
+}
+
+function staticDiagnosticCode(line) {
+  const match = line.match(/\bcode\s*:\s*["']([A-Z][A-Z0-9_]+)["']/);
+  return match?.[1] ?? '';
+}
+
+function staticDiagnosticFields(line) {
+  const object = line.match(/\{\s*code\s*:[^}]*\}/)?.[0] ?? '';
+  if (!object) return [];
+  return [...object.matchAll(/\b([A-Za-z_][A-Za-z0-9_]*)\s*:/g)].map((match) => match[1]);
+}
+
+export function inspectFixtureSource(relativePath, source) {
+  const findings = new Set();
+  const lines = String(source).replaceAll('\r\n', '\n').split('\n');
+  let insideTemplate = false;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const code = staticDiagnosticCode(line);
+    if (code && !OBSERVABILITY_DIAGNOSTIC_ALLOWLIST.has(code)) {
+      findings.add(finding(relativePath, index + 1, 'diagnostic-code-not-allowlisted'));
+    }
+    const diagnosticFields = staticDiagnosticFields(line);
+    if (diagnosticFields.some((field) => field !== 'code' && field !== 'count')) {
+      findings.add(finding(relativePath, index + 1, 'diagnostic-unapproved-field'));
+    }
+    if (diagnosticFields.some((field) => PROMPT_OR_MESSAGE_FIELDS.has(field))) {
+      findings.add(finding(relativePath, index + 1, 'diagnostic-prompt-or-message'));
+    }
+    if (insideTemplate) {
+      for (const category of structuralCategories(line)) {
+        findings.add(finding(relativePath, index + 1, category));
+      }
+    }
+    for (const literal of literalsOnLine(line)) {
+      const field = fieldBefore(line, literal.column);
+      for (const category of categoriesForLiteral(literal.value, field, relativePath)) {
+        findings.add(finding(relativePath, index + 1, category));
+      }
+    }
+    if (unescapedBackticks(line) % 2 === 1) insideTemplate = !insideTemplate;
+  }
+  return [...findings].sort();
+}
+
+export function inspectDiagnosticRecords(relativePath, records) {
+  if (!Array.isArray(records)) {
+    return [finding(relativePath, 1, 'diagnostic-invalid-shape')];
+  }
+
+  const findings = new Set();
+  records.forEach((record, index) => {
+    const line = index + 1;
+    if (!record || typeof record !== 'object' || Array.isArray(record)) {
+      findings.add(finding(relativePath, line, 'diagnostic-invalid-shape'));
+      return;
+    }
+
+    const keys = Object.keys(record);
+    if (keys.some((key) => key !== 'code' && key !== 'count')) {
+      findings.add(finding(relativePath, line, 'diagnostic-unapproved-field'));
+    }
+    if (!OBSERVABILITY_DIAGNOSTIC_ALLOWLIST.has(record.code)) {
+      findings.add(finding(relativePath, line, 'diagnostic-code-not-allowlisted'));
+    }
+    if (!Number.isSafeInteger(record.count) || record.count < 0) {
+      findings.add(finding(relativePath, line, 'diagnostic-invalid-count'));
+    }
+
+    for (const [key, value] of Object.entries(record)) {
+      for (const category of structuralCategories(value)) {
+        findings.add(finding(relativePath, line, category));
+      }
+      if (PROMPT_OR_MESSAGE_FIELDS.has(key)) {
+        findings.add(finding(relativePath, line, 'diagnostic-prompt-or-message'));
+      }
+    }
+  });
+  return [...findings].sort();
+}
+
+export function inspectStagedDiff(diff) {
+  const findings = new Set();
+  let relativePath = '';
+  let destinationLine = 0;
+
+  for (const line of String(diff).replaceAll('\r\n', '\n').split('\n')) {
+    if (line.startsWith('+++ ')) {
+      const target = line.slice(4).trim();
+      relativePath = target === '/dev/null' ? '' : target.replace(/^b\//, '');
+      continue;
+    }
+    const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunk) {
+      destinationLine = Number(hunk[1]);
+      continue;
+    }
+    if (!relativePath || line.startsWith('diff --git ') || line.startsWith('--- ')) continue;
+    if (line.startsWith('+')) {
+      for (const item of inspectFixtureSource(relativePath, line.slice(1))) {
+        const category = item.slice(item.lastIndexOf(':') + 1);
+        findings.add(finding(relativePath, destinationLine, category));
+      }
+      destinationLine += 1;
+      continue;
+    }
+    if (!line.startsWith('-') && !line.startsWith('\\')) destinationLine += 1;
+  }
+
+  return [...findings].sort();
+}
+
+function walkFiles(root, directory) {
+  if (!existsSync(directory)) return [];
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const absolute = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...walkFiles(root, absolute));
+    else if (entry.isFile()) files.push(normalizeRelativePath(relative(root, absolute)));
+  }
+  return files;
+}
+
+function isPrivacySurface(relativePath) {
+  const path = normalizeRelativePath(relativePath);
+  const changeArtifact = path.startsWith(CHANGE_PREFIX)
+    && /\/(?:evidencia|verificacao|verdict)\.json$/i.test(path);
+  return MEMORY_FIXTURE_SOURCES.has(path)
+    || /^tests\/fixtures\/.*(?:observability|subagent).*$/i.test(path)
+    || changeArtifact
+    || /^\.github\/(?:PULL_REQUEST_TEMPLATE|ISSUE_TEMPLATE)(?:\/|\.|$)/i.test(path)
+    || /^(?:RELEASE_NOTES|release-notes)(?:\.|$)/.test(path);
+}
+
+export function repositoryPrivacySources(root) {
+  const listed = spawnSync('git', ['ls-files', '--cached', '--others', '--exclude-standard', '-z'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  if (listed.status !== 0) return [];
+
+  const discovered = listed.stdout.split('\0').filter(Boolean);
+  const changeFiles = walkFiles(root, join(root, ...CHANGE_PREFIX.slice(0, -1).split('/')));
+  return [...new Set([...discovered, ...changeFiles].filter(isPrivacySurface))].sort();
+}
+
+export function scanRepositoryPrivacy(root) {
+  const findings = new Set();
+  for (const relativePath of repositoryPrivacySources(root)) {
+    try {
+      const source = readFileSync(join(root, ...relativePath.split('/')), 'utf8');
+      for (const item of inspectFixtureSource(relativePath, source)) findings.add(item);
+    } catch {
+      findings.add(finding(relativePath, 1, 'scan-read-error'));
+    }
+  }
+
+  const staged = spawnSync('git', ['diff', '--cached', '--no-ext-diff', '--unified=0', '--'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  if (staged.status !== 0) findings.add(finding('git-staged-diff', 1, 'scan-read-error'));
+  else for (const item of inspectStagedDiff(staged.stdout)) findings.add(item);
+  return [...findings].sort();
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+if (process.argv[1] && resolve(process.argv[1]) === currentFile) {
+  const root = resolve(dirname(currentFile), '..');
+  const findings = scanRepositoryPrivacy(root);
+  if (findings.length) {
+    process.stderr.write(`${findings.join('\n')}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/src/cost.mjs
+++ b/src/cost.mjs
@@ -196,19 +196,53 @@ function opt(argv, name) {
   return eq ? eq.slice(name.length + 1) : undefined;
 }
 
+const REBUILD_LIMIT_FLAGS = [
+  ['--max-graph-nodes', 'maxGraphNodes'],
+  ['--max-fallback-days', 'maxFallbackDays'],
+  ['--max-fallback-candidates', 'maxFallbackCandidates'],
+];
+
+export function parseRebuildOptions(argv = []) {
+  const session = opt(argv, '--session') || '';
+  const overrides = {};
+  for (const [flag, key] of REBUILD_LIMIT_FLAGS) {
+    const present = argv.includes(flag) || argv.some((arg) => arg.startsWith(`${flag}=`));
+    if (!present) continue;
+    const value = Number(opt(argv, flag));
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      return { ok: false, exitCode: 2, code: 'INVALID_LIMIT_OVERRIDE' };
+    }
+    overrides[key] = value;
+  }
+  if (Object.keys(overrides).length > 0 && !session) {
+    return { ok: false, exitCode: 2, code: 'TARGET_REQUIRED_FOR_LIMIT_OVERRIDE' };
+  }
+  return {
+    ok: true,
+    options: {
+      apply: argv.includes('--apply'),
+      session,
+      limit: Number(opt(argv, '--limit')) || 0,
+      limits: { ...overrides },
+      overrides: { ...overrides },
+    },
+  };
+}
+
 export function runCost(argv) {
   const vaultRaw = opt(argv, '--vault') || process.env.OBSIDIAN_VAULT_PATH;
   if (!vaultRaw) { process.stderr.write('wendkeep cost: no vault (--vault or OBSIDIAN_VAULT_PATH).\n'); process.exit(2); }
   const vaultBase = isAbsolute(vaultRaw) ? vaultRaw : resolve(process.cwd(), vaultRaw);
   if (!existsSync(vaultBase)) { process.stderr.write(`wendkeep cost: vault not found: ${vaultBase}\n`); process.exit(2); }
   if (argv[0] === 'rebuild') {
-    const report = rebuildSessionCosts(vaultBase, {
-      apply: argv.includes('--apply'),
-      session: opt(argv, '--session') || '',
-      limit: Number(opt(argv, '--limit')) || 0,
-    });
+    const parsed = parseRebuildOptions(argv);
+    if (!parsed.ok) {
+      process.stderr.write(`wendkeep cost rebuild: ${parsed.code}\n`);
+      process.exit(parsed.exitCode);
+    }
+    const report = rebuildSessionCosts(vaultBase, parsed.options);
     if (argv.includes('--json')) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
-    else process.stdout.write(`cost rebuild (${report.mode}): ${report.scanned} lidas · ${report.changed} alteradas · ${report.unchanged} iguais · ${report.missing.length} sem fonte · ${report.errors.length} erros\n${report.mode === 'apply' ? 'Relatório: .brain/COST_REBUILD.json\n' : 'Nenhum arquivo foi alterado; use --apply para gravar.\n'}`);
+    else process.stdout.write(`cost rebuild (${report.mode}): ${report.scanned} lidas · ${report.changed} alteradas · ${report.unchanged} iguais · ${report.degraded} degradadas · ${report.stale} stale · ${report.missing} sem fonte · ${report.errors} erros\n${report.mode === 'apply' ? 'Relatório: .brain/COST_REBUILD.json\n' : 'Nenhum arquivo foi alterado; use --apply para gravar.\n'}`);
     process.exit(report.ok ? 0 : 1);
   }
   const agg = collectVaultCost(vaultBase, { since: opt(argv, '--since') });

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -4,7 +4,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { checkHarness, checkVaultLinks, checkSessionActivity, checkStackedFrontmatter, renderStackedFrontmatterLines, checkUnpricedModels, renderUnpricedModelLines, checkStaleDerivedSections, renderStaleDerivedSectionLines } from '../hooks/harness-doctor.mjs';
+import { checkHarness, checkVaultLinks, checkSessionActivity, checkStackedFrontmatter, renderStackedFrontmatterLines, checkUnpricedModels, renderUnpricedModelLines, checkStaleDerivedSections, renderStaleDerivedSectionLines, checkSessionObservability, renderSessionObservabilityLines } from '../hooks/harness-doctor.mjs';
 import { checkSyncDefs } from './sync-defs.mjs';
 import { resolveProjectVault } from './project-vault.mjs';
 
@@ -78,6 +78,9 @@ export function runDoctor(argv) {
 
   // 3d. Seções derivadas do corpo que ficaram para trás do Encerramento (notas pré-0.53.0).
   process.stdout.write(`\n${renderStaleDerivedSectionLines(checkStaleDerivedSections(vaultBase)).join('\n')}\n`);
+
+  // 3e. Observabilidade materializada: schema vigente não basta sem frontier + manifest frescos.
+  process.stdout.write(`\n${renderSessionObservabilityLines(checkSessionObservability(vaultBase)).join('\n')}\n`);
 
   // 4. Sessão: não mente "inativa" quando há atividade recente (workflow/subagente em background).
   const act = checkSessionActivity(vaultBase);

--- a/src/rebuild-costs.mjs
+++ b/src/rebuild-costs.mjs
@@ -1,45 +1,231 @@
-// Deterministic cost reconstruction for historical sessions.
-// Registry is authoritative: session_file <-> transcript_path. Dry-run restores every note.
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+// Deterministic, causal reconstruction for historical session observability.
+// Dry-run is a pure composition pass; apply delegates all note mutation to the CAS publisher.
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { readSessionRegistry } from '../hooks/obsidian-common.mjs';
-import { updateSessionObservability } from '../hooks/session-observability.mjs';
+import * as sessionObservability from '../hooks/session-observability.mjs';
+import {
+  mutateObservabilityStore,
+  readObservabilityStore,
+} from '../hooks/session-observability-store.mjs';
+import { sanitizeObservabilityDiagnostics } from '../hooks/session-observability-state.mjs';
 import { assertVaultPathSafe } from '../hooks/vault-path-safety.mjs';
 
-export function rebuildSessionCosts(vaultBase, { apply = false, session = '', limit = 0 } = {}) {
-  const registry = readSessionRegistry(vaultBase);
-  const report = { version: 1, generatedAt: new Date().toISOString(), mode: apply ? 'apply' : 'dry-run', scanned: 0, changed: 0, unchanged: 0, missing: [], errors: [], sessions: [] };
-  const entries = Object.entries(registry.sessions || {}).map(([sessionId, value]) => ({ sessionId, ...value }))
-    .filter((e) => e.session_file)
-    .filter((e) => !session || e.sessionId === session || e.session_file === session);
-  for (const entry of entries) {
-    if (limit && report.scanned >= limit) break;
-    report.scanned += 1;
-    const checkedNote = assertVaultPathSafe(vaultBase, join(vaultBase, entry.session_file), {
-      expectedType: 'file', label: 'nota de sessão do rebuild de custos',
-    });
-    const note = checkedNote.target;
-    if (!entry.transcript_path || !checkedNote.exists || !existsSync(entry.transcript_path)) {
-      report.missing.push({ sessionId: entry.sessionId, session: entry.session_file, note: checkedNote.exists, transcript: !!entry.transcript_path && existsSync(entry.transcript_path), transcriptPath: entry.transcript_path || '' });
-      continue;
-    }
-    const before = readFileSync(note, 'utf8');
+function sortedEntries(registry, target) {
+  return Object.entries(registry?.sessions || {})
+    .map(([sessionId, value]) => ({ sessionId, ...value }))
+    .filter((entry) => entry.session_file)
+    .filter((entry) => !target || entry.sessionId === target || entry.session_file === target)
+    .sort((a, b) => a.sessionId.localeCompare(b.sessionId));
+}
+
+function transcriptCandidates(entry) {
+  const paths = new Set();
+  if (entry.transcript_path) paths.add(entry.transcript_path);
+  for (const path of entry.transcript_paths || []) if (path) paths.add(path);
+  const activations = Array.isArray(entry.activations)
+    ? entry.activations
+    : Object.values(entry.activations || {});
+  for (const activation of activations) {
+    if (activation?.transcript_path) paths.add(activation.transcript_path);
+    for (const path of activation?.transcript_paths || []) if (path) paths.add(path);
+  }
+  return [...paths];
+}
+
+function candidateContent(candidate, fallback) {
+  return typeof candidate?.content === 'string' ? candidate.content : fallback;
+}
+
+function candidateHash(candidate, fallback) {
+  return createHash('sha256').update(candidateContent(candidate, fallback)).digest('hex');
+}
+
+function safeDiagnostics(input, fallback = []) {
+  try {
+    return sanitizeObservabilityDiagnostics(input || fallback);
+  } catch {
+    return sanitizeObservabilityDiagnostics(fallback);
+  }
+}
+
+export function semanticRebuildReport(report) {
+  const {
+    generatedAt: _generatedAt,
+    changed = 0,
+    unchanged = 0,
+    sessions = [],
+    ...semantic
+  } = report || {};
+  return {
+    ...semantic,
+    converged: Number(changed || 0) + Number(unchanged || 0),
+    sessions: sessions.map((entry) => ({
+      ...entry,
+      status: entry.status === 'published' || entry.status === 'unchanged'
+        ? 'converged'
+        : entry.status,
+    })),
+  };
+}
+
+export function writeRebuildReportIfChanged(reportPath, report) {
+  if (existsSync(reportPath)) {
     try {
-      updateSessionObservability({
-        vaultBase, sessionPath: note, transcriptPath: entry.transcript_path,
-        caller: 'cost-rebuild', canonicalConversationId: entry.sessionId,
-      });
-      const after = readFileSync(note, 'utf8');
-      const changed = before !== after;
-      if (changed) report.changed += 1; else report.unchanged += 1;
-      report.sessions.push({ sessionId: entry.sessionId, session: entry.session_file, transcript: entry.transcript_path, changed });
-      if (!apply && changed) writeFileSync(note, before, 'utf8');
-    } catch (error) {
-      if (!apply) writeFileSync(note, before, 'utf8');
-      report.errors.push({ sessionId: entry.sessionId, session: entry.session_file, error: error.message });
+      const previous = JSON.parse(readFileSync(reportPath, 'utf8'));
+      if (JSON.stringify(semanticRebuildReport(previous))
+        === JSON.stringify(semanticRebuildReport(report))) return false;
+    } catch {
+      // Invalid prior reports are replaced by the sanitized current schema.
     }
   }
-  report.ok = report.errors.length === 0 && report.missing.length === 0;
-  if (apply) writeFileSync(join(vaultBase, '.brain', 'COST_REBUILD.json'), `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  mkdirSync(dirname(reportPath), { recursive: true });
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  return true;
+}
+
+function markDirtyDefault(vaultBase, sessionId, diagnostics) {
+  mutateObservabilityStore(vaultBase, sessionId, (state) => ({
+    ...state,
+    observability_dirty: true,
+    diagnostics: safeDiagnostics(diagnostics, [{ code: 'STALE_FRONTIER', count: 1 }]),
+  }));
+}
+
+export function rebuildSessionCosts(
+  vaultBase,
+  {
+    apply = false,
+    session = '',
+    limit = 0,
+    limits = {},
+    overrides = {},
+  } = {},
+  effects = {},
+) {
+  const readRegistry = effects.readRegistry || readSessionRegistry;
+  const compose = effects.compose || sessionObservability.composeSessionObservability;
+  const publish = effects.publish || sessionObservability.publishSessionObservability;
+  const readStore = effects.readStore || readObservabilityStore;
+  const markDirty = effects.markDirty || markDirtyDefault;
+  const writeReport = effects.writeReport || writeRebuildReportIfChanged;
+  const now = effects.now || (() => new Date().toISOString());
+  if (typeof compose !== 'function') throw new TypeError('composeSessionObservability indisponível');
+  if (apply && typeof publish !== 'function') throw new TypeError('publishSessionObservability indisponível');
+
+  const registry = readRegistry(vaultBase);
+  const report = {
+    version: 2,
+    generatedAt: now(),
+    mode: apply ? 'apply' : 'dry-run',
+    targeted: Boolean(session),
+    overrides: { ...overrides },
+    scanned: 0,
+    changed: 0,
+    unchanged: 0,
+    degraded: 0,
+    stale: 0,
+    missing: 0,
+    errors: 0,
+    ok: true,
+    sessions: [],
+  };
+
+  for (const entry of sortedEntries(registry, session)) {
+    if (limit && report.scanned >= limit) break;
+    report.scanned += 1;
+    let note;
+    try {
+      const checked = assertVaultPathSafe(vaultBase, join(vaultBase, entry.session_file), {
+        expectedType: 'file', label: 'nota de sessão do rebuild de custos',
+      });
+      const hasTranscript = transcriptCandidates(entry).some((path) => existsSync(path));
+      if (!checked.exists || !hasTranscript) {
+        report.missing += 1;
+        report.sessions.push({
+          sessionId: entry.sessionId, status: 'missing', diagnostics: [],
+        });
+        continue;
+      }
+      note = checked.target;
+      const before = readFileSync(note, 'utf8');
+      const runtimeState = readStore(vaultBase, entry.sessionId);
+      const candidate = compose({
+        vaultBase,
+        sessionContent: before,
+        sessionEntry: entry,
+        canonicalConversationId: entry.sessionId,
+        caller: 'cost-rebuild',
+        mode: 'offline',
+        limits,
+        runtimeState,
+      });
+      const diagnostics = safeDiagnostics(candidate?.diagnostics);
+      const contentHash = candidateHash(candidate, before);
+      if (candidate?.state === 'degraded') {
+        report.degraded += 1;
+        report.sessions.push({ sessionId: entry.sessionId, status: 'degraded', diagnostics });
+        if (apply) markDirty(vaultBase, entry.sessionId, diagnostics);
+        continue;
+      }
+      if (candidate?.state !== 'complete' && candidate?.state !== 'none') {
+        report.degraded += 1;
+        const invalidDiagnostics = [{ code: 'PARENT_META_INVALID', count: 1 }];
+        report.sessions.push({
+          sessionId: entry.sessionId, status: 'degraded', diagnostics: invalidDiagnostics,
+        });
+        if (apply) markDirty(vaultBase, entry.sessionId, invalidDiagnostics);
+        continue;
+      }
+
+      if (!apply) {
+        const changed = candidateContent(candidate, before) !== before;
+        if (changed) report.changed += 1;
+        else report.unchanged += 1;
+        report.sessions.push({
+          sessionId: entry.sessionId,
+          status: changed ? 'would-change' : 'unchanged',
+          candidateHash: contentHash,
+          diagnostics,
+        });
+        continue;
+      }
+
+      const outcome = publish({
+        vaultBase,
+        sessionPath: note,
+        canonicalConversationId: entry.sessionId,
+        candidate,
+        caller: 'cost-rebuild',
+        mode: 'offline',
+        allowSourceRefresh: true,
+      }) || { status: 'degraded' };
+      if (outcome.status === 'published') report.changed += 1;
+      else if (outcome.status === 'unchanged') report.unchanged += 1;
+      else if (outcome.status === 'stale' || outcome.status === 'conflict') {
+        report.stale += 1;
+        markDirty(vaultBase, entry.sessionId, [{ code: 'STALE_FRONTIER', count: 1 }]);
+      } else {
+        report.degraded += 1;
+        markDirty(vaultBase, entry.sessionId, [{ code: 'PARENT_META_INVALID', count: 1 }]);
+      }
+      report.sessions.push({
+        sessionId: entry.sessionId,
+        status: outcome.status || 'degraded',
+        candidateHash: contentHash,
+        diagnostics: safeDiagnostics(outcome.diagnostics, diagnostics),
+      });
+    } catch {
+      report.errors += 1;
+      const diagnostics = [{ code: 'PARENT_META_INVALID', count: 1 }];
+      report.sessions.push({ sessionId: entry.sessionId, status: 'degraded', diagnostics });
+      if (apply) markDirty(vaultBase, entry.sessionId, diagnostics);
+    }
+  }
+
+  report.ok = report.degraded === 0 && report.stale === 0
+    && report.missing === 0 && report.errors === 0;
+  if (apply) writeReport(join(vaultBase, '.brain', 'COST_REBUILD.json'), report);
   return report;
 }

--- a/tests/codex-rollout-meta.test.mjs
+++ b/tests/codex-rollout-meta.test.mjs
@@ -1,0 +1,165 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  readCodexRolloutMeta,
+  readFirstJsonlLine,
+} from '../hooks/codex-rollout-meta.mjs';
+import { inspectTranscriptIdentity } from '../hooks/session-identity.mjs';
+
+const FOUR_MIB = 4 * 1024 * 1024;
+
+function withRollout(content, run) {
+  const dir = mkdtempSync(join(tmpdir(), 'wk-codex-meta-'));
+  const path = join(dir, 'rollout-synthetic.jsonl');
+  try {
+    writeFileSync(path, content);
+    return run(path);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('[req:OBS-3] lê session_meta pequeno mesmo quando o corpo total supera 4 MiB', () => {
+  const event = {
+    type: 'session_meta',
+    payload: {
+      id: 'rollout-alpha',
+      session_id: 'session-alpha',
+      cwd: 'C:\\synthetic\\project',
+      model_provider: 'openai',
+    },
+  };
+  const firstLine = JSON.stringify(event);
+  const largeBody = `${JSON.stringify({ type: 'event_msg', payload: { text: 'x'.repeat(FOUR_MIB + 1024) } })}\n`;
+
+  withRollout(`${firstLine}\n${largeBody}`, (path) => {
+    assert.ok(statSync(path).size > FOUR_MIB, 'fixture discrimina o mutante que mede o arquivo total');
+
+    assert.deepEqual(readFirstJsonlLine(path), {
+      ok: true,
+      line: firstLine,
+      lineBytes: Buffer.byteLength(firstLine),
+    });
+    assert.deepEqual(readCodexRolloutMeta(path), {
+      ok: true,
+      meta: event.payload,
+      lineBytes: Buffer.byteLength(firstLine),
+    });
+  });
+});
+
+test('[req:OBS-3] rejeita primeira linha maior que o limite sem medir o corpo', () => {
+  const firstLine = JSON.stringify({
+    type: 'session_meta',
+    payload: { id: 'rollout-beta', instructions: 'x'.repeat(256) },
+  });
+
+  withRollout(`${firstLine}\n`, (path) => {
+    assert.deepEqual(readFirstJsonlLine(path, { maxBytes: 128 }), {
+      ok: false,
+      reason: 'LINE_TOO_LONG',
+    });
+    assert.deepEqual(readCodexRolloutMeta(path, { maxLineBytes: 128 }), {
+      ok: false,
+      reason: 'LINE_TOO_LONG',
+    });
+  });
+});
+
+test('[req:OBS-3] retorna razão tipada para JSON inválido', () => {
+  withRollout('{"type":"session_meta"\n', (path) => {
+    assert.deepEqual(readCodexRolloutMeta(path), {
+      ok: false,
+      reason: 'INVALID_JSON',
+    });
+  });
+});
+
+test('[req:OBS-3] retorna razão tipada quando o primeiro evento não é session_meta', () => {
+  withRollout(`${JSON.stringify({ type: 'event_msg', payload: { type: 'task_started' } })}\n`, (path) => {
+    assert.deepEqual(readCodexRolloutMeta(path), {
+      ok: false,
+      reason: 'NOT_SESSION_META',
+    });
+  });
+});
+
+test('[req:OBS-3] rejeita session_meta sem payload objeto', () => {
+  withRollout(`${JSON.stringify({ type: 'session_meta', payload: null })}\n`, (path) => {
+    assert.deepEqual(readCodexRolloutMeta(path), {
+      ok: false,
+      reason: 'INVALID_META',
+    });
+  });
+});
+
+test('[req:OBS-3] identidade Codex aceita session_meta somente na primeira linha física', () => {
+  const misplacedMeta = JSON.stringify({
+    type: 'session_meta',
+    payload: {
+      id: 'rollout-misplaced',
+      session_id: 'session-misplaced',
+      model_provider: 'openai',
+    },
+  });
+  const firstEvent = JSON.stringify({ type: 'event_msg', payload: { type: 'task_started' } });
+
+  withRollout(`${firstEvent}\n${misplacedMeta}\n`, (path) => {
+    assert.deepEqual(inspectTranscriptIdentity(path), {
+      transcriptProvider: 'unknown',
+      provider: 'unknown',
+      canonicalConversationId: '',
+      transcriptId: '',
+      parentConversationId: '',
+    });
+  });
+});
+
+test('[req:OBS-3] identidade Codex não carrega o corpo total para validar metadata inicial', () => {
+  const event = {
+    type: 'session_meta',
+    payload: {
+      id: 'rollout-identity',
+      session_id: 'session-identity',
+      parent_thread_id: 'parent-identity',
+      model_provider: 'openai',
+    },
+  };
+  const body = JSON.stringify({ type: 'event_msg', payload: { text: 'x'.repeat(FOUR_MIB + 1024) } });
+
+  withRollout(`${JSON.stringify(event)}\n${body}\n`, (path) => {
+    assert.deepEqual(inspectTranscriptIdentity(path), {
+      transcriptProvider: 'openai',
+      provider: 'codex',
+      canonicalConversationId: 'session-identity',
+      transcriptId: 'rollout-identity',
+      parentConversationId: 'parent-identity',
+    });
+  });
+});
+
+test('[req:OBS-3] integração incremental preserva inspeção Claude', () => {
+  const claudeEvent = {
+    type: 'user',
+    sessionId: 'claude-synthetic',
+    message: { role: 'user', content: 'conteúdo sintético' },
+  };
+
+  withRollout(`${JSON.stringify(claudeEvent)}\n`, (path) => {
+    assert.deepEqual(inspectTranscriptIdentity(path), {
+      transcriptProvider: 'anthropic',
+      provider: 'claude',
+      canonicalConversationId: 'claude-synthetic',
+      transcriptId: 'rollout-synthetic',
+      parentConversationId: '',
+    });
+  });
+});

--- a/tests/codex-subagent-graph.test.mjs
+++ b/tests/codex-subagent-graph.test.mjs
@@ -1,0 +1,721 @@
+// [req:OBS-3] [req:OBS-12]
+// Synthetic Codex graph fixtures only. No consumer transcript, identifier, path or prompt
+// belongs in this suite.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  appendFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  CODEX_SUBAGENT_GRAPH_LIMITS,
+  composeCodexSubagentGraph,
+} from "../hooks/codex-subagent-graph.mjs";
+
+const ROOT = "root-alpha";
+const CHILD_A = "child-alpha";
+const CHILD_B = "child-beta";
+
+function sandbox(t) {
+  const path = mkdtempSync(join(tmpdir(), "wk-codex-graph-"));
+  t.after(() => rmSync(path, { recursive: true, force: true }));
+  return path;
+}
+
+function sessionMeta(
+  id,
+  { sessionId, parentId, depth = 1, nickname = "Synthetic Agent" } = {},
+) {
+  const payload = {
+    id,
+    timestamp: "2026-01-01T10:00:00.000Z",
+    cwd: "C:\\synthetic-project",
+    model_provider: "openai",
+  };
+  if (sessionId !== undefined) payload.session_id = sessionId;
+  if (parentId !== undefined) {
+    payload.parent_thread_id = parentId;
+    payload.source = {
+      subagent: {
+        thread_spawn: {
+          parent_thread_id: parentId,
+          depth,
+          agent_nickname: nickname,
+        },
+      },
+    };
+  }
+  return { type: "session_meta", timestamp: payload.timestamp, payload };
+}
+
+function activity(
+  childId,
+  {
+    kind = "started",
+    timestamp = "2026-01-02T11:00:00.000Z",
+    agentPath = `/root/${childId}`,
+  } = {},
+) {
+  const event = {
+    type: "event_msg",
+    payload: {
+      type: "sub_agent_activity",
+      kind,
+      agent_thread_id: childId,
+      agent_path: agentPath,
+    },
+  };
+  if (timestamp !== null) event.timestamp = timestamp;
+  return event;
+}
+
+function usage({ model = "gpt-5.6-terra", input = 100, output = 20 } = {}) {
+  return {
+    type: "event_msg",
+    timestamp: "2026-01-02T11:01:00.000Z",
+    payload: {
+      type: "token_count",
+      info: {
+        model,
+        model_provider: "openai",
+        last_token_usage: {
+          input_tokens: input,
+          output_tokens: output,
+        },
+      },
+    },
+  };
+}
+
+function toolCall(name = "synthetic_tool") {
+  return {
+    type: "response_item",
+    timestamp: "2026-01-02T11:00:30.000Z",
+    payload: { type: "function_call", name, arguments: "{}" },
+  };
+}
+
+function writeRollout(base, day, id, events, { suffix = id } = {}) {
+  const dir = join(base, "sessions", "2026", "01", day);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `rollout-2026-01-${day}T10-00-00-${suffix}.jsonl`);
+  writeFileSync(
+    path,
+    `${events.map((event) => JSON.stringify(event)).join("\n")}\n`,
+    "utf8",
+  );
+  return path;
+}
+
+function growPastFourMiB(path) {
+  const filler = `${JSON.stringify({ type: "event_msg", payload: { type: "synthetic_noop" } })}\n`;
+  const repetitions = Math.ceil(
+    (4 * 1024 * 1024 + 1024) / Buffer.byteLength(filler),
+  );
+  appendFileSync(path, filler.repeat(repetitions), "utf8");
+}
+
+function diagnosticCodes(result) {
+  return result.diagnostics.map((item) => item.code);
+}
+
+test("OBS-3: D+3 discovery follows started only and does not depend on total file size", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [
+    sessionMeta(ROOT),
+    activity(CHILD_A, { timestamp: "2026-01-04T11:00:00.000Z" }),
+    toolCall("spawn_agent"), // A tool call alone is not evidence that another agent started.
+  ]);
+  const childPath = writeRollout(base, "04", CHILD_A, [
+    sessionMeta(CHILD_A, { sessionId: ROOT, parentId: ROOT }),
+    toolCall(),
+    usage({ input: 400, output: 50 }),
+  ]);
+  growPastFourMiB(rootPath);
+  growPastFourMiB(childPath);
+
+  const result = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "offline",
+  });
+
+  assert.equal(result.state, "complete");
+  assert.deepEqual(
+    result.subagents.map((agent) => agent.id),
+    [CHILD_A],
+  );
+  assert.equal(result.aggregate.count, 1);
+  assert.equal(result.aggregate.calls, 1);
+  assert.equal(result.aggregate.tokens, 450);
+  assert.equal(result.subagents[0].tools, 1);
+});
+
+test("OBS-3: depth 2, A-B-A replay and duplicate signals produce each child once", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [
+    sessionMeta(ROOT),
+    activity(CHILD_A),
+    activity(CHILD_A),
+    activity(CHILD_A, { kind: "interacted" }),
+  ]);
+  const childAPath = writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { sessionId: ROOT, parentId: ROOT, depth: 1 }),
+    activity(CHILD_B, { timestamp: "2026-01-03T11:00:00.000Z" }),
+    activity(CHILD_B, { timestamp: "2026-01-03T11:00:00.000Z" }),
+    activity(CHILD_B, {
+      kind: "interrupted",
+      timestamp: "2026-01-03T11:02:00.000Z",
+    }),
+    usage({ input: 100, output: 10 }),
+  ]);
+  writeRollout(base, "03", CHILD_B, [
+    sessionMeta(CHILD_B, { sessionId: ROOT, parentId: CHILD_A, depth: 2 }),
+    activity(CHILD_A, { timestamp: "2026-01-02T11:00:00.000Z" }),
+  ]);
+
+  const repeatedSignal = {
+    kind: "started",
+    rolloutId: CHILD_A,
+    parentRolloutId: ROOT,
+    timestamp: "2026-01-02T11:00:00.000Z",
+    transcriptPath: childAPath,
+  };
+  const result = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    signals: [repeatedSignal, { ...repeatedSignal }],
+    mode: "offline",
+  });
+
+  assert.equal(result.state, "complete");
+  assert.deepEqual(
+    result.subagents.map((agent) => agent.id),
+    [CHILD_A, CHILD_B],
+  );
+  assert.equal(result.aggregate.count, 2);
+  assert.equal(new Set(result.subagents.map((agent) => agent.id)).size, 2);
+  assert.equal(
+    result.subagents.find((agent) => agent.id === CHILD_A).status,
+    "interacted",
+  );
+  const zeroUsage = result.subagents.find((agent) => agent.id === CHILD_B);
+  assert.equal(zeroUsage.status, "interrupted");
+  assert.equal(zeroUsage.model, "unknown");
+  assert.equal(zeroUsage.calls, 0);
+  assert.equal(zeroUsage.tokens, 0);
+  assert.equal(zeroUsage.cost, 0);
+});
+
+test("OBS-11/OBS-12: a signal-only child is accepted before started reaches the root transcript", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [sessionMeta(ROOT)]);
+  const childPath = writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { sessionId: ROOT, parentId: ROOT }),
+    usage({ input: 25, output: 5 }),
+  ]);
+
+  const result = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    signals: [
+      {
+        rollout_id: CHILD_A,
+        transcript_path: childPath,
+        kind: "started",
+        timestamp: "2026-01-02T11:00:00.000Z",
+        agent_path: `/root/${CHILD_A}`,
+      },
+    ],
+    mode: "offline",
+  });
+
+  assert.equal(result.state, "complete");
+  assert.deepEqual(
+    result.subagents.map((agent) => agent.id),
+    [CHILD_A],
+  );
+  assert.equal(result.aggregate.tokens, 30);
+  assert.deepEqual(result.diagnostics, []);
+});
+
+test("OBS-11/OBS-12: signal-only parent derivation does not admit another canonical root", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [sessionMeta(ROOT)]);
+  const childPath = writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { sessionId: "foreign-root", parentId: ROOT }),
+    usage(),
+  ]);
+
+  const result = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    signals: [
+      { rollout_id: CHILD_A, transcript_path: childPath, kind: "started" },
+    ],
+    mode: "offline",
+  });
+
+  assert.equal(result.state, "degraded");
+  assert.equal(result.aggregate.count, 0);
+  assert.deepEqual(diagnosticCodes(result), ["ROOT_MISMATCH"]);
+});
+
+test("OBS-11/OBS-12: an explicit mismatched signal parent is not replaced from child metadata", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [sessionMeta(ROOT)]);
+  const otherRootPath = writeRollout(base, "01", "root-beta", [
+    sessionMeta("root-beta"),
+  ]);
+  const childPath = writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { sessionId: ROOT, parentId: ROOT }),
+    usage(),
+  ]);
+
+  const result = composeCodexSubagentGraph({
+    rootPaths: [rootPath, otherRootPath],
+    canonicalSessionId: ROOT,
+    signals: [
+      {
+        rollout_id: CHILD_A,
+        transcript_path: childPath,
+        parent_thread_id: "root-beta",
+        kind: "started",
+      },
+    ],
+    mode: "offline",
+  });
+
+  assert.equal(result.state, "degraded");
+  assert.equal(result.aggregate.count, 0);
+  assert.deepEqual(diagnosticCodes(result), ["ROOT_MISMATCH"]);
+});
+
+test("OBS-3/OBS-12: a modern child from another canonical root is excluded and degraded", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [
+    sessionMeta(ROOT),
+    activity(CHILD_A),
+  ]);
+  writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { sessionId: "foreign-root", parentId: ROOT }),
+    usage(),
+  ]);
+
+  const result = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "offline",
+  });
+
+  assert.equal(result.state, "degraded");
+  assert.equal(result.aggregate.count, 0);
+  assert.deepEqual(diagnosticCodes(result), ["ROOT_MISMATCH"]);
+});
+
+test("OBS-3/OBS-12: a complete legacy parent chain is accepted", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [
+    sessionMeta(ROOT),
+    activity(CHILD_A),
+  ]);
+  writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { parentId: ROOT }),
+    activity(CHILD_B, { timestamp: "2026-01-03T11:00:00.000Z" }),
+    usage(),
+  ]);
+  writeRollout(base, "03", CHILD_B, [
+    sessionMeta(CHILD_B, { parentId: CHILD_A, depth: 2 }),
+  ]);
+
+  const result = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "offline",
+  });
+
+  assert.equal(result.state, "complete");
+  assert.deepEqual(
+    result.subagents.map((agent) => agent.id),
+    [CHILD_A, CHILD_B],
+  );
+});
+
+test("OBS-3/OBS-12: an unproven legacy signal never becomes none", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [sessionMeta(ROOT)]);
+  const orphanPath = writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { parentId: "missing-parent" }),
+  ]);
+
+  const result = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    signals: [
+      {
+        kind: "started",
+        rolloutId: CHILD_A,
+        parentRolloutId: "missing-parent",
+        timestamp: "2026-01-02T11:00:00.000Z",
+        transcriptPath: orphanPath,
+      },
+    ],
+    mode: "offline",
+  });
+
+  assert.equal(result.state, "degraded");
+  assert.equal(result.aggregate.count, 0);
+  assert.ok(diagnosticCodes(result).includes("LEGACY_CHAIN_UNPROVEN"));
+});
+
+test("OBS-3/OBS-12: divergent files claiming one rollout id are not double-counted", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [
+    sessionMeta(ROOT),
+    activity(CHILD_A),
+  ]);
+  writeRollout(
+    base,
+    "02",
+    CHILD_A,
+    [
+      sessionMeta(CHILD_A, { sessionId: ROOT, parentId: ROOT }),
+      usage({ input: 100 }),
+    ],
+    { suffix: `copy-${CHILD_A}` },
+  );
+  writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { sessionId: ROOT, parentId: ROOT }),
+    usage({ input: 999 }),
+  ]);
+
+  const result = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "offline",
+  });
+
+  assert.equal(result.state, "degraded");
+  assert.equal(result.aggregate.count, 0);
+  assert.ok(diagnosticCodes(result).includes("DUPLICATE_ROLLOUT_ID"));
+});
+
+test("OBS-3/OBS-12: immutable second composition is a zero-parse cache hit", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [
+    sessionMeta(ROOT),
+    activity(CHILD_A),
+  ]);
+  const childPath = writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { sessionId: ROOT, parentId: ROOT }),
+    usage({ input: 100, output: 10 }),
+  ]);
+
+  const first = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "offline",
+  });
+  const second = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    cache: first.cache,
+    mode: "offline",
+  });
+
+  assert.equal(first.stats.parsedRollouts, 2);
+  assert.equal(second.stats.parsedRollouts, 0);
+  assert.equal(second.stats.cacheHits, 2);
+  assert.deepEqual(second.aggregate, first.aggregate);
+  assert.equal(second.frontier.graphCursor, first.frontier.graphCursor);
+  assert.equal(
+    second.frontier.sourceManifestHash,
+    first.frontier.sourceManifestHash,
+  );
+
+  appendFileSync(
+    childPath,
+    `${JSON.stringify(usage({ input: 300, output: 30 }))}\n`,
+    "utf8",
+  );
+  const changed = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    cache: second.cache,
+    mode: "offline",
+  });
+  assert.equal(changed.stats.parsedRollouts, 1);
+  assert.equal(changed.stats.cacheHits, 1);
+  assert.ok(changed.aggregate.tokens > second.aggregate.tokens);
+});
+
+test("OBS-12: source mutation at manifest recheck degrades instead of publishing a partial snapshot", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [
+    sessionMeta(ROOT),
+    activity(CHILD_A),
+  ]);
+  const childPath = writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { sessionId: ROOT, parentId: ROOT }),
+    usage(),
+  ]);
+  let mutated = false;
+  const now = (phase) => {
+    if (phase === "before-recheck" && !mutated) {
+      mutated = true;
+      appendFileSync(
+        childPath,
+        `${JSON.stringify({ type: "event_msg", payload: { type: "late_write" } })}\n`,
+        "utf8",
+      );
+    }
+    return 0;
+  };
+
+  const result = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "live",
+    deadlineAt: 1_000,
+    now,
+  });
+
+  assert.equal(result.state, "degraded");
+  assert.ok(diagnosticCodes(result).includes("SOURCE_CHANGED_DURING_SCAN"));
+});
+
+test("OBS-12: a corrupt cache is discarded, rebuilt and reported as degraded", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [
+    sessionMeta(ROOT),
+    activity(CHILD_A),
+  ]);
+  writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { sessionId: ROOT, parentId: ROOT }),
+    usage(),
+  ]);
+
+  const result = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    cache: { version: 999, entries: [] },
+    mode: "offline",
+  });
+
+  assert.equal(result.state, "degraded");
+  assert.equal(
+    result.aggregate.count,
+    1,
+    "transcripts rebuild the derived cache",
+  );
+  assert.ok(diagnosticCodes(result).includes("CACHE_INVALID"));
+  assert.equal(result.stats.parsedRollouts, 2);
+});
+
+test("OBS-12: hashes are independent of root input order", (t) => {
+  const base = sandbox(t);
+  const rootAPath = writeRollout(base, "01", ROOT, [
+    sessionMeta(ROOT),
+    activity(CHILD_A),
+  ]);
+  const rootBPath = writeRollout(base, "01", "root-beta", [
+    sessionMeta("root-beta"),
+  ]);
+  writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { sessionId: ROOT, parentId: ROOT }),
+    usage(),
+  ]);
+
+  const left = composeCodexSubagentGraph({
+    rootPaths: [rootAPath, rootBPath],
+    canonicalSessionId: ROOT,
+    mode: "offline",
+  });
+  const right = composeCodexSubagentGraph({
+    rootPaths: [rootBPath, rootAPath],
+    canonicalSessionId: ROOT,
+    mode: "offline",
+  });
+
+  assert.deepEqual(right.aggregate, left.aggregate);
+  assert.deepEqual(right.subagents, left.subagents);
+  assert.deepEqual(right.frontier, left.frontier);
+});
+
+test("OBS-12: structural, fallback, byte and deadline limits are explicit and discriminating", (t) => {
+  assert.deepEqual(CODEX_SUBAGENT_GRAPH_LIMITS, {
+    maxGraphNodes: 4096,
+    maxFallbackDays: 31,
+    maxFallbackCandidates: 20_000,
+    maxLiveUncachedBytes: 512 * 1024 * 1024,
+  });
+
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [
+    sessionMeta(ROOT),
+    activity(CHILD_A),
+    activity(CHILD_B, { timestamp: "2026-01-03T11:00:00.000Z" }),
+  ]);
+  writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { sessionId: ROOT, parentId: ROOT }),
+  ]);
+  writeRollout(base, "03", CHILD_B, [
+    sessionMeta(CHILD_B, { sessionId: ROOT, parentId: ROOT }),
+  ]);
+
+  const graphLimited = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "offline",
+    limits: { maxGraphNodes: 1 },
+  });
+  assert.equal(graphLimited.state, "degraded");
+  assert.ok(diagnosticCodes(graphLimited).includes("GRAPH_LIMIT_EXCEEDED"));
+
+  const byteLimited = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "live",
+    deadlineAt: 1_000,
+    now: () => 0,
+    limits: { maxLiveUncachedBytes: 1 },
+  });
+  assert.equal(byteLimited.state, "degraded");
+  assert.ok(diagnosticCodes(byteLimited).includes("LIVE_BYTE_BUDGET_EXCEEDED"));
+
+  const deadlineLimited = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "live",
+    deadlineAt: 45_000,
+    now: () => 45_000,
+  });
+  assert.equal(deadlineLimited.state, "degraded");
+  assert.deepEqual(diagnosticCodes(deadlineLimited), [
+    "LIVE_DEADLINE_EXCEEDED",
+  ]);
+
+  const offline = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "offline",
+    deadlineAt: 0,
+    now: () => Number.MAX_SAFE_INTEGER,
+    limits: { maxLiveUncachedBytes: 1 },
+  });
+  assert.equal(offline.state, "complete");
+  assert.equal(offline.aggregate.count, 2);
+});
+
+test("[req:OBS-12] live deadline is checked between transcript chunks", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [sessionMeta(ROOT)]);
+  const filler = `${JSON.stringify({ type: "event_msg", payload: { type: "synthetic_noop" } })}\n`;
+  appendFileSync(rootPath, filler.repeat(Math.ceil((128 * 1024) / Buffer.byteLength(filler))), "utf8");
+  let chunks = 0;
+
+  const result = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "live",
+    deadlineAt: 100,
+    now: (phase) => (phase === "chunk" && ++chunks === 2 ? 100 : 0),
+  });
+
+  assert.equal(chunks, 2);
+  assert.equal(result.state, "degraded");
+  assert.deepEqual(diagnosticCodes(result), ["LIVE_DEADLINE_EXCEEDED"]);
+});
+
+test("[req:OBS-12] live deadline is checked between descendant rollouts", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [
+    sessionMeta(ROOT),
+    activity(CHILD_A),
+    activity(CHILD_B, { timestamp: "2026-01-03T11:00:00.000Z" }),
+  ]);
+  writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { sessionId: ROOT, parentId: ROOT }),
+    usage(),
+  ]);
+  writeRollout(base, "03", CHILD_B, [
+    sessionMeta(CHILD_B, { sessionId: ROOT, parentId: ROOT }),
+    usage(),
+  ]);
+  let rollouts = 0;
+
+  const result = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "live",
+    deadlineAt: 100,
+    now: (phase) => (phase === "node" && ++rollouts === 2 ? 100 : 0),
+  });
+
+  assert.equal(rollouts, 2);
+  assert.equal(result.state, "degraded");
+  assert.equal(result.aggregate.count, 1, "the first rollout completed before cancellation");
+  assert.deepEqual(diagnosticCodes(result), ["LIVE_DEADLINE_EXCEEDED"]);
+});
+
+test("OBS-12: fallback day and candidate caps degrade a missing direct lookup", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [
+    sessionMeta(ROOT),
+    activity(CHILD_A, { timestamp: null }),
+  ]);
+  writeRollout(base, "01", "unrelated", [sessionMeta("unrelated")]);
+  writeRollout(base, "02", CHILD_A, [
+    sessionMeta(CHILD_A, { sessionId: ROOT, parentId: ROOT }),
+  ]);
+
+  const days = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "offline",
+    limits: { maxFallbackDays: 1 },
+  });
+  assert.equal(days.state, "degraded");
+  assert.ok(diagnosticCodes(days).includes("FALLBACK_LIMIT_EXCEEDED"));
+
+  const candidates = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "offline",
+    limits: { maxFallbackDays: 2, maxFallbackCandidates: 1 },
+  });
+  assert.equal(candidates.state, "degraded");
+  assert.ok(diagnosticCodes(candidates).includes("FALLBACK_LIMIT_EXCEEDED"));
+});
+
+test("OBS-12: a stable scan with no started agents is none, not degraded", (t) => {
+  const base = sandbox(t);
+  const rootPath = writeRollout(base, "01", ROOT, [
+    sessionMeta(ROOT),
+    toolCall("spawn_agent"),
+  ]);
+  const result = composeCodexSubagentGraph({
+    rootPaths: [rootPath],
+    canonicalSessionId: ROOT,
+    mode: "offline",
+  });
+  assert.equal(result.state, "none");
+  assert.equal(result.aggregate.count, 0);
+  assert.deepEqual(result.diagnostics, []);
+});
+
+test("OBS-12: absence of every registered root is degraded, never none", () => {
+  const result = composeCodexSubagentGraph({
+    rootPaths: [],
+    canonicalSessionId: ROOT,
+    mode: "offline",
+  });
+  assert.equal(result.state, "degraded");
+  assert.deepEqual(diagnosticCodes(result), ["PARENT_META_INVALID"]);
+});

--- a/tests/cost-rebuild-options.test.mjs
+++ b/tests/cost-rebuild-options.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseRebuildOptions } from '../src/cost.mjs';
+
+test('[req:OBS-13] targeted rebuild accepts audited positive limit overrides', () => {
+  assert.deepEqual(parseRebuildOptions([
+    'rebuild', '--session', 'synthetic-session', '--max-graph-nodes', '99',
+    '--max-fallback-days', '7', '--max-fallback-candidates', '123', '--apply',
+  ]), {
+    ok: true,
+    options: {
+      apply: true,
+      session: 'synthetic-session',
+      limit: 0,
+      limits: { maxGraphNodes: 99, maxFallbackDays: 7, maxFallbackCandidates: 123 },
+      overrides: { maxGraphNodes: 99, maxFallbackDays: 7, maxFallbackCandidates: 123 },
+    },
+  });
+});
+
+test('[req:OBS-13] graph/fallback overrides are rejected for bulk rebuild', () => {
+  const result = parseRebuildOptions(['rebuild', '--max-graph-nodes', '99']);
+  assert.equal(result.ok, false);
+  assert.equal(result.exitCode, 2);
+  assert.equal(result.code, 'TARGET_REQUIRED_FOR_LIMIT_OVERRIDE');
+});
+
+test('[req:OBS-13] invalid or non-positive overrides are usage errors', () => {
+  for (const value of ['0', '-1', '1.5', 'nope', '']) {
+    const argv = ['rebuild', '--session', 'synthetic-session', '--max-fallback-days'];
+    if (value) argv.push(value);
+    const result = parseRebuildOptions(argv);
+    assert.equal(result.ok, false, value || 'missing');
+    assert.equal(result.exitCode, 2, value || 'missing');
+    assert.equal(result.code, 'INVALID_LIMIT_OVERRIDE', value || 'missing');
+  }
+});

--- a/tests/docs-bilingual.test.mjs
+++ b/tests/docs-bilingual.test.mjs
@@ -353,3 +353,93 @@ test('DOC-7: links Markdown locais resolvem para arquivos e âncoras existentes'
     for (const guide of GUIDES) assertLocalLinksResolve(join(dir, guide));
   }
 });
+
+test('[req:OBS-13] DOC-10: rebuild documenta preview puro, apply causal, flags direcionadas e exits', () => {
+  const cases = {
+    pt: {
+      text: readFileSync(join(GUIDE_DIR.pt, 'costs-and-observability.md'), 'utf8'),
+      zeroWrite: /dry-run[\s\S]*zero escrita|dry-run[\s\S]*não (?:grava|escreve)[\s\S]*(?:nota|registry|runtime|relatório|lock)/i,
+      applySafe: /--apply[\s\S]*(?:somente|apenas)[\s\S]*`complete`[\s\S]*`none`/i,
+      preserve: /(?:`degraded`|`stale`)[\s\S]*exit `?1`?[\s\S]*(?:preserva|não altera)[\s\S]*nota/i,
+      targeted: /(?:overrides|limites)[\s\S]*(?:exclusiv|somente)[\s\S]*--session/i,
+      invalidUsage: /sem `?--session`?[\s\S]*exit `?2`?/i,
+    },
+    en: {
+      text: readFileSync(join(GUIDE_DIR.en, 'costs-and-observability.md'), 'utf8'),
+      zeroWrite: /dry-run[\s\S]*zero writes|dry-run[\s\S]*(?:does not|never) write[\s\S]*(?:note|registry|runtime|report|lock)/i,
+      applySafe: /--apply[\s\S]*(?:only)[\s\S]*`complete`[\s\S]*`none`/i,
+      preserve: /(?:`degraded`|`stale`)[\s\S]*exit `?1`?[\s\S]*(?:preserves|does not change)[\s\S]*note/i,
+      targeted: /(?:overrides|limits)[\s\S]*(?:exclusiv|only)[\s\S]*--session/i,
+      invalidUsage: /without `?--session`?[\s\S]*exit `?2`?/i,
+    },
+  };
+  const flags = ['--max-graph-nodes', '--max-fallback-days', '--max-fallback-candidates'];
+  for (const [locale, contract] of Object.entries(cases)) {
+    for (const flag of flags) assert.match(contract.text, new RegExp(flag), `${locale}: flag ausente ${flag}`);
+    for (const key of ['zeroWrite', 'applySafe', 'preserve', 'targeted', 'invalidUsage']) {
+      assert.match(contract.text, contract[key], `${locale}: contrato rebuild ausente: ${key}`);
+    }
+  }
+});
+
+test('[req:OBS-11] [req:OBS-12] [req:IMPORT-5] DOC-11: hooks e import têm contrato causal bilíngue', () => {
+  const cases = {
+    pt: {
+      text: readFileSync(join(GUIDE_DIR.pt, 'sessions-and-import.md'), 'utf8'),
+      reconcile: /import[\s\S]*reconcilia[\s\S]*observabilidade[\s\S]*(?:mesmo|ainda que)[\s\S]*(?:nenhum `wk-turn`|sem `wk-turn`)[\s\S]*(?:ausente|faltando)/i,
+      coalesce: /SubagentStop[\s\S]*250\s*ms[\s\S]*(?:coalesc|agrup)/i,
+    },
+    en: {
+      text: readFileSync(join(GUIDE_DIR.en, 'sessions-and-import.md'), 'utf8'),
+      reconcile: /import[\s\S]*reconcile[\s\S]*observability[\s\S]*(?:even|although)[\s\S]*no `wk-turn`[\s\S]*(?:missing|absent)/i,
+      coalesce: /SubagentStop[\s\S]*250\s*ms[\s\S]*(?:coalesc|batch)/i,
+    },
+  };
+  for (const [locale, contract] of Object.entries(cases)) {
+    assert.match(contract.text, /Stop[^\n]*45\s*s/i, `${locale}: deadline Stop 45 s`);
+    assert.match(contract.text, /SubagentStop[^\n]*15\s*s/i, `${locale}: deadline SubagentStop 15 s`);
+    assert.match(contract.text, contract.coalesce, `${locale}: coalescência SubagentStop`);
+    assert.match(contract.text, contract.reconcile, `${locale}: reconciliação sem turno faltante`);
+    for (const state of ['complete', 'none', 'degraded']) {
+      assert.match(contract.text, new RegExp(`\\b${state}\\b`), `${locale}: estado ${state}`);
+    }
+  }
+});
+
+test('[req:DIAG-9] DOC-12: doctor distingue frescor e recomenda dry-run antes de apply', () => {
+  const cases = {
+    pt: readFileSync(join(GUIDE_DIR.pt, 'maintenance-and-diagnostics.md'), 'utf8'),
+    en: readFileSync(join(GUIDE_DIR.en, 'maintenance-and-diagnostics.md'), 'utf8'),
+  };
+  for (const [locale, text] of Object.entries(cases)) {
+    for (const state of ['legacy', 'degraded', 'stale', 'manifest-unproven', 'none', 'complete']) {
+      assert.match(text, new RegExp(`\\b${state}\\b`), `${locale}: doctor sem estado ${state}`);
+    }
+    assert.match(text, /(?:`none`|`complete`)[\s\S]*(?:fresc|fresh)/i, `${locale}: estado saudável sem frescor`);
+    assert.match(text, /wendkeep cost rebuild --session <[^>]+> --json[\s\S]*wendkeep cost rebuild --session <[^>]+> --apply/i,
+      `${locale}: doctor não recomenda dry-run antes de apply`);
+    assert.match(text, /doctor[\s\S]*(?:read-only|somente leitura)/i, `${locale}: doctor não é read-only`);
+  }
+});
+
+test('[req:OBS-11] [req:OBS-12] DOC-13: READMEs resumem observabilidade e delegam detalhes aos guias', () => {
+  const cases = {
+    pt: {
+      text: readFileSync(join(ROOT, 'README.md'), 'utf8'),
+      summary: /Custos e observabilidade[^\n]*(?:dry-run)[^\n]*(?:tri-state|complete|degraded)/i,
+      sessions: /Sessões e importação[^\n]*(?:hooks causais|reconciliação)/i,
+      doctor: /Manutenção e diagnóstico[^\n]*(?:frescor|frontier|manifest)/i,
+    },
+    en: {
+      text: readFileSync(join(ROOT, 'README.en.md'), 'utf8'),
+      summary: /Costs and observability[^\n]*(?:dry-run)[^\n]*(?:tri-state|complete|degraded)/i,
+      sessions: /Sessions and import[^\n]*(?:causal hooks|reconciliation)/i,
+      doctor: /Maintenance and diagnostics[^\n]*(?:freshness|frontier|manifest)/i,
+    },
+  };
+  for (const [locale, contract] of Object.entries(cases)) {
+    assert.match(contract.text, contract.summary, `${locale}: resumo de rebuild/tri-state`);
+    assert.match(contract.text, contract.sessions, `${locale}: resumo de hooks/import`);
+    assert.match(contract.text, contract.doctor, `${locale}: resumo de doctor/frescor`);
+  }
+});

--- a/tests/doctor-session-observability.test.mjs
+++ b/tests/doctor-session-observability.test.mjs
@@ -1,0 +1,192 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  checkSessionObservability,
+  renderSessionObservabilityLines,
+} from '../hooks/harness-doctor.mjs';
+import { renderObservabilityCheckpointLines } from '../hooks/session-observability-state.mjs';
+import {
+  markObservabilityCheckpoint,
+  observabilityStorePath,
+  recordObservabilitySignal,
+} from '../hooks/session-observability-store.mjs';
+
+const SESSION_ID = 'synthetic-session';
+const stableHash = (value) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
+
+function fixture({ state = 'none', diagnostics = [], legacy = false, withManifest = true } = {}) {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-doctor-observe-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  mkdirSync(join(vault, 'sessions'), { recursive: true });
+  const source = join(vault, 'synthetic-rollout.jsonl');
+  const note = join(vault, 'sessions', 'synthetic.md');
+  writeFileSync(source, '{"type":"synthetic"}\n');
+  const sourceStat = statSync(source);
+  const manifest = [{
+    path: source,
+    rolloutId: 'synthetic-rollout',
+    size: sourceStat.size,
+    mtimeMs: sourceStat.mtimeMs,
+  }];
+  const hashInput = manifest.map(({ rolloutId, size, mtimeMs }) => ({ rolloutId, size, mtimeMs }));
+  const frontier = {
+    canonical_session_id: SESSION_ID,
+    activation_id: 'synthetic-activation',
+    activation_epoch: 1,
+    turn_sequence: 1,
+    signal_sequence: 0,
+    roots_stat_hash: 'synthetic-roots',
+    graph_cursor: 'synthetic-graph',
+    source_manifest_hash: stableHash(hashInput),
+  };
+  const checkpointLines = legacy
+    ? 'observability_schema: 1\nsubagents_observability_state: none'
+    : renderObservabilityCheckpointLines(frontier, { state, diagnostics });
+  writeFileSync(note, `---\ntype: session\nprovider: codex\n${checkpointLines}\n---\n\n# Synthetic\n`);
+  markObservabilityCheckpoint(vault, SESSION_ID, {
+    checkpointSequence: 0,
+    frontier,
+    ...(withManifest ? { sourceManifest: manifest } : {}),
+    diagnostics,
+  });
+  const registry = {
+    version: 2,
+    sessions: {
+      [SESSION_ID]: {
+        provider: 'codex',
+        session_file: 'sessions/synthetic.md',
+        transcript_path: source,
+      },
+    },
+  };
+  const registryFile = join(vault, '.brain', 'SESSION_REGISTRY.json');
+  writeFileSync(registryFile, `${JSON.stringify(registry, null, 2)}\n`);
+  return {
+    vault,
+    note,
+    source,
+    frontier,
+    registry,
+    registryFile,
+    store: observabilityStorePath(vault, SESSION_ID),
+  };
+}
+
+function check(fx, deps = {}) {
+  return checkSessionObservability(fx.vault, deps);
+}
+
+function snapshot(paths) {
+  return paths.map((path) => ({
+    path,
+    bytes: readFileSync(path),
+    mtimeMs: statSync(path).mtimeMs,
+  }));
+}
+
+function assertSnapshotUnchanged(before) {
+  for (const item of before) {
+    assert.deepEqual(readFileSync(item.path), item.bytes, item.path);
+    assert.equal(statSync(item.path).mtimeMs, item.mtimeMs, item.path);
+  }
+}
+
+test('[req:DIAG-9] fresh none and complete are healthy and byte-for-byte read-only', () => {
+  const fixtures = [fixture(), fixture({ state: 'complete' })];
+  try {
+    for (const fx of fixtures) {
+      const before = snapshot([fx.note, fx.source, fx.store, fx.registryFile]);
+      const result = check(fx);
+      assert.equal(result.ok, true, fx.note);
+      assert.equal(result.healthy, 1, fx.note);
+      assert.deepEqual(result.issues, [], fx.note);
+      assertSnapshotUnchanged(before);
+    }
+  } finally {
+    for (const fx of fixtures) rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:DIAG-9] every repairable state is distinguished without changing any source', () => {
+  const signal = fixture();
+  recordObservabilitySignal(signal.vault, SESSION_ID, {
+    rollout_id: 'wk-fixture-signal-child',
+    kind: 'started',
+  });
+  const roots = fixture();
+  markObservabilityCheckpoint(roots.vault, SESSION_ID, {
+    checkpointSequence: 0,
+    frontier: { ...roots.frontier, roots_stat_hash: 'synthetic-roots-new' },
+  });
+  const fixtures = [
+    [fixture({ legacy: true }), 'legacy'],
+    [fixture({ state: 'degraded', diagnostics: [{ code: 'CHILD_MISSING', count: 1 }] }), 'degraded'],
+    [fixture({ withManifest: false }), 'manifest-unproven'],
+    [fixture(), 'stale'],
+    [signal, 'stale'],
+    [roots, 'stale'],
+  ];
+  try {
+    writeFileSync(fixtures[3][0].source, '{"type":"synthetic-mutated"}\n');
+    for (const [fx, expected] of fixtures) {
+      const before = snapshot([fx.note, fx.source, fx.store, fx.registryFile]);
+      const result = check(fx);
+      assert.equal(result.ok, false, expected);
+      assert.equal(result.issues[0].status, expected);
+      assert.match(result.issues[0].command, /cost rebuild --session synthetic-session --json$/);
+      assertSnapshotUnchanged(before);
+    }
+    assert.deepEqual(fixtures[1][0] && check(fixtures[1][0]).issues[0].diagnostics, [
+      { code: 'CHILD_MISSING', count: 1 },
+    ]);
+  } finally {
+    for (const [fx] of fixtures) rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:DIAG-9] doctor reads the note but only stats transcript manifest entries', () => {
+  const fx = fixture({ state: 'complete' });
+  const fullReads = [];
+  const stats = [];
+  try {
+    const result = check(fx, {
+      readNote(path) {
+        fullReads.push(path);
+        if (path !== fx.note) throw new Error('transcript content must not be read');
+        return readFileSync(path, 'utf8');
+      },
+      statSource(path) {
+        stats.push(path);
+        return statSync(path);
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.deepEqual(fullReads, [fx.note]);
+    assert.deepEqual(stats, [fx.source]);
+  } finally {
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:DIAG-9] renderer recommends dry-run before apply', () => {
+  const fx = fixture({ legacy: true });
+  try {
+    const lines = renderSessionObservabilityLines(check(fx));
+    const text = lines.join('\n');
+    assert.ok(text.indexOf('--json') < text.indexOf('--apply'));
+    assert.match(text, /^\[observabilidade\]/);
+  } finally {
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});

--- a/tests/import-observability-reconciliation.test.mjs
+++ b/tests/import-observability-reconciliation.test.mjs
@@ -1,0 +1,319 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runImport } from '../hooks/import-sessions.mjs';
+import { parseObservabilityCheckpoint } from '../hooks/session-observability-state.mjs';
+import {
+  mutateObservabilityStore,
+  readObservabilityStore,
+} from '../hooks/session-observability-store.mjs';
+
+const SESSION_ID = 'synthetic-session';
+const TRANSCRIPT = [
+  { type: 'user', uuid: 'turn-1', timestamp: '2026-01-01T09:00:00.000Z', sessionId: SESSION_ID, message: { role: 'user', content: 'synthetic request' } },
+  { type: 'assistant', uuid: 'answer-1', timestamp: '2026-01-01T09:00:01.000Z', sessionId: SESSION_ID, message: { role: 'assistant', model: 'claude-opus-4-8', usage: { input_tokens: 10, output_tokens: 20 }, content: [{ type: 'text', text: 'synthetic answer' }] } },
+];
+
+function seed() {
+  const source = mkdtempSync(join(tmpdir(), 'wk-import-observe-src-'));
+  const vault = mkdtempSync(join(tmpdir(), 'wk-import-observe-vault-'));
+  writeFileSync(join(source, `${SESSION_ID}.jsonl`), `${TRANSCRIPT.map(JSON.stringify).join('\n')}\n`);
+  const first = runImport(vault, { source: 'claude', from: source });
+  return { source, vault, note: join(vault, first.sessions[0].relPath) };
+}
+
+function codexSeed() {
+  const source = mkdtempSync(join(tmpdir(), 'wk-import-observe-codex-'));
+  const vault = mkdtempSync(join(tmpdir(), 'wk-import-observe-vault-'));
+  const day = join(source, '2026', '01', '01');
+  mkdirSync(day, { recursive: true });
+  const transcript = join(day, 'synthetic-rollout.jsonl');
+  const events = [
+    { type: 'session_meta', timestamp: '2026-01-01T09:00:00.000Z', payload: { id: SESSION_ID, cwd: 'synthetic-project', model: 'gpt-5.6-sol', model_provider: 'openai' } },
+    { type: 'event_msg', timestamp: '2026-01-01T09:00:01.000Z', payload: { type: 'task_started', turn_id: 'turn-1' } },
+    { type: 'event_msg', timestamp: '2026-01-01T09:00:02.000Z', payload: { type: 'user_message', turn_id: 'turn-1', message: 'synthetic request' } },
+    { type: 'event_msg', timestamp: '2026-01-01T09:00:03.000Z', payload: { type: 'agent_message', turn_id: 'turn-1', message: 'synthetic answer' } },
+    { type: 'event_msg', timestamp: '2026-01-01T09:00:04.000Z', payload: { type: 'token_count', turn_id: 'turn-1', info: { model: 'gpt-5.6-sol', last_token_usage: { input_tokens: 10, output_tokens: 5 } } } },
+  ];
+  writeFileSync(transcript, `${events.map(JSON.stringify).join('\n')}\n`);
+  const first = runImport(vault, {
+    source: 'codex', projectPath: 'synthetic-project', codexFrom: source,
+  });
+  return { source, vault, transcript, note: join(vault, first.sessions[0].relPath) };
+}
+
+test('[req:IMPORT-5] a complete note still reconciles observability without duplicating turns', () => {
+  const fx = seed();
+  try {
+    const before = readFileSync(fx.note, 'utf8');
+    const calls = [];
+    const report = runImport(fx.vault, {
+      source: 'claude',
+      from: fx.source,
+      reconcileObservability(input) {
+        calls.push(input);
+        return { status: 'published', diagnostics: [] };
+      },
+    });
+
+    assert.equal(calls.length, 1, 'the old no-missing-turn early return must not bypass observability');
+    assert.equal(calls[0].sessionId, SESSION_ID);
+    assert.equal(calls[0].sessionPath, fx.note);
+    assert.equal((readFileSync(fx.note, 'utf8').match(/<!-- wk-turn:/g) || []).length, 1);
+    assert.equal((before.match(/<!-- wk-turn:/g) || []).length, 1);
+    assert.equal(report.observabilityReconciled, 1);
+    assert.equal(report.sessions[0].turns, 0);
+    assert.deepEqual(report.sessions[0].observability, { status: 'published', diagnostics: [] });
+  } finally {
+    rmSync(fx.source, { recursive: true, force: true });
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:IMPORT-5] reconciliation failure is reported without leaking private error text', () => {
+  const fx = seed();
+  const privateMarker = 'PRIVATE_TRANSCRIPT_MARKER';
+  try {
+    let report;
+    assert.doesNotThrow(() => {
+      report = runImport(fx.vault, {
+        source: 'claude',
+        from: fx.source,
+        reconcileObservability() {
+          throw new Error(privateMarker);
+        },
+      });
+    });
+
+    assert.equal(report.observabilityDegraded, 1);
+    assert.deepEqual(report.sessions[0].observability, {
+      status: 'degraded',
+      diagnostics: [{ code: 'CACHE_INVALID', count: 1 }],
+    });
+    assert.ok(!JSON.stringify(report).includes(privateMarker));
+  } finally {
+    rmSync(fx.source, { recursive: true, force: true });
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:IMPORT-5] degraded reconciliation strips private diagnostic fields', () => {
+  const fx = seed();
+  const privateMarker = 'PRIVATE_TRANSCRIPT_MARKER';
+  try {
+    const report = runImport(fx.vault, {
+      source: 'claude',
+      from: fx.source,
+      reconcileObservability() {
+        return {
+          status: 'degraded',
+          diagnostics: [{
+            code: 'CHILD_MISSING',
+            count: 2,
+            transcriptExcerpt: privateMarker,
+          }],
+        };
+      },
+    });
+
+    assert.equal(report.observabilityDegraded, 1);
+    assert.deepEqual(report.sessions[0].observability, {
+      status: 'degraded',
+      diagnostics: [{ code: 'CHILD_MISSING', count: 2 }],
+    });
+    assert.ok(!JSON.stringify(report).includes(privateMarker));
+  } finally {
+    rmSync(fx.source, { recursive: true, force: true });
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:IMPORT-5] a proven-fresh reconciliation remains byte-identical', () => {
+  const fx = seed();
+  try {
+    const before = readFileSync(fx.note);
+    const report = runImport(fx.vault, {
+      source: 'claude',
+      from: fx.source,
+      reconcileObservability() {
+        return { status: 'fresh', diagnostics: [] };
+      },
+    });
+
+    assert.deepEqual(readFileSync(fx.note), before);
+    assert.equal(report.observabilityFresh, 1);
+    assert.equal(report.observabilityReconciled, 0);
+  } finally {
+    rmSync(fx.source, { recursive: true, force: true });
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:IMPORT-5] real Codex import skips a fresh frontier and reconciles advanced source stat', () => {
+  const fx = codexSeed();
+  try {
+    const before = readFileSync(fx.note);
+    const beforeMtime = statSync(fx.note).mtimeMs;
+    const initialCheckpoint = parseObservabilityCheckpoint(before.toString('utf8'));
+    const initialRuntime = readObservabilityStore(fx.vault, SESSION_ID);
+    assert.deepEqual(initialRuntime.checkpoint_frontier, initialCheckpoint.frontier);
+    assert.equal(initialRuntime.observability_checkpoint_sequence, initialRuntime.observability_signal_sequence);
+    assert.equal(initialRuntime.observability_dirty, false);
+    const currentManifest = initialRuntime.source_manifest.map((source) => {
+      const stat = statSync(source.path);
+      assert.equal(stat.size, source.size);
+      assert.equal(stat.mtimeMs, source.mtimeMs);
+      return { rolloutId: source.rolloutId, size: stat.size, mtimeMs: stat.mtimeMs };
+    }).sort((left, right) =>
+      `${left.rolloutId}\u0000${left.size}\u0000${left.mtimeMs}`.localeCompare(
+        `${right.rolloutId}\u0000${right.size}\u0000${right.mtimeMs}`,
+      ));
+    assert.equal(
+      createHash('sha256').update(JSON.stringify(currentManifest)).digest('hex'),
+      initialCheckpoint.frontier.source_manifest_hash,
+    );
+    const fresh = runImport(fx.vault, {
+      source: 'codex', projectPath: 'synthetic-project', codexFrom: fx.source,
+    });
+    assert.deepEqual({
+      fresh: fresh.observabilityFresh,
+      reconciled: fresh.observabilityReconciled,
+      degraded: fresh.observabilityDegraded,
+      sessions: fresh.sessions,
+    }, {
+      fresh: 1,
+      reconciled: 0,
+      degraded: 0,
+      sessions: [{
+        sessionId: SESSION_ID,
+        turns: 0,
+        observability: { status: 'fresh', diagnostics: [] },
+      }],
+    });
+    assert.deepEqual(readFileSync(fx.note), before);
+    assert.equal(statSync(fx.note).mtimeMs, beforeMtime);
+
+    writeFileSync(fx.transcript, `${readFileSync(fx.transcript, 'utf8')}${JSON.stringify({
+      type: 'event_msg',
+      timestamp: '2026-01-01T09:00:05.000Z',
+      payload: { type: 'token_count', turn_id: 'turn-1', info: { model: 'gpt-5.6-sol', last_token_usage: { input_tokens: 20, output_tokens: 5 } } },
+    })}\n`);
+    const stale = runImport(fx.vault, {
+      source: 'codex', projectPath: 'synthetic-project', codexFrom: fx.source,
+    });
+    assert.equal(stale.observabilityReconciled, 1);
+    assert.equal((readFileSync(fx.note, 'utf8').match(/<!-- wk-turn:/g) || []).length, 1);
+  } finally {
+    rmSync(fx.source, { recursive: true, force: true });
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:IMPORT-5] advanced signal reconciles with unchanged source stat and no new turn', () => {
+  const fx = codexSeed();
+  try {
+    const sourceBefore = statSync(fx.transcript);
+    mutateObservabilityStore(fx.vault, SESSION_ID, (state) => ({
+      ...state,
+      observability_signal_sequence: state.observability_signal_sequence + 1,
+      observability_dirty: true,
+    }));
+
+    const report = runImport(fx.vault, {
+      source: 'codex', projectPath: 'synthetic-project', codexFrom: fx.source,
+    });
+
+    assert.equal(report.observabilityReconciled, 1);
+    assert.equal(report.observabilityFresh, 0);
+    assert.equal((readFileSync(fx.note, 'utf8').match(/<!-- wk-turn:/g) || []).length, 1);
+    const sourceAfter = statSync(fx.transcript);
+    assert.equal(sourceAfter.size, sourceBefore.size);
+    assert.equal(sourceAfter.mtimeMs, sourceBefore.mtimeMs);
+  } finally {
+    rmSync(fx.source, { recursive: true, force: true });
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:IMPORT-5] legacy observability schema is reconciled without adding a turn', () => {
+  const fx = codexSeed();
+  try {
+    writeFileSync(fx.note, readFileSync(fx.note, 'utf8').replace(
+      /^observability_schema:\s*2$/m,
+      'observability_schema: 1',
+    ));
+    const legacyBytes = readFileSync(fx.note);
+    const preview = runImport(fx.vault, {
+      source: 'codex', projectPath: 'synthetic-project', codexFrom: fx.source, dryRun: true,
+    });
+    assert.equal(preview.observabilityReconciled, 1);
+    assert.deepEqual(readFileSync(fx.note), legacyBytes, 'dry-run only plans reconciliation');
+    const report = runImport(fx.vault, {
+      source: 'codex', projectPath: 'synthetic-project', codexFrom: fx.source,
+    });
+    assert.equal(report.observabilityReconciled, 1);
+    const noteContent = readFileSync(fx.note, 'utf8');
+    assert.match(noteContent, /^observability_schema:\s*2$/m);
+    assert.equal((noteContent.match(/<!-- wk-turn:/g) || []).length, 1);
+  } finally {
+    rmSync(fx.source, { recursive: true, force: true });
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:IMPORT-5] degraded state and missing frontier force reconciliation without adding turns', () => {
+  const cases = [
+    {
+      label: 'degraded',
+      mutate(content) {
+        return content.replace(
+          /^subagents_observability_state:\s*.*$/m,
+          "subagents_observability_state: 'degraded'",
+        );
+      },
+    },
+    {
+      label: 'frontier-missing',
+      mutate(content) {
+        return content.replace(
+          /^observability_(?:session_id|activation_id|activation_epoch|turn_sequence|signal_sequence|roots_stat_hash|graph_cursor|source_manifest_hash):.*\r?\n/gm,
+          '',
+        );
+      },
+    },
+  ];
+  const fixtures = cases.map((entry) => ({ ...entry, fx: codexSeed() }));
+  try {
+    for (const { label, mutate, fx } of fixtures) {
+      writeFileSync(fx.note, mutate(readFileSync(fx.note, 'utf8')));
+      const beforeTurns = (readFileSync(fx.note, 'utf8').match(/<!-- wk-turn:/g) || []).length;
+
+      const report = runImport(fx.vault, {
+        source: 'codex', projectPath: 'synthetic-project', codexFrom: fx.source,
+      });
+
+      assert.equal(
+        report.observabilityReconciled,
+        1,
+        `${label}: ${JSON.stringify(report.sessions[0]?.observability)}`,
+      );
+      assert.equal(report.observabilityFresh, 0, label);
+      assert.equal(
+        (readFileSync(fx.note, 'utf8').match(/<!-- wk-turn:/g) || []).length,
+        beforeTurns,
+        label,
+      );
+      const checkpoint = parseObservabilityCheckpoint(readFileSync(fx.note, 'utf8'));
+      assert.ok(checkpoint, label);
+      assert.notEqual(checkpoint.state, 'degraded', label);
+    }
+  } finally {
+    for (const { fx } of fixtures) {
+      rmSync(fx.source, { recursive: true, force: true });
+      rmSync(fx.vault, { recursive: true, force: true });
+    }
+  }
+});

--- a/tests/import-subagent.test.mjs
+++ b/tests/import-subagent.test.mjs
@@ -67,7 +67,7 @@ test('discoverCodexTranscripts expõe o marcador de subagent do session_meta', (
   assert.equal(child.subagent?.nickname, 'Lovelace');
 });
 
-test('runImport: subagent nunca vira nota; só o pai produz sessão', () => {
+test('[req:IMPORT-5] runImport: subagent nunca vira nota; só o pai produz sessão', () => {
   const { src } = seedRollouts();
   const vault = mkdtempSync(join(tmpdir(), 'wk-sub-vault-'));
   mkdirSync(join(vault, '.brain'), { recursive: true });

--- a/tests/privacy-hygiene.test.mjs
+++ b/tests/privacy-hygiene.test.mjs
@@ -1,153 +1,16 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  inspectDiagnosticRecords,
+  inspectFixtureSource,
+  inspectStagedDiff,
+  repositoryPrivacySources,
+} from '../scripts/privacy-hygiene.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const FIXTURE_SOURCES = new Set([
-  'tests/memory-handoff.test.mjs',
-  'tests/memory-hybrid-e2e.test.mjs',
-  'tests/session-stop-memory.test.mjs',
-  'tests/fixtures/synthetic-memory-lifecycle.mjs',
-]);
-
-const SENSITIVE_FIELDS = new Set([
-  'NOTE',
-  'SID',
-  'SUMMARY',
-  'canonicalConversationId',
-  'context',
-  'contexto',
-  'message',
-  'noteRel',
-  'objective',
-  'pedido',
-  'projectId',
-  'project_id',
-  'sessionId',
-  'sessionRel',
-  'session_id',
-  'summary',
-  'title',
-  'transcriptId',
-  'transcript_id',
-  'vault',
-  'vaultName',
-]);
-
-const SAFE_RELATIVE_SEGMENTS = new Set([
-  '.brain',
-  '03-Sessões',
-  '03-Sessions',
-]);
-
-function decodeLiteral(raw, quote) {
-  if (quote === '"') {
-    try { return JSON.parse(`${quote}${raw}${quote}`); } catch { return raw; }
-  }
-  return raw
-    .replaceAll('\\\\', '\\')
-    .replaceAll(`\\${quote}`, quote)
-    .replaceAll('\\n', '\n')
-    .replaceAll('\\r', '\r')
-    .replaceAll('\\t', '\t');
-}
-
-function literalsOnLine(line) {
-  const literals = [];
-  const pattern = /(["'`])((?:\\.|(?!\1).)*)\1/g;
-  for (const match of line.matchAll(pattern)) {
-    literals.push({
-      column: match.index ?? 0,
-      raw: match[0],
-      value: decodeLiteral(match[2], match[1]),
-    });
-  }
-  return literals;
-}
-
-function allowedFixtureValue(value) {
-  if (!value) return true;
-  if (/^\[wk-fixture\]/.test(value)) return true;
-  if (/^\.?wk-fixture-[a-z0-9-]+(?:\.[a-z0-9]+)?$/i.test(value)) return true;
-
-  const segments = value.split(/[\\/]/).filter(Boolean);
-  return segments.length > 0 && segments.every((segment) => (
-    SAFE_RELATIVE_SEGMENTS.has(segment)
-    || /^\.?wk-fixture-[a-z0-9-]+(?:\.[a-z0-9]+)?$/i.test(segment)
-  ));
-}
-
-function sensitiveFieldBefore(line, column) {
-  const prefix = line.slice(0, column);
-  const match = prefix.match(/(?:^|[,{;]\s*|\bconst\s+)["']?([A-Za-z_][A-Za-z0-9_]*)["']?\s*[:=]\s*$/);
-  return match && SENSITIVE_FIELDS.has(match[1]) ? match[1] : '';
-}
-
-function structuralCategories(value) {
-  const categories = [];
-  if (/^[A-Za-z]:[\\/]/.test(value)
-    || /^\/(?:Users|home)\//.test(value)
-    || /^\\\\[^\\/]+[\\/][^\\/]+/.test(value)) {
-    categories.push('absolute-local-path');
-  }
-  if (/\b[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\b/i.test(value)
-    || /\b[0-9a-f]{24,}\b/i.test(value)
-    || /\b[A-Za-z0-9_-]{32,}\b/.test(value)) {
-    if (!allowedFixtureValue(value)) categories.push('opaque-identifier');
-  }
-  return categories;
-}
-
-function categoriesForLiteral(value, field) {
-  const categories = structuralCategories(value);
-  if (field && !allowedFixtureValue(value)) categories.push('unapproved-fixture-value');
-  return categories;
-}
-
-function unescapedBackticks(line) {
-  let found = 0;
-  for (let index = 0; index < line.length; index += 1) {
-    if (line[index] !== '`') continue;
-    let slashes = 0;
-    for (let cursor = index - 1; cursor >= 0 && line[cursor] === '\\'; cursor -= 1) slashes += 1;
-    if (slashes % 2 === 0) found += 1;
-  }
-  return found;
-}
-
-export function inspectFixtureSource(relativePath, source) {
-  const findings = new Set();
-  const lines = String(source).replaceAll('\r\n', '\n').split('\n');
-  let insideTemplate = false;
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index];
-    if (insideTemplate) {
-      for (const category of structuralCategories(line)) {
-        findings.add(`${relativePath}:${index + 1}:${category}`);
-      }
-    }
-    for (const literal of literalsOnLine(line)) {
-      const field = sensitiveFieldBefore(line, literal.column);
-      for (const category of categoriesForLiteral(literal.value, field)) {
-        findings.add(`${relativePath}:${index + 1}:${category}`);
-      }
-    }
-    if (unescapedBackticks(line) % 2 === 1) insideTemplate = !insideTemplate;
-  }
-  return [...findings].sort();
-}
-
-function repositoryFixtureSources() {
-  const listed = spawnSync('git', ['ls-files', '--cached', '--others', '--exclude-standard', '-z'], {
-    cwd: ROOT,
-    encoding: 'utf8',
-  });
-  assert.equal(listed.status, 0, listed.stderr);
-  return listed.stdout.split('\0').filter((relativePath) => FIXTURE_SOURCES.has(relativePath));
-}
 
 function runtimeSamples() {
   const slash = '\\';
@@ -201,8 +64,116 @@ test('[req:MEM-STOP-7] privacy diagnostics never disclose rejected values', () =
 });
 
 test('[req:MEM-STOP-7] versioned memory lifecycle fixtures contain only synthetic data', () => {
-  const findings = repositoryFixtureSources().flatMap((relativePath) => (
+  const findings = repositoryPrivacySources(ROOT).flatMap((relativePath) => (
     inspectFixtureSource(relativePath, readFileSync(join(ROOT, relativePath), 'utf8'))
   ));
   if (findings.length) throw new Error(findings.join('\n'));
+});
+
+test('[req:OBS-14] generated verification hashes are allowed only in their structural fields', () => {
+  const contentHash = 'a'.repeat(64);
+  const generated = JSON.stringify({
+    tasksHash: 'b'.repeat(12),
+    effectiveSpecHash: contentHash,
+  }, null, 2);
+
+  assert.deepEqual(inspectFixtureSource(
+    '.WendKeep-vault/08-Mudanças/codex-subagent-observability/verificacao.json',
+    generated,
+  ), []);
+  assert.deepEqual(inspectFixtureSource(
+    '.WendKeep-vault/08-Mudanças/codex-subagent-observability/evidencia.json',
+    JSON.stringify({ transcriptId: contentHash }, null, 2),
+  ), [
+    '.WendKeep-vault/08-Mudanças/codex-subagent-observability/evidencia.json:2:opaque-identifier',
+    '.WendKeep-vault/08-Mudanças/codex-subagent-observability/evidencia.json:2:unapproved-fixture-value',
+  ]);
+});
+
+test('[req:OBS-14] generated verdict evidence allows only relative source locations', () => {
+  const verdictPath = '.WendKeep-vault/08-Mudanças/codex-subagent-observability/verdict.json';
+  const evidence = [
+    'tests/session-observability-reconciliation.test.mjs:267',
+    'hooks/session-observability.mjs:640',
+  ].join('; ');
+
+  assert.deepEqual(inspectFixtureSource(
+    verdictPath,
+    JSON.stringify({ evidence }, null, 2),
+  ), []);
+  assert.deepEqual(inspectFixtureSource(
+    verdictPath,
+    JSON.stringify({ evidence: `tests/${'a'.repeat(40)}` }, null, 2),
+  ), [`${verdictPath}:2:opaque-identifier`]);
+});
+
+test('[req:MEM-STOP-7] lifecycle paths allow only the declared synthetic interpolation', () => {
+  const interpolation = ['${', 'SYNTHETIC_MEMORY.changeSlug', '}'].join('');
+  const privateInterpolation = ['${', 'runtimeProject.changeSlug', '}'].join('');
+  const syntheticSource = [
+    `const evidence = { path: \`04-Decisões/ADR-0001-${interpolation}.md\` };`,
+    `const verdict = { path: \`08-Mudanças/_arquivo/${interpolation}/verdict.json\` };`,
+  ].join('\n');
+
+  assert.deepEqual(inspectFixtureSource('tests/memory-handoff.test.mjs', syntheticSource), []);
+  assert.deepEqual(inspectFixtureSource(
+    'tests/memory-handoff.test.mjs',
+    `const evidence = { path: \`04-Decisões/ADR-0001-${privateInterpolation}.md\` };`,
+  ), ['tests/memory-handoff.test.mjs:1:unapproved-fixture-value']);
+});
+
+test('[req:OBS-14] diagnostics reject unknown codes, extra fields and sensitive values', () => {
+  const sample = runtimeSamples();
+  const pathField = ['pa', 'th'].join('');
+  const promptField = ['pro', 'mpt'].join('');
+  const sessionField = ['session', 'Id'].join('');
+  const records = [
+    { code: ['NOT', 'ALLOWLISTED'].join('_'), count: 1 },
+    { code: 'CHILD_MISSING', count: 1, [pathField]: sample.homePath },
+    { code: 'CHILD_MISSING', count: 1, [promptField]: ['raw', ' prompt'].join('') },
+    { code: 'CHILD_MISSING', count: 1, [sessionField]: sample.opaqueId },
+  ];
+
+  assert.deepEqual(inspectDiagnosticRecords('virtual.json', records), [
+    'virtual.json:1:diagnostic-code-not-allowlisted',
+    'virtual.json:2:absolute-local-path',
+    'virtual.json:2:diagnostic-unapproved-field',
+    'virtual.json:3:diagnostic-prompt-or-message',
+    'virtual.json:3:diagnostic-unapproved-field',
+    'virtual.json:4:diagnostic-unapproved-field',
+    'virtual.json:4:opaque-identifier',
+  ]);
+});
+
+test('[req:OBS-14] staged diff scans only added content and reports destination line numbers', () => {
+  const sample = runtimeSamples();
+  const diff = [
+    'diff --git a/tests/fixtures/wk-fixture-observability.mjs b/tests/fixtures/wk-fixture-observability.mjs',
+    '--- a/tests/fixtures/wk-fixture-observability.mjs',
+    '+++ b/tests/fixtures/wk-fixture-observability.mjs',
+    '@@ -1,2 +1,2 @@',
+    `-const projectId = ${JSON.stringify(sample.consumerLabel)};`,
+    "+const projectId = 'wk-fixture-example-project';",
+    `+const transcriptId = ${JSON.stringify(sample.opaqueId)};`,
+  ].join('\n');
+
+  assert.deepEqual(inspectStagedDiff(diff), [
+    'tests/fixtures/wk-fixture-observability.mjs:2:opaque-identifier',
+    'tests/fixtures/wk-fixture-observability.mjs:2:unapproved-fixture-value',
+  ]);
+});
+
+test('[req:OBS-14] every privacy diagnostic is redacted to file line and category', () => {
+  const sample = runtimeSamples();
+  const pathField = ['pa', 'th'].join('');
+  const report = [
+    ...inspectFixtureSource('virtual.test.mjs', `const message = ${JSON.stringify(sample.consumerLabel)};`),
+    ...inspectDiagnosticRecords('virtual.json', [
+      { code: 'CHILD_MISSING', count: 1, [pathField]: sample.homePath },
+    ]),
+  ].join('\n');
+
+  assert.match(report, /^(?:[^:\r\n]+(?:[/\\][^:\r\n]+)*:\d+:[a-z-]+)(?:\n[^:\r\n]+(?:[/\\][^:\r\n]+)*:\d+:[a-z-]+)*$/);
+  assert.equal(report.includes(sample.consumerLabel), false);
+  assert.equal(report.includes(sample.homePath), false);
 });

--- a/tests/rebuild-costs.test.mjs
+++ b/tests/rebuild-costs.test.mjs
@@ -1,0 +1,326 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  rebuildSessionCosts,
+  writeRebuildReportIfChanged,
+} from '../src/rebuild-costs.mjs';
+import { readSessionRegistry, upsertSessionRegistry } from '../hooks/obsidian-common.mjs';
+import { readObservabilityStore } from '../hooks/session-observability-store.mjs';
+
+function fixture(ids = ['synthetic-one']) {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-rebuild-observe-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  mkdirSync(join(vault, 'sessions'), { recursive: true });
+  const sessions = {};
+  for (const id of ids) {
+    const sessionFile = `sessions/${id}.md`;
+    const transcriptPath = join(vault, `${id}.jsonl`);
+    writeFileSync(join(vault, sessionFile), `---\ntype: session\n---\n\n# ${id}\n`);
+    writeFileSync(transcriptPath, '{"type":"synthetic"}\n');
+    sessions[id] = { session_file: sessionFile, transcript_path: transcriptPath };
+  }
+  return { vault, sessions };
+}
+
+function treeSnapshot(root, relative = '') {
+  const directory = join(root, relative);
+  return readdirSync(directory, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .flatMap((entry) => {
+      const child = join(relative, entry.name);
+      if (entry.isDirectory()) return [{ path: `${child}/`, type: 'directory' }, ...treeSnapshot(root, child)];
+      const path = join(root, child);
+      return [{
+        path: child,
+        type: 'file',
+        bytes: readFileSync(path).toString('base64'),
+        mtimeMs: statSync(path).mtimeMs,
+      }];
+    });
+}
+
+function codexRollout({ id, sessionId = id, model, input, output, parentId = '' }) {
+  const meta = {
+    id,
+    session_id: sessionId,
+    model,
+    model_provider: 'openai',
+    ...(parentId ? {
+      parent_thread_id: parentId,
+      source: { subagent: { thread_spawn: { parent_thread_id: parentId, depth: 1 } } },
+    } : {}),
+  };
+  return [
+    { type: 'session_meta', payload: meta },
+    { type: 'turn_context', payload: { model, model_provider: 'openai', effort: 'high' } },
+    { type: 'event_msg', payload: { type: 'user_message', message: 'synthetic request' } },
+    { type: 'event_msg', payload: { type: 'token_count', info: { model, model_provider: 'openai', last_token_usage: { input_tokens: input, output_tokens: output, total_tokens: input + output } } } },
+  ];
+}
+
+function realLifecycleFixture({ withChild = false } = {}) {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-rebuild-real-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  const note = join(vault, 'session.md');
+  writeFileSync(note, '---\ntype: session\nprovider: codex\n---\n\n# Synthetic\n\n## Pendências\n\nNenhuma.\n');
+  const rolloutDir = join(vault, 'rollouts', '2026', '01', '01');
+  mkdirSync(rolloutDir, { recursive: true });
+  const rootId = 'root-synthetic';
+  const root = join(rolloutDir, `rollout-2026-01-01T10-00-00-${rootId}.jsonl`);
+  const rootEvents = codexRollout({ id: rootId, model: 'model-main', input: 10, output: 5 });
+  const transcriptPaths = [root];
+  if (withChild) {
+    const childId = 'child-synthetic';
+    rootEvents.push({
+      type: 'event_msg',
+      timestamp: '2026-01-01T10:01:00.000Z',
+      payload: { type: 'sub_agent_activity', kind: 'started', agent_thread_id: childId },
+    });
+    const child = join(rolloutDir, `rollout-2026-01-01T10-02-00-${childId}.jsonl`);
+    writeFileSync(child, `${codexRollout({
+      id: childId,
+      sessionId: rootId,
+      parentId: rootId,
+      model: 'model-child',
+      input: 7,
+      output: 3,
+    }).map(JSON.stringify).join('\n')}\n`);
+    transcriptPaths.push(child);
+  }
+  writeFileSync(root, `${rootEvents.map(JSON.stringify).join('\n')}\n`);
+  upsertSessionRegistry(vault, rootId, {
+    session_file: 'session.md',
+    transcript_path: root,
+    transcript_paths: transcriptPaths,
+    provider: 'codex',
+    active_activation_id: 'activation-synthetic',
+    activation_epoch: 1,
+    last_turn_sequence: 1,
+    observability_signal_sequence: 0,
+  });
+  return { vault, note, rootId };
+}
+
+test('[req:OBS-13] dry-run composes without acquiring a publisher or writing any file', () => {
+  const fx = fixture();
+  try {
+    const note = join(fx.vault, fx.sessions['synthetic-one'].session_file);
+    const before = readFileSync(note);
+    const beforeMtime = statSync(note).mtimeMs;
+    let publishes = 0;
+    const report = rebuildSessionCosts(fx.vault, { apply: false }, {
+      readRegistry: () => ({ sessions: fx.sessions }),
+      compose: () => ({ state: 'complete', content: 'synthetic changed content', diagnostics: [] }),
+      publish: () => { publishes += 1; throw new Error('dry-run invoked publisher'); },
+      writeReport: () => { throw new Error('dry-run wrote report'); },
+      now: () => '2026-01-01T00:00:00.000Z',
+    });
+
+    assert.equal(report.scanned, 1);
+    assert.equal(report.changed, 1);
+    assert.equal(report.ok, true);
+    assert.equal(publishes, 0);
+    assert.deepEqual(readFileSync(note), before);
+    assert.equal(statSync(note).mtimeMs, beforeMtime);
+    assert.equal(existsSync(join(fx.vault, '.brain', 'COST_REBUILD.json')), false);
+  } finally {
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-13] dry-run with a fresh note lock preserves the complete vault tree', () => {
+  const fx = fixture();
+  try {
+    const note = join(fx.vault, fx.sessions['synthetic-one'].session_file);
+    mkdirSync(`${note}.lock`);
+    const before = treeSnapshot(fx.vault);
+    let writerCalls = 0;
+    const report = rebuildSessionCosts(fx.vault, { apply: false }, {
+      readRegistry: () => ({ sessions: fx.sessions }),
+      compose: () => ({ state: 'complete', content: 'synthetic changed content', diagnostics: [] }),
+      publish: () => { writerCalls += 1; return { status: 'published' }; },
+      markDirty: () => { writerCalls += 1; },
+      writeReport: () => { writerCalls += 1; },
+      now: () => '2026-01-01T00:00:00.000Z',
+    });
+
+    assert.equal(report.changed, 1);
+    assert.equal(writerCalls, 0);
+    assert.deepEqual(treeSnapshot(fx.vault), before);
+  } finally {
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-13] dry-run exercises the real registered Codex lifecycle without a writer', () => {
+  const fx = fixture();
+  try {
+    const entry = fx.sessions['synthetic-one'];
+    const note = join(fx.vault, entry.session_file);
+    writeFileSync(note, '---\ntype: session\nprovider: codex\n---\n\n# Synthetic\n\n## Pendências\n\nNenhuma.\n');
+    writeFileSync(entry.transcript_path, [
+      { type: 'session_meta', payload: { id: 'synthetic-one', session_id: 'synthetic-one', model: 'gpt-5.6-sol', model_provider: 'openai' } },
+      { type: 'turn_context', payload: { model: 'gpt-5.6-sol', model_provider: 'openai', effort: 'high' } },
+      { type: 'event_msg', payload: { type: 'user_message', message: 'synthetic request' } },
+      { type: 'event_msg', payload: { type: 'token_count', info: { model: 'gpt-5.6-sol', last_token_usage: { input_tokens: 10, output_tokens: 5 } } } },
+    ].map(JSON.stringify).join('\n') + '\n');
+    entry.provider = 'codex';
+    const before = readFileSync(note);
+    const report = rebuildSessionCosts(fx.vault, { apply: false }, {
+      readRegistry: () => ({ sessions: fx.sessions }),
+      now: () => '2026-01-01T00:00:00.000Z',
+    });
+    assert.equal(report.ok, true);
+    assert.equal(report.changed, 1);
+    assert.equal(report.sessions[0].status, 'would-change');
+    assert.deepEqual(readFileSync(note), before);
+  } finally {
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-13] apply publishes only complete/none and preserves degraded or stale sessions', () => {
+  const fx = fixture(['synthetic-complete', 'synthetic-none', 'synthetic-degraded', 'synthetic-stale']);
+  try {
+    const original = Object.fromEntries(Object.entries(fx.sessions).map(([id, entry]) => [
+      id, {
+        content: readFileSync(join(fx.vault, entry.session_file), 'utf8'),
+        mtimeMs: statSync(join(fx.vault, entry.session_file)).mtimeMs,
+      },
+    ]));
+    const report = rebuildSessionCosts(fx.vault, { apply: true }, {
+      readRegistry: () => ({ sessions: fx.sessions }),
+      compose: ({ canonicalConversationId }) => ({
+        state: canonicalConversationId === 'synthetic-none'
+          ? 'none'
+          : (canonicalConversationId === 'synthetic-degraded' ? 'degraded' : 'complete'),
+        content: `changed:${canonicalConversationId}`,
+        diagnostics: canonicalConversationId === 'synthetic-degraded'
+          ? [{ code: 'GRAPH_LIMIT_EXCEEDED', count: 1 }]
+          : [],
+      }),
+      publish: ({ canonicalConversationId, sessionPath, candidate }) => {
+        if (canonicalConversationId === 'synthetic-stale') return { status: 'stale' };
+        writeFileSync(sessionPath, candidate.content);
+        return { status: 'published' };
+      },
+      writeReport: () => {},
+      now: () => '2026-01-01T00:00:00.000Z',
+    });
+
+    assert.equal(readFileSync(join(fx.vault, fx.sessions['synthetic-complete'].session_file), 'utf8'), 'changed:synthetic-complete');
+    assert.equal(readFileSync(join(fx.vault, fx.sessions['synthetic-none'].session_file), 'utf8'), 'changed:synthetic-none');
+    const degradedNote = join(fx.vault, fx.sessions['synthetic-degraded'].session_file);
+    const staleNote = join(fx.vault, fx.sessions['synthetic-stale'].session_file);
+    assert.equal(readFileSync(degradedNote, 'utf8'), original['synthetic-degraded'].content);
+    assert.equal(statSync(degradedNote).mtimeMs, original['synthetic-degraded'].mtimeMs);
+    assert.equal(readFileSync(staleNote, 'utf8'), original['synthetic-stale'].content);
+    assert.equal(statSync(staleNote).mtimeMs, original['synthetic-stale'].mtimeMs);
+    assert.equal(readObservabilityStore(fx.vault, 'synthetic-degraded').observability_dirty, true);
+    assert.equal(readObservabilityStore(fx.vault, 'synthetic-stale').observability_dirty, true);
+    assert.equal(report.changed, 2);
+    assert.equal(report.degraded, 1);
+    assert.equal(report.stale, 1);
+    assert.equal(report.ok, false);
+    assert.deepEqual(report.sessions.map(({ sessionId, status }) => [sessionId, status]), [
+      ['synthetic-complete', 'published'],
+      ['synthetic-degraded', 'degraded'],
+      ['synthetic-none', 'published'],
+      ['synthetic-stale', 'stale'],
+    ]);
+  } finally {
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-13] real apply classifies root and child exactly once without duplicating totals', () => {
+  const fx = realLifecycleFixture({ withChild: true });
+  try {
+    const report = rebuildSessionCosts(fx.vault, { apply: true }, {
+      now: () => '2026-01-01T00:00:00.000Z',
+    });
+    const note = readFileSync(fx.note, 'utf8');
+    assert.equal(report.ok, true);
+    assert.equal(report.changed, 1);
+    assert.equal((note.match(/\| model-main \| openai \| main \|/g) || []).length, 1);
+    assert.equal((note.match(/\| model-child \| openai \| subagent \|/g) || []).length, 1);
+    assert.match(note, /\| Total tokens \| 15 \| 10 \| 25 \|/);
+  } finally {
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-13] second real apply preserves note, checkpoint, store and report bytes plus mtimes', async () => {
+  const fx = realLifecycleFixture();
+  try {
+    const first = rebuildSessionCosts(fx.vault, { apply: true }, {
+      now: () => '2026-01-01T00:00:00.000Z',
+    });
+    const reportPath = join(fx.vault, '.brain', 'COST_REBUILD.json');
+    const before = {
+      note: readFileSync(fx.note),
+      noteMtime: statSync(fx.note).mtimeMs,
+      checkpoint: readSessionRegistry(fx.vault).sessions[fx.rootId].observability_checkpoint_frontier,
+      store: readObservabilityStore(fx.vault, fx.rootId),
+      report: readFileSync(reportPath),
+      reportMtime: statSync(reportPath).mtimeMs,
+    };
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const second = rebuildSessionCosts(fx.vault, { apply: true }, {
+      now: () => '2026-01-02T00:00:00.000Z',
+    });
+
+    assert.equal(first.changed, 1);
+    assert.equal(second.unchanged, 1);
+    assert.deepEqual(readFileSync(fx.note), before.note);
+    assert.equal(statSync(fx.note).mtimeMs, before.noteMtime);
+    assert.deepEqual(readSessionRegistry(fx.vault).sessions[fx.rootId].observability_checkpoint_frontier, before.checkpoint);
+    assert.deepEqual(readObservabilityStore(fx.vault, fx.rootId), before.store);
+    assert.deepEqual(readFileSync(reportPath), before.report);
+    assert.equal(statSync(reportPath).mtimeMs, before.reportMtime);
+  } finally {
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-13] semantically identical apply report preserves bytes, mtime and generatedAt', () => {
+  const fx = fixture();
+  try {
+    const reportPath = join(fx.vault, '.brain', 'COST_REBUILD.json');
+    const first = {
+      version: 2, generatedAt: '2026-01-01T00:00:00.000Z', mode: 'apply',
+      scanned: 1, changed: 1, unchanged: 0, degraded: 0, stale: 0, missing: 0,
+      ok: true, sessions: [{ sessionId: 'synthetic-one', status: 'published', candidateHash: 'hash-a', diagnostics: [] }],
+    };
+    assert.equal(writeRebuildReportIfChanged(reportPath, first), true);
+    const bytes = readFileSync(reportPath);
+    const mtime = statSync(reportPath).mtimeMs;
+    assert.equal(writeRebuildReportIfChanged(reportPath, {
+      ...first,
+      generatedAt: '2026-01-02T00:00:00.000Z',
+    }), false);
+    assert.deepEqual(readFileSync(reportPath), bytes);
+    assert.equal(statSync(reportPath).mtimeMs, mtime);
+    assert.equal(writeRebuildReportIfChanged(reportPath, {
+      ...first,
+      generatedAt: '2026-01-03T00:00:00.000Z',
+      changed: 0,
+      unchanged: 1,
+      sessions: [{ sessionId: 'synthetic-one', status: 'unchanged', candidateHash: 'hash-b', diagnostics: [] }],
+    }), true, 'a different candidate hash is a real semantic change');
+  } finally {
+    rmSync(fx.vault, { recursive: true, force: true });
+  }
+});

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -5,6 +5,8 @@ import { extractReleaseNotes } from '../src/release-changelog.mjs';
 
 const AUTO_TAG_WORKFLOW = readFileSync(new URL('../.github/workflows/auto-tag.yml', import.meta.url), 'utf8');
 const AGENT_RULES = readFileSync(new URL('../AGENTS.md', import.meta.url), 'utf8');
+const CHANGELOG = readFileSync(new URL('../CHANGELOG.md', import.meta.url), 'utf8');
+const PACKAGE = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 
 const FIXTURE = `# Changelog
 
@@ -64,6 +66,18 @@ test('extractReleaseNotes: body is trimmed (no leading/trailing blank lines)', (
 
 test('extractReleaseNotes: throws when the version is absent', () => {
   assert.throws(() => extractReleaseNotes(FIXTURE, '9.9.9'), /9\.9\.9/);
+});
+
+test('[sensor:release-tests] 0.66.5 notes are extractable and match the package', () => {
+  const release = extractReleaseNotes(CHANGELOG, '0.66.5');
+  assert.equal(PACKAGE.version, '0.66.5');
+  assert.equal(release.date, '2026-08-01');
+  assert.match(release.notes, /Codex/i);
+  assert.match(release.notes, /rebuild/i);
+  assert.match(release.notes, /import/i);
+  assert.match(release.notes, /doctor/i);
+  assert.match(release.notes, /privacidade|diagnostic/i);
+  assert.doesNotMatch(release.notes, /memory recover-attempt/);
 });
 
 test('auto-tag: existing tag still refreshes the GitHub Release from CHANGELOG', () => {

--- a/tests/session-observability-cas.test.mjs
+++ b/tests/session-observability-cas.test.mjs
@@ -1,0 +1,273 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { publishSessionObservability } from '../hooks/session-observability.mjs';
+import { readSessionRegistry, upsertSessionRegistry } from '../hooks/obsidian-common.mjs';
+import { readObservabilityStore } from '../hooks/session-observability-store.mjs';
+
+function frontier(overrides = {}) {
+  return {
+    canonical_session_id: 'session-synthetic',
+    activation_id: 'activation-synthetic',
+    activation_epoch: 2,
+    turn_sequence: 4,
+    signal_sequence: 6,
+    roots_stat_hash: 'roots-synthetic',
+    graph_cursor: 'graph-synthetic',
+    source_manifest_hash: 'manifest-synthetic',
+    ...overrides,
+  };
+}
+
+function checkpointContent(value, state = 'complete') {
+  return `---\ntype: session\nobservability_schema: 2\nsubagents_observability_state: '${state}'\nobservability_session_id: 'session-synthetic'\nobservability_activation_id: 'activation-synthetic'\nobservability_activation_epoch: ${value.activation_epoch}\nobservability_turn_sequence: ${value.turn_sequence}\nobservability_signal_sequence: ${value.signal_sequence}\nobservability_roots_stat_hash: '${value.roots_stat_hash}'\nobservability_graph_cursor: '${value.graph_cursor}'\nobservability_source_manifest_hash: '${value.source_manifest_hash}'\nsubagents_diagnostics_json: '[]'\n---\n\n# Synthetic\n`;
+}
+
+function candidate(value = frontier(), content = checkpointContent(value)) {
+  return { state: 'complete', frontier: value, diagnostics: [], snapshot: { version: 2 }, content };
+}
+
+function memoryNote(initial) {
+  let content = initial;
+  let writes = 0;
+  let lockHeld = false;
+  return {
+    get content() { return content; },
+    get writes() { return writes; },
+    get lockHeld() { return lockHeld; },
+    mutate(_path, mutator) {
+      lockHeld = true;
+      try {
+        const next = mutator(content);
+        if (next == null) return { written: false, reason: 'aborted', content };
+        if (next === content) return { written: false, reason: 'unchanged', content };
+        content = next;
+        writes += 1;
+        return { written: true, reason: 'ok', content };
+      } finally {
+        lockHeld = false;
+      }
+    },
+  };
+}
+
+test('[req:OBS-12] publish composes outside the note lock and equal candidates are byte-identical', () => {
+  const value = frontier();
+  const note = memoryNote(checkpointContent(value));
+  let composedOutsideLock = false;
+  let registryWrites = 0;
+  let revalidatedCandidate = null;
+
+  const result = publishSessionObservability({
+    sessionPath: 'synthetic.md',
+    frontier: value,
+    compose: () => {
+      composedOutsideLock = !note.lockHeld;
+      return candidate(value, note.content);
+    },
+    readRuntimeFrontier: (candidateFrontier) => {
+      revalidatedCandidate = candidateFrontier;
+      return value;
+    },
+    writeRegistryCheckpoint: () => { registryWrites += 1; },
+  }, { mutateNote: note.mutate.bind(note) });
+
+  assert.equal(composedOutsideLock, true);
+  assert.deepEqual(revalidatedCandidate, value);
+  assert.equal(result.status, 'unchanged');
+  assert.equal(note.writes, 0);
+  assert.equal(registryWrites, 1, 'registry is reconciled even when note already has the candidate');
+});
+
+test('[req:OBS-11] [req:OBS-12] older candidate loses the causal CAS and never changes the note', () => {
+  const current = frontier({ activation_epoch: 5, turn_sequence: 1, signal_sequence: 1 });
+  const older = frontier({ activation_epoch: 4, turn_sequence: 99, signal_sequence: 99 });
+  const original = checkpointContent(current);
+  const note = memoryNote(original);
+
+  const result = publishSessionObservability({
+    sessionPath: 'synthetic.md',
+    frontier: older,
+    candidate: candidate(older, checkpointContent(older)),
+    readRuntimeFrontier: () => current,
+  }, { mutateNote: note.mutate.bind(note) });
+
+  assert.equal(result.status, 'stale');
+  assert.equal(note.content, original);
+  assert.equal(note.writes, 0);
+});
+
+test('[req:OBS-11] a signal that advances after composition is rejected under the publication guard', () => {
+  const composed = frontier({ signal_sequence: 6 });
+  const advanced = frontier({ signal_sequence: 7 });
+  const original = checkpointContent(composed);
+  const note = memoryNote(original);
+  let guardHeld = false;
+
+  const result = publishSessionObservability({
+    sessionPath: 'synthetic.md',
+    candidate: candidate(composed, `${checkpointContent(composed)}\nnew snapshot\n`),
+    withPublicationGuard(candidateFrontier, publish) {
+      assert.deepEqual(candidateFrontier, composed);
+      guardHeld = true;
+      try { return publish({ current: advanced }); }
+      finally { guardHeld = false; }
+    },
+    readRuntimeFrontier(candidateFrontier, context) {
+      assert.equal(guardHeld, true, 'revalidation must run while the registry guard is held');
+      assert.deepEqual(candidateFrontier, composed);
+      return context.current;
+    },
+  }, { mutateNote: note.mutate.bind(note) });
+
+  assert.equal(result.status, 'stale');
+  assert.equal(note.content, original);
+  assert.equal(note.writes, 0);
+});
+
+test('[req:OBS-12] degraded and manifest-conflicting candidates fail closed without touching the note', () => {
+  const value = frontier();
+  const original = checkpointContent(value);
+  const note = memoryNote(original);
+
+  const degraded = publishSessionObservability({
+    sessionPath: 'synthetic.md',
+    frontier: value,
+    candidate: { ...candidate(value), state: 'degraded', content: 'must-not-publish' },
+  }, { mutateNote: note.mutate.bind(note) });
+  assert.equal(degraded.status, 'degraded');
+
+  const conflicting = frontier({ source_manifest_hash: 'manifest-other' });
+  const conflict = publishSessionObservability({
+    sessionPath: 'synthetic.md',
+    frontier: conflicting,
+    candidate: candidate(conflicting, checkpointContent(conflicting)),
+    readRuntimeFrontier: () => value,
+  }, { mutateNote: note.mutate.bind(note) });
+  assert.equal(conflict.status, 'conflict');
+  assert.equal(note.content, original);
+  assert.equal(note.writes, 0);
+});
+
+test('[req:OBS-12] crash after note publication is reconciled idempotently on retry', () => {
+  const value = frontier({ signal_sequence: 7, source_manifest_hash: 'manifest-next' });
+  const note = memoryNote('---\ntype: session\n---\n\n# Synthetic\n');
+  let registryAttempts = 0;
+  const publish = () => publishSessionObservability({
+    sessionPath: 'synthetic.md',
+    frontier: value,
+    candidate: candidate(value, checkpointContent(value)),
+    readRuntimeFrontier: () => value,
+    writeRegistryCheckpoint: () => {
+      registryAttempts += 1;
+      if (registryAttempts === 1) throw new Error('synthetic registry crash');
+    },
+  }, { mutateNote: note.mutate.bind(note) });
+
+  assert.throws(publish, /synthetic registry crash/);
+  assert.equal(note.writes, 1, 'note was durably published before the simulated crash');
+  const bytesAfterCrash = note.content;
+
+  const retried = publish();
+  assert.equal(retried.status, 'unchanged');
+  assert.equal(note.content, bytesAfterCrash);
+  assert.equal(note.writes, 1, 'retry must not republish the same handoff');
+  assert.equal(registryAttempts, 2);
+});
+
+test('[req:OBS-11] [req:OBS-12] vault publication defaults hold the registry guard and persist both checkpoints', () => {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-observe-default-cas-'));
+  try {
+    mkdirSync(join(vault, '.brain'), { recursive: true });
+    const note = join(vault, 'session.md');
+    writeFileSync(note, '---\ntype: session\nprovider: codex\n---\n\n# Synthetic\n');
+    upsertSessionRegistry(vault, 'session-synthetic', {
+      session_file: 'session.md',
+      provider: 'codex',
+      active_activation_id: 'activation-synthetic',
+      activation_epoch: 2,
+      last_turn_sequence: 4,
+      observability_signal_sequence: 0,
+    });
+    const initial = frontier({ signal_sequence: 0 });
+    const first = publishSessionObservability({
+      vaultBase: vault,
+      sessionPath: note,
+      canonicalConversationId: 'session-synthetic',
+      candidate: candidate(initial, checkpointContent(initial)),
+    });
+    assert.equal(first.status, 'published');
+    assert.equal(readSessionRegistry(vault).sessions['session-synthetic'].observability_checkpoint_sequence, 0);
+    assert.equal(readObservabilityStore(vault, 'session-synthetic').checkpoint_frontier.signal_sequence, 0);
+
+    upsertSessionRegistry(vault, 'session-synthetic', {
+      active_activation_id: 'activation-next',
+      activation_epoch: 3,
+      last_turn_sequence: 1,
+    });
+    const bytes = readFileSync(note, 'utf8');
+    const stale = publishSessionObservability({
+      vaultBase: vault,
+      sessionPath: note,
+      canonicalConversationId: 'session-synthetic',
+      candidate: candidate(initial, `${checkpointContent(initial)}\nold overwrite\n`),
+    });
+    assert.equal(stale.status, 'stale');
+    assert.equal(readFileSync(note, 'utf8'), bytes);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-12] an offline source refresh is rejected if the manifest changes after composition', () => {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-observe-refresh-cas-'));
+  try {
+    mkdirSync(join(vault, '.brain'), { recursive: true });
+    const note = join(vault, 'session.md');
+    const root = join(vault, 'root.jsonl');
+    const current = frontier({ signal_sequence: 0, source_manifest_hash: 'manifest-old' });
+    const refreshed = frontier({ signal_sequence: 0, source_manifest_hash: 'manifest-new' });
+    writeFileSync(note, checkpointContent(current));
+    writeFileSync(root, `${JSON.stringify({ type: 'session_meta', payload: { id: 'root-synthetic', session_id: 'session-synthetic' } })}\n`);
+    const rootStat = statSync(root);
+    upsertSessionRegistry(vault, 'session-synthetic', {
+      session_file: 'session.md',
+      provider: 'codex',
+      transcript_path: root,
+      active_activation_id: 'activation-synthetic',
+      activation_epoch: 2,
+      last_turn_sequence: 4,
+      observability_signal_sequence: 0,
+    });
+    const composed = {
+      ...candidate(refreshed, checkpointContent(refreshed)),
+      snapshot: {
+        version: 2,
+        roots: { rootPaths: [root], descendantIds: [] },
+        subagents: {
+          sourceManifest: [{
+            path: root,
+            rolloutId: 'root-synthetic',
+            size: rootStat.size,
+            mtimeMs: rootStat.mtimeMs,
+          }],
+        },
+      },
+    };
+    writeFileSync(root, `${readFileSync(root, 'utf8')}\n`);
+
+    const result = publishSessionObservability({
+      vaultBase: vault,
+      sessionPath: note,
+      canonicalConversationId: 'session-synthetic',
+      candidate: composed,
+      allowSourceRefresh: true,
+    });
+    assert.equal(result.status, 'conflict');
+    assert.equal(readFileSync(note, 'utf8'), checkpointContent(current));
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});

--- a/tests/session-observability-frontier.test.mjs
+++ b/tests/session-observability-frontier.test.mjs
@@ -1,0 +1,132 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  OBSERVABILITY_SCHEMA,
+  buildObservabilityFrontier,
+  compareObservabilityFrontiers,
+  parseObservabilityCheckpoint,
+  readObservabilityCheckpoint,
+  renderObservabilityCheckpoint,
+  renderObservabilityCheckpointLines,
+  sanitizeObservabilityDiagnostics,
+} from '../hooks/session-observability-state.mjs';
+
+function frontier(overrides = {}) {
+  return buildObservabilityFrontier({
+    canonical_session_id: 'session-synthetic',
+    activation_id: 'activation-synthetic',
+    activation_epoch: 4,
+    turn_sequence: 8,
+    signal_sequence: 12,
+    roots_stat_hash: 'roots-a',
+    graph_cursor: 'graph-a',
+    source_manifest_hash: 'manifest-a',
+    ...overrides,
+  });
+}
+
+test('[req:OBS-12] frontier comparison is monotonic by activation, turn and signal authority', () => {
+  const current = frontier();
+
+  assert.equal(compareObservabilityFrontiers(current, frontier({ activation_epoch: 3 })), 'stale');
+  assert.equal(compareObservabilityFrontiers(current, frontier({ turn_sequence: 7 })), 'stale');
+  assert.equal(compareObservabilityFrontiers(current, frontier({ signal_sequence: 11 })), 'stale');
+  assert.equal(compareObservabilityFrontiers(current, frontier({ activation_epoch: 5 })), 'newer');
+  assert.equal(compareObservabilityFrontiers(current, frontier({ turn_sequence: 9 })), 'newer');
+  assert.equal(compareObservabilityFrontiers(current, frontier({ signal_sequence: 13 })), 'newer');
+  assert.equal(compareObservabilityFrontiers(current, frontier()), 'same');
+});
+
+test('[req:OBS-12] equal authority with divergent identity or source hashes is conflict', () => {
+  const current = frontier();
+
+  assert.equal(compareObservabilityFrontiers(
+    current,
+    frontier({ source_manifest_hash: 'manifest-b' }),
+  ), 'conflict');
+  assert.equal(compareObservabilityFrontiers(
+    current,
+    frontier({ activation_id: 'activation-other' }),
+  ), 'conflict');
+  assert.equal(compareObservabilityFrontiers(
+    current,
+    frontier({ canonical_session_id: 'session-other' }),
+  ), 'conflict');
+  assert.equal(compareObservabilityFrontiers(null, current), 'newer');
+});
+
+test('[req:OBS-12] equal authority with a divergent roots stat hash is conflict', () => {
+  const current = frontier();
+  assert.equal(compareObservabilityFrontiers(
+    current,
+    frontier({ roots_stat_hash: 'roots-b' }),
+  ), 'conflict');
+});
+
+test('[req:OBS-12] equal authority with a divergent graph cursor is conflict', () => {
+  const current = frontier();
+  assert.equal(compareObservabilityFrontiers(
+    current,
+    frontier({ graph_cursor: 'graph-b' }),
+  ), 'conflict');
+});
+
+test('[req:OBS-12] schema 2 checkpoint renders and parses without losing the frontier', () => {
+  const source = frontier();
+  const diagnostics = [
+    { code: 'CHILD_MISSING', count: 2 },
+    { code: 'CACHE_INVALID', count: 1 },
+    { code: 'CHILD_MISSING', count: 3 },
+  ];
+  const fields = renderObservabilityCheckpoint(source, { state: 'degraded', diagnostics });
+
+  assert.equal(fields.observability_schema, OBSERVABILITY_SCHEMA);
+  assert.equal(fields.subagents_observability_state, 'degraded');
+  assert.equal(fields.subagents_diagnostics_json, JSON.stringify([
+    { code: 'CACHE_INVALID', count: 1 },
+    { code: 'CHILD_MISSING', count: 5 },
+  ]));
+
+  const parsed = parseObservabilityCheckpoint(fields);
+  assert.deepEqual(parsed, {
+    schema: OBSERVABILITY_SCHEMA,
+    state: 'degraded',
+    frontier: source,
+    diagnostics: [
+      { code: 'CACHE_INVALID', count: 1 },
+      { code: 'CHILD_MISSING', count: 5 },
+    ],
+  });
+  assert.deepEqual(readObservabilityCheckpoint(renderObservabilityCheckpointLines(
+    source,
+    { state: 'degraded', diagnostics },
+  )), parsed);
+});
+
+test('[req:OBS-12] legacy or incomplete schema does not masquerade as a current checkpoint', () => {
+  assert.equal(parseObservabilityCheckpoint({ observability_schema: 1 }), null);
+  assert.equal(parseObservabilityCheckpoint({
+    ...renderObservabilityCheckpoint(frontier(), { state: 'complete' }),
+    observability_graph_cursor: '',
+  }), null);
+});
+
+test('[req:OBS-14] diagnostics accept only allowlisted {code,count} objects', () => {
+  assert.deepEqual(sanitizeObservabilityDiagnostics([
+    { code: 'MAIN_TRANSCRIPT_UNRESOLVED', count: 1 },
+  ]), [{ code: 'MAIN_TRANSCRIPT_UNRESOLVED', count: 1 }]);
+
+  const sensitive = 'synthetic-private-marker';
+  for (const diagnostics of [
+    [{ code: 'NOT_ALLOWLISTED', count: 1 }],
+    [{ code: 'CHILD_MISSING', count: 1, path: sensitive }],
+    [{ code: 'CHILD_MISSING', count: 0 }],
+    [{ code: 'CHILD_MISSING', count: 1.5 }],
+  ]) {
+    assert.throws(
+      () => sanitizeObservabilityDiagnostics(diagnostics),
+      (error) => error?.code === 'OBSERVABILITY_DIAGNOSTIC_INVALID'
+        && !String(error.message).includes(sensitive),
+    );
+  }
+});

--- a/tests/session-observability-roots.test.mjs
+++ b/tests/session-observability-roots.test.mjs
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import {
+  collectSessionUsage,
+  collectSessionUsageForRoots,
+} from '../hooks/token-usage.mjs';
+
+const CONVERSATION = '11111111-1111-7111-8111-111111111111';
+
+function rollout(id, tokens, extra = {}) {
+  return [
+    { type: 'session_meta', payload: { id, session_id: CONVERSATION, model: 'gpt-5.6-sol', model_provider: 'openai', ...extra } },
+    { type: 'turn_context', payload: { model: 'gpt-5.6-sol', model_provider: 'openai', effort: 'high' } },
+    { type: 'event_msg', payload: { type: 'user_message', message: 'synthetic request' } },
+    { type: 'event_msg', payload: { type: 'token_count', info: { model: 'gpt-5.6-sol', last_token_usage: { input_tokens: tokens, output_tokens: 10 } } } },
+  ].map(JSON.stringify).join('\n') + '\n';
+}
+
+function note() {
+  return '---\ntype: session\nprovider: codex\n---\n\n# Synthetic session\n\n## Pendências\n\nNenhuma.\n';
+}
+
+function seed() {
+  const dir = mkdtempSync(join(tmpdir(), 'wk-observe-roots-'));
+  const a = join(dir, 'root-a.jsonl');
+  const b = join(dir, 'root-b.jsonl');
+  const c = join(dir, 'child-c.jsonl');
+  writeFileSync(a, rollout('root-a', 100));
+  writeFileSync(b, rollout('root-b', 200));
+  writeFileSync(c, rollout('child-c', 300, {
+    parent_thread_id: 'root-a',
+    source: { subagent: { thread_spawn: { parent_thread_id: 'root-a', depth: 1, agent_nickname: 'synthetic-child' } } },
+  }));
+  return { dir, a, b, c };
+}
+
+test('[req:OBS-11] roots A+B remain main while descendant C is removed from main history', () => {
+  const fx = seed();
+  try {
+    let content = collectSessionUsage({ sessionContent: note(), transcriptPath: fx.a }).content;
+    content = collectSessionUsage({ sessionContent: content, transcriptPath: fx.b }).content;
+    content = collectSessionUsage({ sessionContent: content, transcriptPath: fx.c }).content;
+
+    const result = collectSessionUsageForRoots({
+      sessionContent: content,
+      rootPaths: [fx.a, fx.b],
+      descendantIds: [basename(fx.c, '.jsonl'), 'child-c'],
+    });
+
+    assert.equal(result.state, 'complete');
+    assert.deepEqual(result.entries.map((entry) => entry.transcript_id).sort(), ['root-a', 'root-b']);
+    assert.equal(result.aggregate.total, 320, 'main is exactly A+B, without child C');
+    assert.doesNotMatch(result.content, /transcript_id: "child-c"/);
+  } finally {
+    rmSync(fx.dir, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-11] registry roots reject a source.subagent path instead of treating it as main', async () => {
+  const fx = seed();
+  try {
+    const { resolveObservabilityRoots } = await import('../hooks/session-observability-lifecycle.mjs');
+    const roots = resolveObservabilityRoots({
+      provider: 'codex',
+      transcript_path: fx.c,
+      transcript_paths: [fx.a, fx.c, fx.b],
+      activations: {
+        older: { transcript_path: fx.a },
+        current: { transcript_path: fx.b },
+      },
+    });
+
+    assert.equal(roots.state, 'complete');
+    assert.deepEqual(roots.rootPaths, [fx.a, fx.b].sort());
+    assert.deepEqual(roots.descendantPaths, [fx.c]);
+  } finally {
+    rmSync(fx.dir, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-11] unresolved historical main entry degrades and preserves original content', () => {
+  const fx = seed();
+  try {
+    const unknown = join(fx.dir, 'root-unknown.jsonl');
+    writeFileSync(unknown, rollout('root-unknown', 400));
+    let content = collectSessionUsage({ sessionContent: note(), transcriptPath: fx.a }).content;
+    content = collectSessionUsage({ sessionContent: content, transcriptPath: unknown }).content;
+
+    const result = collectSessionUsageForRoots({
+      sessionContent: content,
+      rootPaths: [fx.a],
+      descendantIds: [],
+    });
+
+    assert.equal(result.state, 'degraded');
+    assert.deepEqual(result.diagnostics, [{ code: 'MAIN_TRANSCRIPT_UNRESOLVED', count: 1 }]);
+    assert.equal(result.content, content, 'fail closed: unknown main history is not deleted');
+  } finally {
+    rmSync(fx.dir, { recursive: true, force: true });
+  }
+});

--- a/tests/session-observability-store.test.mjs
+++ b/tests/session-observability-store.test.mjs
@@ -1,0 +1,260 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import {
+  markObservabilityCheckpoint,
+  observabilityStorePath,
+  readObservabilityStore,
+  recordObservabilitySignal,
+  releaseObservabilityLease,
+  tryAcquireObservabilityLease,
+} from '../hooks/session-observability-store.mjs';
+
+function createVault(prefix = 'wk-observability-store-') {
+  const vault = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  return vault;
+}
+
+function signal(rolloutId) {
+  return {
+    rollout_id: rolloutId,
+    transcript_path: `synthetic/rollouts/${rolloutId}.jsonl`,
+    activation_id: 'activation-synthetic',
+    activation_epoch: 1,
+    turn_sequence: 2,
+  };
+}
+
+test('[req:OBS-11] duplicate child signals do not advance sequence and new children do', () => {
+  const vault = createVault();
+  try {
+    const first = recordObservabilitySignal(vault, 'session-synthetic', signal('child-c'));
+    const duplicate = recordObservabilitySignal(vault, 'session-synthetic', signal('child-c'));
+    const second = recordObservabilitySignal(vault, 'session-synthetic', signal('child-d'));
+
+    assert.deepEqual(
+      [first.sequence, duplicate.sequence, second.sequence],
+      [1, 1, 2],
+    );
+    assert.equal(first.duplicate, false);
+    assert.equal(duplicate.duplicate, true);
+    assert.equal(second.state.observability_dirty, true);
+    assert.equal(second.state.signals.length, 2);
+    assert.deepEqual(
+      readObservabilityStore(vault, 'session-synthetic').signals
+        .map((entry) => entry.signal_sequence),
+      [1, 2],
+    );
+
+    const persisted = JSON.parse(readFileSync(observabilityStorePath(
+      vault,
+      'session-synthetic',
+    ), 'utf8'));
+    assert.equal(persisted.observability_signal_sequence, 2);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-11] signal metadata survives alias normalization and invalid kinds fail closed', () => {
+  const vault = createVault();
+  try {
+    const recorded = recordObservabilitySignal(vault, 'session-synthetic', {
+      rolloutId: 'child-c',
+      transcriptPath: 'synthetic/rollouts/child-c.jsonl',
+      parentRolloutId: ' root-a ',
+      kind: ' STARTED ',
+      timestamp: ' 2026-01-02T03:04:05.000Z ',
+      agentPath: ' /root/child-c ',
+    });
+
+    assert.deepEqual(recorded.state.signals, [{
+      rollout_id: 'child-c',
+      transcript_path: 'synthetic/rollouts/child-c.jsonl',
+      parent_thread_id: 'root-a',
+      kind: 'started',
+      timestamp: '2026-01-02T03:04:05.000Z',
+      agent_path: '/root/child-c',
+      signal_sequence: 1,
+    }]);
+    assert.deepEqual(
+      readObservabilityStore(vault, 'session-synthetic').signals,
+      recorded.state.signals,
+    );
+    assert.throws(
+      () => recordObservabilitySignal(vault, 'session-synthetic', {
+        rollout_id: 'child-d',
+        kind: 'spawn-requested',
+      }),
+      (error) => error?.code === 'OBSERVABILITY_SIGNAL_INVALID',
+    );
+    assert.equal(
+      readObservabilityStore(vault, 'session-synthetic').observability_signal_sequence,
+      1,
+    );
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-11] lease for signal 1 loses to signal 2 and stale workers cannot release it', () => {
+  const vault = createVault();
+  try {
+    recordObservabilitySignal(vault, 'session-synthetic', signal('child-c'));
+    const first = tryAcquireObservabilityLease(vault, 'session-synthetic', {
+      signalSequence: 1,
+      ownerToken: 'worker-1',
+      now: 1_000,
+      ttlMs: 10_000,
+    });
+    assert.equal(first.acquired, true);
+
+    recordObservabilitySignal(vault, 'session-synthetic', signal('child-d'));
+    const stale = tryAcquireObservabilityLease(vault, 'session-synthetic', {
+      signalSequence: 1,
+      ownerToken: 'worker-1',
+      now: 1_100,
+      ttlMs: 10_000,
+    });
+    const winner = tryAcquireObservabilityLease(vault, 'session-synthetic', {
+      signalSequence: 2,
+      ownerToken: 'worker-2',
+      now: 1_100,
+      ttlMs: 10_000,
+    });
+
+    assert.deepEqual({ acquired: stale.acquired, reason: stale.reason }, {
+      acquired: false,
+      reason: 'stale-signal',
+    });
+    assert.equal(winner.acquired, true);
+    assert.equal(winner.state.lease.owner_token, 'worker-2');
+    assert.equal(releaseObservabilityLease(
+      vault,
+      'session-synthetic',
+      { ownerToken: 'worker-1' },
+    ).released, false);
+    assert.equal(releaseObservabilityLease(
+      vault,
+      'session-synthetic',
+      { ownerToken: 'worker-2' },
+    ).released, true);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-12] checkpoint clears dirty only after catching the newest signal', () => {
+  const vault = createVault();
+  try {
+    recordObservabilitySignal(vault, 'session-synthetic', signal('child-c'));
+    recordObservabilitySignal(vault, 'session-synthetic', signal('child-d'));
+
+    const behind = markObservabilityCheckpoint(vault, 'session-synthetic', {
+      checkpointSequence: 1,
+      frontier: { source_manifest_hash: 'manifest-a' },
+    });
+    const caughtUp = markObservabilityCheckpoint(vault, 'session-synthetic', {
+      checkpointSequence: 2,
+      frontier: { source_manifest_hash: 'manifest-b' },
+    });
+
+    assert.equal(behind.observability_dirty, true);
+    assert.equal(caughtUp.observability_dirty, false);
+    assert.equal(caughtUp.observability_checkpoint_sequence, 2);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-12] corrupt derived cache is discarded and reconstructed on the next signal', () => {
+  const vault = createVault();
+  try {
+    const path = observabilityStorePath(vault, 'session-synthetic');
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, '{not-json', 'utf8');
+
+    const recovered = readObservabilityStore(vault, 'session-synthetic');
+    assert.equal(recovered.reconstructed, true);
+    assert.deepEqual(recovered.diagnostics, [{ code: 'CACHE_INVALID', count: 1 }]);
+    assert.equal(recovered.observability_signal_sequence, 0);
+    assert.equal(recovered.observability_dirty, true);
+
+    const next = recordObservabilitySignal(vault, 'session-synthetic', signal('child-c'));
+    assert.equal(next.sequence, 1);
+    assert.doesNotThrow(() => JSON.parse(readFileSync(path, 'utf8')));
+    assert.deepEqual(readdirSync(dirname(path)).filter((name) => /\.tmp$|\.lock$/.test(name)), []);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-12] store uses a deterministic opaque sha256 filename', () => {
+  const vault = createVault();
+  try {
+    const path = observabilityStorePath(vault, 'session-name-that-must-not-leak');
+    assert.match(basename(path), /^[a-f0-9]{64}\.json$/);
+    assert.equal(path.includes('session-name-that-must-not-leak'), false);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-12] store rejects a hardlinked target instead of reading or replacing it', () => {
+  const vault = createVault();
+  try {
+    const path = observabilityStorePath(vault, 'session-synthetic');
+    mkdirSync(dirname(path), { recursive: true });
+    const source = join(dirname(path), 'source.json');
+    writeFileSync(source, '{}\n');
+    linkSync(source, path);
+
+    assert.throws(
+      () => readObservabilityStore(vault, 'session-synthetic'),
+      (error) => error?.code === 'OBSERVABILITY_STORE_PATH_UNSAFE',
+    );
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-12] store rejects a symlinked runtime directory', (t) => {
+  const vault = createVault();
+  const outside = mkdtempSync(join(tmpdir(), 'wk-observability-outside-'));
+  try {
+    const runtime = join(vault, '.brain', 'runtime');
+    mkdirSync(runtime, { recursive: true });
+    const storeDir = join(runtime, 'session-observability');
+    try {
+      symlinkSync(outside, storeDir, process.platform === 'win32' ? 'junction' : 'dir');
+    } catch (error) {
+      if (error?.code === 'EPERM') {
+        t.skip('symlink/junction creation unavailable');
+        return;
+      }
+      throw error;
+    }
+
+    assert.equal(existsSync(storeDir), true);
+    assert.throws(
+      () => recordObservabilitySignal(vault, 'session-synthetic', signal('child-c')),
+      (error) => error?.code === 'OBSERVABILITY_STORE_PATH_UNSAFE',
+    );
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});

--- a/tests/session-observability.test.mjs
+++ b/tests/session-observability.test.mjs
@@ -1,11 +1,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { updateSessionObservability } from '../hooks/session-observability.mjs';
-import { refreshSubagents } from '../hooks/subagent-stop.mjs';
-import { upsertSessionRegistry, writeControl } from '../hooks/obsidian-common.mjs';
+import {
+  composeRegisteredSessionObservability,
+  composeSessionObservability,
+  updateSessionObservability,
+} from '../hooks/session-observability.mjs';
 import { sameUsageData } from '../hooks/token-usage.mjs';
 
 // Preservação de `atualizado_em`: o dado é "o mesmo" independente da ORDEM das chaves.
@@ -61,12 +63,34 @@ test('single writer merges main + subagent reasoning/effort and migrates legacy 
     assert.match(content, /gpt-5\.6-sol \| openai \| main \| high/);
     assert.match(content, /gpt-5\.6-luna \| openai \| subagent \| low/);
     assert.match(content, /\| Reasoning tokens \| 20 \| 4 \| 24 \|/);
-    assert.match(content, /observability_schema: 1/);
+    assert.match(content, /observability_schema: 2/);
+    assert.match(content, /subagents_observability_state: 'complete'/);
     assert.match(content, /"reasoning":20/);
     assert.match(content, /"effort":"low"/);
 
     updateSessionObservability({ sessionPath: note, transcriptPath: transcript });
     assert.equal(readFileSync(note, 'utf8'), content, 'same sources produce byte-identical markdown');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('[req:OBS-11] changing only the caller preserves note bytes and mtime', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wk-observe-caller-'));
+  try {
+    const transcript = join(root, 'main.jsonl');
+    writeFileSync(transcript, codexTranscript({ id: 'main', model: 'gpt-5.6-sol', effort: 'high', input: 10, cached: 0, output: 5, reasoning: 2 }));
+    const note = join(root, 'session.md');
+    writeFileSync(note, '---\ntype: session\n---\n\n# Sessão\n');
+
+    updateSessionObservability({ sessionPath: note, transcriptPath: transcript, caller: 'stop' });
+    const before = readFileSync(note, 'utf8');
+    const stableTime = new Date('2026-01-01T00:00:00.000Z');
+    utimesSync(note, stableTime, stableTime);
+    const beforeMtime = statSync(note).mtimeMs;
+
+    updateSessionObservability({ sessionPath: note, transcriptPath: transcript, caller: 'cost-rebuild' });
+
+    assert.equal(readFileSync(note, 'utf8'), before);
+    assert.equal(statSync(note).mtimeMs, beforeMtime);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
@@ -151,21 +175,245 @@ test('Claude with no thinking blocks reports effort none, not unknown', () => {
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
-test('SubagentStop hook recomposes main usage instead of updating a competing section', () => {
-  const vault = mkdtempSync(join(tmpdir(), 'wk-observe-hook-'));
+function composeClaudeFilesystemState(root) {
+  const transcript = join(root, 'main.jsonl');
+  writeFileSync(transcript, JSON.stringify({
+    type: 'assistant', uuid: 'answer-synthetic', sessionId: 'session-synthetic', requestId: 'request-synthetic',
+    message: {
+      id: 'message-synthetic', role: 'assistant', model: 'claude-opus-4-8',
+      usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+      content: [{ type: 'text', text: 'synthetic response' }],
+    },
+  }));
+  return composeRegisteredSessionObservability({
+    sessionContent: '---\ntype: session\nprovider: claude\n---\n\n# Synthetic\n',
+    sessionEntry: {
+      provider: 'claude', transcript_path: transcript,
+      active_activation_id: 'activation-synthetic', activation_epoch: 1, last_turn_sequence: 1,
+    },
+    canonicalConversationId: 'session-synthetic',
+    mode: 'offline',
+  });
+}
+
+test('[req:OBS-12] Claude absent or confirmed-empty subagent directory materializes none', () => {
+  for (const layout of ['absent', 'empty']) {
+    const root = mkdtempSync(join(tmpdir(), `wk-observe-claude-${layout}-`));
+    try {
+      if (layout === 'empty') mkdirSync(join(root, 'main', 'subagents'), { recursive: true });
+      const result = composeClaudeFilesystemState(root);
+      assert.equal(result.state, 'none', layout);
+      assert.deepEqual(result.diagnostics, [], layout);
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  }
+});
+
+test('[req:OBS-12] Claude filesystem errors or malformed agent transcripts degrade safely', () => {
+  for (const layout of ['error', 'malformed']) {
+    const root = mkdtempSync(join(tmpdir(), `wk-observe-claude-${layout}-`));
+    try {
+      const sessionDir = join(root, 'main');
+      mkdirSync(sessionDir, { recursive: true });
+      const subagents = join(sessionDir, 'subagents');
+      if (layout === 'error') {
+        writeFileSync(subagents, 'not a directory');
+      } else {
+        mkdirSync(subagents);
+        writeFileSync(join(subagents, 'agent-malformed.jsonl'), '{not-json}\n');
+      }
+      const result = composeClaudeFilesystemState(root);
+      assert.equal(result.state, 'degraded', layout);
+      assert.deepEqual(result.diagnostics, [{ code: 'CHILD_META_INVALID', count: 1 }], layout);
+      assert.doesNotMatch(JSON.stringify(result.diagnostics), /not a directory|not-json|wk-observe/i);
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  }
+});
+
+function frontier(overrides = {}) {
+  return {
+    canonical_session_id: 'session-synthetic',
+    activation_id: 'activation-synthetic',
+    activation_epoch: 3,
+    turn_sequence: 7,
+    signal_sequence: 11,
+    roots_stat_hash: 'roots-synthetic',
+    graph_cursor: 'graph-synthetic',
+    source_manifest_hash: 'manifest-synthetic',
+    ...overrides,
+  };
+}
+
+function syntheticMain(content) {
+  return {
+    state: 'complete',
+    diagnostics: [],
+    summary: {
+      pensamento: 'high',
+      modelRows: [{
+        provider: 'openai', model: 'model-main', calls: 1,
+        usage: { input: 100, cached: 0, cacheWrite: 0, output: 20, reasoning: 5, total: 120 },
+        costs: { model: 0.01 },
+      }],
+    },
+    aggregate: { calls: 1, input: 100, cached: 0, cacheWrite: 0, output: 20, reasoning: 5, total: 120, custo: 0.01 },
+    entries: [{ transcript_id: 'root-a', modelos: ['model-main'], pensamento: 'high', input: 100, cache_write: 0, cache_read: 0, output: 20, reasoning: 5, total: 120, custo_usd: 0.01 }],
+    content,
+  };
+}
+
+function syntheticSubagents() {
+  return {
+    state: 'complete',
+    diagnostics: [],
+    aggregate: {
+      count: 1, calls: 1, tokens: 50, cost: 0.005, wasted: 0, tools: ['Read'],
+      usage: { input: 40, cached: 0, cacheWrite: 0, output: 10, reasoning: 2 },
+      modelRows: [{ provider: 'openai', model: 'model-child', effort: 'low', calls: 1, usage: { input: 40, cached: 0, cacheWrite: 0, output: 10, reasoning: 2, total: 50 }, cost: 0.005 }],
+    },
+    subagents: [{ id: 'child-a', agentType: 'worker', workflow: '', model: 'model-child', effort: 'low', tools: 1, tokens: 50, cost: 0.005 }],
+    workflows: [],
+  };
+}
+
+test('[req:OBS-11] [req:OBS-12] compose materializes schema 2 with exclusive main and subagent buckets', () => {
+  const sessionContent = '---\ntype: session\nprovider: codex\n---\n\n# Synthetic\n\n## Pendências\n\nNenhuma.\n';
+  const seen = {};
+  const result = composeSessionObservability({
+    sessionContent,
+    frontier: frontier(),
+    roots: { rootPaths: ['root-a.jsonl'], descendantIds: ['child-a'] },
+    allowNone: true,
+  }, {
+    collectMain(input) {
+      seen.main = input;
+      return syntheticMain(input.sessionContent);
+    },
+    collectSubagents(input) {
+      seen.subagents = input;
+      return syntheticSubagents();
+    },
+  });
+
+  assert.equal(result.state, 'complete');
+  assert.equal(result.snapshot.version, 2);
+  assert.deepEqual(result.snapshot.main.entries.map((entry) => entry.transcript_id), ['root-a']);
+  assert.deepEqual(result.snapshot.subagents.subagents.map((entry) => entry.id), ['child-a']);
+  assert.deepEqual(seen.main.rootPaths, ['root-a.jsonl']);
+  assert.deepEqual(seen.subagents.descendantIds, ['child-a']);
+  assert.match(result.content, /^observability_schema: 2$/m);
+  assert.match(result.content, /^subagents_observability_state: 'complete'$/m);
+  assert.match(result.content, /^observability_signal_sequence: 11$/m);
+  assert.match(result.content, /^subagents_diagnostics_json: '\[\]'$/m);
+  assert.match(result.content, /\| Total tokens \| 120 \| 50 \| 170 \|/);
+});
+
+test('[req:OBS-12] stable zero-agent scan materializes none while an isolated signal degrades', () => {
+  const sessionContent = '---\ntype: session\nprovider: codex\nsubagents_count: 9\n---\n\n# Synthetic\n\n## Pendências\n\nNenhuma.\n';
+  const deps = {
+    collectMain: ({ sessionContent: content }) => syntheticMain(content),
+    collectSubagents: () => ({ state: 'none', diagnostics: [], aggregate: { count: 0, calls: 0, tokens: 0, cost: 0, wasted: 0, tools: [], usage: {}, modelRows: [] }, subagents: [], workflows: [], sourceManifest: [{ path: 'synthetic', rolloutId: 'root', size: 1, mtimeMs: 1 }], cache: { version: 1, entries: {} } }),
+  };
+
+  const stable = composeSessionObservability({ sessionContent, frontier: frontier(), roots: {}, allowNone: true }, deps);
+  assert.equal(stable.state, 'none');
+  assert.equal(stable.snapshot.subagents.sourceManifest.length, 1, 'none still carries freshness proof to the runtime store');
+  assert.match(stable.content, /^subagents_count: 0$/m);
+  assert.match(stable.content, /Nenhum subagent registrado/);
+
+  const isolated = composeSessionObservability({ sessionContent, frontier: frontier(), roots: {}, allowNone: false }, deps);
+  assert.equal(isolated.state, 'degraded');
+  assert.equal(isolated.content, sessionContent, 'an isolated SubagentStop cannot erase the previous snapshot');
+});
+
+test('[req:OBS-12] degraded composition sanitizes diagnostics and preserves the prior note byte-for-byte', () => {
+  const previous = '---\ntype: session\nprovider: codex\nobservability_schema: 2\nsubagents_observability_state: \'complete\'\nsubagents_count: 4\n---\n\n# Synthetic\n\n## Agentes, tokens e custos\n\nprevious snapshot\n';
+  const result = composeSessionObservability({
+    sessionContent: previous,
+    frontier: frontier({ signal_sequence: 12 }),
+    roots: {},
+    previousSnapshot: { version: 2, marker: 'previous' },
+  }, {
+    collectMain: ({ sessionContent }) => syntheticMain(sessionContent),
+    collectSubagents: () => ({ state: 'degraded', diagnostics: [{ code: 'CHILD_MISSING', count: 1 }] }),
+  });
+
+  assert.equal(result.state, 'degraded');
+  assert.deepEqual(result.diagnostics, [{ code: 'CHILD_MISSING', count: 1 }]);
+  assert.deepEqual(result.snapshot, { version: 2, marker: 'previous' });
+  assert.equal(result.content, previous);
+});
+
+test('[req:OBS-12] degraded without a prior snapshot preserves numeric fields and never invents none', () => {
+  const original = [
+    '---',
+    'type: session',
+    'provider: codex',
+    'observability_schema: 2',
+    "subagents_observability_state: 'complete'",
+    'subagents_count: 7',
+    'subagents_tokens_total: 321',
+    'subagents_custo_usd: 4.5',
+    'tokens_total_incl_subagents: 654',
+    'custo_total_incl_subagents_usd: 7.25',
+    '---',
+    '',
+    '# Synthetic',
+    '',
+    '## Agentes, tokens e custos',
+    '',
+    'last proven totals',
+    '',
+  ].join('\n');
+  const result = composeSessionObservability({
+    sessionContent: original,
+    frontier: frontier({ signal_sequence: 13 }),
+    roots: {},
+  }, {
+    collectMain: ({ sessionContent }) => syntheticMain(sessionContent),
+    collectSubagents: () => ({
+      state: 'degraded',
+      diagnostics: [{ code: 'CHILD_MISSING', count: 1 }],
+    }),
+  });
+
+  assert.equal(result.state, 'degraded');
+  assert.equal(result.snapshot, null);
+  assert.equal(result.content, original);
+  assert.match(result.content, /^subagents_count: 7$/m);
+  assert.match(result.content, /^subagents_tokens_total: 321$/m);
+  assert.match(result.content, /^subagents_custo_usd: 4\.5$/m);
+  assert.doesNotMatch(result.content, /Nenhum subagent registrado/);
+});
+
+test('[req:OBS-13] registered offline composition reads registry roots without any writer side effect', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wk-observe-offline-'));
   try {
-    const rel = '02-Sessões/session.md';
-    const note = join(vault, rel);
-    mkdirSync(join(vault, '02-Sessões'), { recursive: true });
-    writeFileSync(note, '---\ntype: session\n---\n\n# Sessão\n\n## Pendências\n\nNenhuma.\n');
-    const transcript = join(vault, 'main.jsonl');
-    writeFileSync(transcript, codexTranscript({ id: 'main', model: 'gpt-5.6-sol', effort: 'high', input: 10, cached: 0, output: 5, reasoning: 2 }));
-    writeControl(vault, { status: 'active', session_file: rel, session_id: 'main' });
-    upsertSessionRegistry(vault, 'main', { status: 'active', provider: 'codex', session_file: rel, transcript_path: transcript });
-    assert.equal(refreshSubagents(vault, { transcript_path: transcript, provider: 'codex' }), true);
-    const content = readFileSync(note, 'utf8');
-    assert.match(content, /## Agentes, tokens e custos/);
-    assert.match(content, /\| Reasoning tokens \| 2 \| 0 \| 2 \|/);
-    assert.doesNotMatch(content, /## Uso de tokens e custos|## Subagents & Workflows/);
-  } finally { rmSync(vault, { recursive: true, force: true }); }
+    const transcript = join(root, 'root.jsonl');
+    writeFileSync(transcript, codexTranscript({ id: 'root', model: 'model-main', effort: 'medium', input: 10, cached: 0, output: 5, reasoning: 1 }));
+    const note = join(root, 'session.md');
+    const original = '---\ntype: session\nprovider: codex\n---\n\n# Synthetic\n\n## Pendências\n\nNenhuma.\n';
+    writeFileSync(note, original);
+
+    const candidate = composeRegisteredSessionObservability({
+      sessionContent: original,
+      sessionEntry: {
+        session_id: 'session-synthetic',
+        provider: 'codex',
+        transcript_path: transcript,
+        active_activation_id: 'activation-synthetic',
+        activation_epoch: 1,
+        last_turn_sequence: 2,
+      },
+      canonicalConversationId: 'session-synthetic',
+      runtimeState: { observability_signal_sequence: 0, signals: [], graph_cache: null },
+      mode: 'offline',
+    });
+
+    assert.equal(candidate.state, 'none');
+    assert.match(candidate.content, /^observability_schema: 2$/m);
+    assert.equal(readFileSync(note, 'utf8'), original, 'pure preview must not write the session note');
+    assert.equal(existsSync(join(root, '.brain')), false, 'pure preview must not create runtime state');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/tests/session-stop-migration-lifecycle.test.mjs
+++ b/tests/session-stop-migration-lifecycle.test.mjs
@@ -399,7 +399,7 @@ test('[req:MEM-STOP-4] concurrent activation between Stop CAS and staging preser
 import { main } from ${JSON.stringify(stopModule)};
 import { stageStopMemoryAttempt } from ${JSON.stringify(lifecycleModule)};
 import { mutateSessionRegistry, openActivation } from ${JSON.stringify(commonModule)};
-main({
+await main({
   stageMemory(vaultBase, context) {
     mutateSessionRegistry(vaultBase, (registry) => {
       const next = openActivation(registry, {

--- a/tests/subagent-observability-lifecycle.test.mjs
+++ b/tests/subagent-observability-lifecycle.test.mjs
@@ -1,0 +1,376 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { refreshSubagents } from '../hooks/subagent-stop.mjs';
+import { refreshStopObservability } from '../hooks/session-stop.mjs';
+
+function fixture() {
+  const vaultBase = mkdtempSync(join(tmpdir(), 'wk-observability-hook-'));
+  const sessionRel = join('02-Sessões', 'synthetic-session.md');
+  const sessionPath = join(vaultBase, sessionRel);
+  mkdirSync(join(vaultBase, '02-Sessões'), { recursive: true });
+  writeFileSync(sessionPath, '---\ntype: session\nprovider: codex\n---\n\n# Synthetic session\n');
+  return {
+    vaultBase,
+    sessionRel,
+    sessionPath,
+    rootA: join(vaultBase, 'root-a.jsonl'),
+    rootB: join(vaultBase, 'root-b.jsonl'),
+  };
+}
+
+function registryEntry(fx, {
+  activationId = 'activation-a',
+  epoch = 2,
+  turnSequence = 7,
+} = {}) {
+  return {
+    provider: 'codex',
+    session_file: fx.sessionRel,
+    transcript_path: fx.rootA,
+    transcript_paths: [fx.rootA, fx.rootB],
+    active_activation_id: activationId,
+    activation_epoch: epoch,
+    last_turn_sequence: turnSequence,
+    activations: {
+      [activationId]: {
+        activation_id: activationId,
+        epoch,
+        status: 'active',
+        last_turn_sequence: turnSequence,
+      },
+    },
+  };
+}
+
+function resolved(input, entry) {
+  return {
+    identity: {
+      state: 'resolved',
+      provider: 'codex',
+      canonicalConversationId: 'session-alpha',
+      transcriptPath: input.transcript_path,
+      transcriptId: basename(input.transcript_path, '.jsonl'),
+    },
+    entry,
+  };
+}
+
+function registryMutation(entry) {
+  const registry = { version: 2, sessions: { 'session-alpha': entry } };
+  return (_vault, mutator) => mutator(registry);
+}
+
+function childMeta(path) {
+  const id = basename(path, '.jsonl');
+  return {
+    ok: true,
+    meta: {
+      id,
+      session_id: 'session-alpha',
+      source: {
+        subagent: {
+          thread_spawn: { parent_thread_id: 'root-a', depth: 1 },
+        },
+      },
+    },
+    lineBytes: 128,
+  };
+}
+
+test('[req:OBS-11] rajada de SubagentStop publica uma vez pela maior sequence após 250 ms', async () => {
+  const fx = fixture();
+  try {
+    const entry = registryEntry(fx);
+    const events = [];
+    const sleepers = [];
+    const signals = new Map();
+    let sequence = 0;
+
+    const deps = {
+      now: () => 1_000,
+      sleep: (ms) => new Promise((resolve) => {
+        events.push(`sleep:${ms}`);
+        sleepers.push(resolve);
+      }),
+      resolveEntry: (_vault, input) => resolved(input, entry),
+      readMeta: childMeta,
+      mutateRegistry: registryMutation(entry),
+      recordSignal: (_vault, _sessionId, signal) => {
+        assert.equal(signal.parent_thread_id, 'root-a');
+        assert.equal(signal.kind, 'started');
+        events.push(`signal:${signal.rollout_id}`);
+        if (!signals.has(signal.rollout_id)) signals.set(signal.rollout_id, ++sequence);
+        return {
+          recorded: true,
+          duplicate: false,
+          sequence: signals.get(signal.rollout_id),
+          state: { observability_dirty: true, observability_signal_sequence: sequence },
+        };
+      },
+      readStore: () => ({
+        observability_dirty: true,
+        observability_signal_sequence: sequence,
+        signals: [...signals].map(([rollout_id]) => ({ rollout_id })),
+        graph_cache: { fixture: 'cached' },
+      }),
+      acquireLease: (_vault, _sessionId, lease) => {
+        events.push(`lease:${lease.signalSequence}`);
+        return {
+          acquired: true,
+          ownerToken: 'lease-owner',
+          state: {
+            signals: [...signals].map(([rollout_id]) => ({ rollout_id })),
+            graph_cache: { fixture: 'cached' },
+          },
+        };
+      },
+      releaseLease: () => {
+        events.push('release');
+        return { released: true };
+      },
+      resolveRoots: () => ({
+        state: 'complete',
+        rootPaths: [fx.rootA, fx.rootB],
+        descendantPaths: [],
+        diagnostics: [],
+      }),
+      materialize: async (request) => {
+        events.push(`publish:${request.signalSequence}`);
+        assert.deepEqual(request.rootPaths, [fx.rootA, fx.rootB]);
+        assert.equal(request.transcriptPath, fx.rootA, 'o filho nunca vira main');
+        assert.equal(request.allowNone, false, 'SubagentStop nunca autoriza publicação none');
+        assert.equal(request.deadlineAt, 16_000, 'deadline absoluto nasce na entrada do hook');
+        assert.equal(request.frontier.signal_sequence, 3);
+        assert.deepEqual(request.signals.map((signal) => signal.rollout_id), [
+          'child-a', 'child-b', 'child-c',
+        ]);
+        assert.deepEqual(request.cache, { fixture: 'cached' });
+        assert.equal(request.withPublicationGuard(request.frontier, (guardContext) => {
+          assert.equal(guardContext.entry.observability_signal_sequence, 3);
+          assert.equal(
+            request.readRuntimeFrontier(request.frontier, guardContext).signal_sequence,
+            3,
+          );
+          return true;
+        }), true, 'CAS roda sob a guarda do registry');
+        return { status: 'published' };
+      },
+    };
+
+    const pending = ['child-a', 'child-b', 'child-c'].map((id) => (
+      refreshSubagents(fx.vaultBase, {
+        provider: 'codex',
+        transcript_path: join(fx.vaultBase, `${id}.jsonl`),
+      }, deps)
+    ));
+    await Promise.resolve();
+
+    assert.equal(sleepers.length, 3, 'todos os sinais são persistidos antes da janela');
+    sleepers.forEach((resolve) => resolve());
+    assert.deepEqual(await Promise.all(pending), [true, true, true]);
+
+    assert.deepEqual(events.filter((event) => event.startsWith('signal:')), [
+      'signal:child-a',
+      'signal:child-b',
+      'signal:child-c',
+    ]);
+    assert.deepEqual(events.filter((event) => event.startsWith('lease:')), ['lease:3']);
+    assert.deepEqual(events.filter((event) => event.startsWith('publish:')), ['publish:3']);
+    assert.equal(events.filter((event) => event === 'release').length, 1);
+  } finally {
+    rmSync(fx.vaultBase, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-11] SubagentStop respeita deadline absoluto de 15 s e mantém dirty', async () => {
+  const fx = fixture();
+  try {
+    const entry = registryEntry(fx);
+    let nowCalls = 0;
+    let materializations = 0;
+    let leases = 0;
+    const result = await refreshSubagents(fx.vaultBase, {
+      provider: 'codex',
+      transcript_path: join(fx.vaultBase, 'child-deadline.jsonl'),
+    }, {
+      now: () => (++nowCalls === 1 ? 10_000 : 25_000),
+      sleep: async (ms) => assert.equal(ms, 250),
+      resolveEntry: (_vault, input) => resolved(input, entry),
+      readMeta: childMeta,
+      mutateRegistry: registryMutation(entry),
+      recordSignal: () => ({
+        recorded: true,
+        duplicate: false,
+        sequence: 1,
+        state: { observability_dirty: true, observability_signal_sequence: 1 },
+      }),
+      readStore: () => ({ observability_dirty: true, observability_signal_sequence: 1 }),
+      acquireLease: () => { leases += 1; return { acquired: true, ownerToken: 'late' }; },
+      releaseLease: () => ({ released: true }),
+      resolveRoots: () => ({ state: 'complete', rootPaths: [fx.rootA], diagnostics: [] }),
+      materialize: () => { materializations += 1; return { status: 'published' }; },
+    });
+
+    assert.equal(result, true, 'o sinal foi aceito mesmo quando materialização não coube');
+    assert.equal(leases, 0, 'não inicia lease sem orçamento restante');
+    assert.equal(materializations, 0);
+  } finally {
+    rmSync(fx.vaultBase, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-11] activation, turn ou signal mais novo impedem SubagentStop atrasado', async () => {
+  const fx = fixture();
+  try {
+    const original = registryEntry(fx);
+    for (const stale of ['activation', 'turn', 'signal']) {
+      let resolves = 0;
+      let materializations = 0;
+      let releases = 0;
+      const newer = stale === 'activation'
+        ? registryEntry(fx, { activationId: 'activation-b', epoch: 3 })
+        : stale === 'turn'
+          ? registryEntry(fx, { turnSequence: 8 })
+          : original;
+      const result = await refreshSubagents(fx.vaultBase, {
+        provider: 'codex',
+        transcript_path: join(fx.vaultBase, `child-${stale}.jsonl`),
+      }, {
+        now: () => 1_000,
+        sleep: async () => {},
+        resolveEntry: (_vault, input) => resolved(input, ++resolves === 1 ? original : newer),
+        readMeta: childMeta,
+        mutateRegistry: registryMutation(original),
+        recordSignal: () => ({
+          recorded: true,
+          duplicate: false,
+          sequence: 1,
+          state: { observability_dirty: true, observability_signal_sequence: 1 },
+        }),
+        readStore: () => ({
+          observability_dirty: true,
+          observability_signal_sequence: stale === 'signal' ? 2 : 1,
+        }),
+        acquireLease: () => ({ acquired: true, ownerToken: `owner-${stale}` }),
+        releaseLease: () => { releases += 1; return { released: true }; },
+        resolveRoots: () => ({ state: 'complete', rootPaths: [fx.rootA], diagnostics: [] }),
+        materialize: () => { materializations += 1; return { status: 'published' }; },
+      });
+
+      assert.equal(result, true, `${stale}: sinal permanece para convergência posterior`);
+      assert.equal(materializations, 0, `${stale}: candidate atrasado não publica`);
+      assert.equal(releases, stale === 'signal' ? 0 : 1, `${stale}: lease adquirida é liberada`);
+    }
+  } finally {
+    rmSync(fx.vaultBase, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-12] SessionStop usa gate causal, todos os roots e deadline entry +45 s', async () => {
+  const fx = fixture();
+  try {
+    const entry = registryEntry(fx);
+    const requests = [];
+    const base = {
+      vaultBase: fx.vaultBase,
+      input: { provider: 'codex', transcript_path: fx.rootA },
+      sessionPath: fx.sessionPath,
+      sessionId: 'session-alpha',
+      entry,
+      causalStop: {
+        canPromoteMemory: true,
+        activationId: 'activation-a',
+        activation: { epoch: 2 },
+      },
+      turnSequence: 7,
+      hookStartedAt: 2_000,
+    };
+    const deps = {
+      now: () => 3_000,
+      resolveEntry: (_vault, input) => resolved(input, entry),
+      mutateRegistry: registryMutation(entry),
+      readStore: () => ({ observability_signal_sequence: 4 }),
+      resolveRoots: () => ({
+        state: 'complete', rootPaths: [fx.rootA, fx.rootB], diagnostics: [],
+      }),
+      materialize: async (request) => {
+        requests.push(request);
+        assert.equal(request.withPublicationGuard(request.frontier, (guardContext) => {
+          assert.equal(guardContext.entry.active_activation_id, 'activation-a');
+          return true;
+        }), true);
+        return { status: 'published' };
+      },
+    };
+
+    assert.equal(await refreshStopObservability(base, deps), true);
+    assert.equal(requests.length, 1);
+    assert.deepEqual(requests[0].rootPaths, [fx.rootA, fx.rootB]);
+    assert.equal(requests[0].deadlineAt, 47_000);
+    assert.equal(requests[0].signalSequence, 4);
+    assert.equal(requests[0].frontier.signal_sequence, 4);
+    assert.equal(requests[0].allowNone, true, 'Stop causal pode comprovar none');
+
+    requests.length = 0;
+    assert.equal(await refreshStopObservability({
+      ...base,
+      causalStop: { ...base.causalStop, canPromoteMemory: false },
+    }, deps), false);
+    assert.equal(requests.length, 0, 'gate causal rejeitado impede composição/publicação');
+  } finally {
+    rmSync(fx.vaultBase, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-12] SessionStop stale ou no limite do deadline não publica', async () => {
+  const fx = fixture();
+  try {
+    const original = registryEntry(fx);
+    const base = {
+      vaultBase: fx.vaultBase,
+      input: { provider: 'codex', transcript_path: fx.rootA },
+      sessionPath: fx.sessionPath,
+      sessionId: 'session-alpha',
+      entry: original,
+      causalStop: {
+        canPromoteMemory: true,
+        activationId: 'activation-a',
+        activation: { epoch: 2 },
+      },
+      turnSequence: 7,
+      hookStartedAt: 5_000,
+    };
+
+    for (const stale of ['activation', 'turn', 'signal', 'deadline']) {
+      let materializations = 0;
+      const freshEntry = stale === 'activation'
+        ? registryEntry(fx, { activationId: 'activation-b', epoch: 3 })
+        : stale === 'turn'
+          ? registryEntry(fx, { turnSequence: 8 })
+          : original;
+      const result = await refreshStopObservability({
+        ...base,
+        expectedSignalSequence: 4,
+      }, {
+        now: () => (stale === 'deadline' ? 50_000 : 6_000),
+        resolveEntry: (_vault, input) => resolved(input, freshEntry),
+        readStore: () => ({ observability_signal_sequence: stale === 'signal' ? 5 : 4 }),
+        resolveRoots: () => ({ state: 'complete', rootPaths: [fx.rootA], diagnostics: [] }),
+        materialize: () => { materializations += 1; return { status: 'published' }; },
+      });
+
+      assert.equal(result, false, stale);
+      assert.equal(materializations, 0, `${stale}: nenhuma publicação`);
+    }
+  } finally {
+    rmSync(fx.vaultBase, { recursive: true, force: true });
+  }
+});

--- a/tests/tarball-smoke.test.mjs
+++ b/tests/tarball-smoke.test.mjs
@@ -15,6 +15,13 @@ import { HOOK_FILES } from '../src/taxonomy.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = join(here, '..');
+const OBSERVABILITY_HOOK_MODULES = Object.freeze([
+  'codex-rollout-meta.mjs',
+  'codex-subagent-graph.mjs',
+  'session-observability-state.mjs',
+  'session-observability-store.mjs',
+  'session-observability-lifecycle.mjs',
+]);
 
 // Files that `npm publish` would include, per `npm pack`.
 // Command is a single string with shell:true (npm is a .cmd shim on Windows); this
@@ -63,6 +70,24 @@ test('every relative import in hooks/ resolves to a published file', () => {
       );
     }
   }
+});
+
+test('[req:OBS-3] [req:OBS-11] [req:OBS-12] Codex observability modules ship together', () => {
+  const published = publishedFiles();
+  for (const file of OBSERVABILITY_HOOK_MODULES) {
+    assert.ok(published.has(`hooks/${file}`), `missing observability module: hooks/${file}`);
+  }
+});
+
+test('[req:OBS-14] published tarball excludes local vault and runtime state', () => {
+  const published = [...publishedFiles()];
+  const forbidden = published.filter((path) => (
+    /(^|\/)\.brain(?:\/|$)/i.test(path)
+    || /(^|\/)\.[^/]+-vault(?:\/|$)/i.test(path)
+    || /(^|\/)(?:SESSION_REGISTRY\.json|CURRENT_SESSION\.md|MEMORY_EVENTS\.jsonl|SHARED_MEMORY\.md)$/i.test(path)
+  ));
+
+  assert.deepEqual(forbidden, []);
 });
 
 test('every published hook passes node --check (no broken syntax shipped)', () => {
@@ -204,6 +229,10 @@ test('[req:MOD-4] [req:MOD-6] [req:MOD-9] [req:MOD-10] [req:MOD-11] [req:MOD-12]
       "const legacyCommon = await import('wendkeep/hooks/obsidian-common.mjs');",
       "const legacyUsage = await import('wendkeep/hooks/token-usage.mjs');",
       "const legacySessionStop = await import('wendkeep/hooks/session-stop.mjs');",
+      `const observabilitySpecifiers = ${JSON.stringify(
+        OBSERVABILITY_HOOK_MODULES.map((file) => `wendkeep/hooks/${file}`),
+      )};`,
+      "for (const specifier of observabilitySpecifiers) await import(specifier);",
       "if (typeof vault.resolveProjectVault !== 'function') process.exit(11);",
       "if (typeof legacy.assertVaultPathSafe !== 'function') process.exit(12);",
       "const shared = vault.renderSharedMemory({ updatedAt: '2026-07-28T00:00:00.000Z', reviewAfter: '2026-08-04T00:00:00.000Z' });",

--- a/tests/token-usage-content.test.mjs
+++ b/tests/token-usage-content.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  parseTokenUsageFromContent,
+  parseTokenUsageFromTranscript,
+  summarizeTokenUsage,
+} from '../hooks/token-usage.mjs';
+
+test('[req:OBS-3] parsing an already-read rollout is identical to parsing the file wrapper', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wk-usage-content-'));
+  try {
+    const transcriptPath = join(root, 'synthetic.jsonl');
+    const content = [
+      { type: 'session_meta', payload: { id: 'synthetic', session_id: 'synthetic', model: 'gpt-5.6-sol', model_provider: 'openai' } },
+      { type: 'turn_context', payload: { model: 'gpt-5.6-sol', model_provider: 'openai', effort: 'high' } },
+      { type: 'event_msg', payload: { type: 'user_message', message: 'synthetic request' } },
+      { type: 'event_msg', payload: { type: 'token_count', info: { model: 'gpt-5.6-sol', last_token_usage: { input_tokens: 123, cached_input_tokens: 23, output_tokens: 7 } } } },
+    ].map(JSON.stringify).join('\n') + '\n';
+    writeFileSync(transcriptPath, content);
+
+    const fromContent = summarizeTokenUsage(parseTokenUsageFromContent(content, { transcriptPath }));
+    const fromFile = summarizeTokenUsage(parseTokenUsageFromTranscript(transcriptPath));
+    assert.deepEqual(fromContent, fromFile);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/wendkeep.sensors.json
+++ b/wendkeep.sensors.json
@@ -98,6 +98,14 @@
       "command": "node --test tests/session-stop-migration-lifecycle.test.mjs tests/memory-activation.test.mjs tests/session-memory-lifecycle.test.mjs tests/vault-health-memory.test.mjs"
     },
     {
+      "id": "privacy-hygiene",
+      "name": "Privacy hygiene",
+      "description": "Rejects non-allowlisted observability diagnostics and sensitive data in persistable fixtures, evidence and staged changes",
+      "severity": "critical",
+      "type": "command",
+      "command": "node scripts/privacy-hygiene.mjs"
+    },
+    {
       "id": "memory-recovery",
       "name": "Memory recovery",
       "description": "Exercises projected-attempt acknowledgement recovery, causal safety, topology defenses and diagnostics",


### PR DESCRIPTION
## Resumo

- reconstrói o grafo recursivo de rollouts Codex e separa roots principais de descendentes sem dupla contagem;
- coalesce `SubagentStop` e `SessionStop` sob frontier causal, CAS e estados explícitos `complete|none|degraded`;
- torna import, rebuild e doctor conscientes de observabilidade stale/degraded, com recuperação idempotente e fail-closed;
- adiciona sensor de privacidade, cobertura TDD discriminante e documentação bilíngue;
- prepara a release `0.66.5` em package, lockfile, CHANGELOG e definições gerenciadas.

## Causa raiz

A leitura de metadata limitava o arquivo inteiro em vez da primeira linha, o fallback histórico usava uma janela curta e a descoberta dependia do pai direto. Além disso, `SubagentStop` podia tratar o transcript filho como atividade principal. Em sessões grandes, retomadas e netos ficavam ausentes ou contaminavam os buckets de uso.

## Impacto

Sessões Codex passam a materializar o grafo comprovado de subagentes, preservando roots top-level em `main`. Evidência incompleta produz diagnóstico `degraded` e não sobrescreve snapshots históricos com zero ou associações inferidas.

## Verificação

- `wendkeep verify --deep`: 8/8 sensores;
- verdict independente: `ok: true`, 7/7 requisitos, zero blockers;
- 29/29 tarefas concluídas;
- testes pós-reseed de release, tarball e sync-defs: 24/24;
- `npm run check`;
- sensor `privacy-hygiene`;
- `git diff --check`;
- tarball confirma módulos de observabilidade presentes e ausência de vault/runtime local.