### PR TITLE
feat: rotas adaptativas e saneamento de sessões (0.67.0)

### DIFF
--- a/.agents/skills/example-skill/.wendkeep-meta.json
+++ b/.agents/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.5",
+  "wendkeepVersion": "0.67.0",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.agents/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.agents/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.5",
+  "wendkeepVersion": "0.67.0",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.agents/skills/wk-debugging/.wendkeep-meta.json
+++ b/.agents/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.5",
+  "wendkeepVersion": "0.67.0",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.agents/skills/wk-planning/.wendkeep-meta.json
+++ b/.agents/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.5",
+  "wendkeepVersion": "0.67.0",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.agents/skills/wk-tdd/.wendkeep-meta.json
+++ b/.agents/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.5",
+  "wendkeepVersion": "0.67.0",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.agents/skills/wk-verify/.wendkeep-meta.json
+++ b/.agents/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.5",
+  "wendkeepVersion": "0.67.0",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.agents/skills/wk-workflow/.wendkeep-meta.json
+++ b/.agents/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.5",
-  "sourceHash": "c3299e94ce34103fb599744eabec7aec581aefc6fd7c6b959e0350293ee5d8bf"
+  "wendkeepVersion": "0.67.0",
+  "sourceHash": "ee0cb172a5b5bbd2ebb5c7e4039ba1a9081992f0461da98d508a5cba67ab23db"
 }

--- a/.agents/skills/wk-workflow/SKILL.md
+++ b/.agents/skills/wk-workflow/SKILL.md
@@ -1,12 +1,30 @@
 ---
 name: wk-workflow
-description: Use quando o usuário pedir para implementar, criar, corrigir, refatorar, adicionar ou alterar código: leia o perfil efetivo e roteie OFF/FLOW/GUIDE/GOVERN/ASSURE ANTES de editar. Keep Core permanece ativo; GOVERN é o padrão compatível.
+description: Use quando o usuário pedir para implementar, criar, corrigir, refatorar, adicionar ou alterar código: classifique e registre a rota temporária FLOW/GUIDE/GOVERN/ASSURE ANTES de editar, então siga o perfil efetivo. Keep Core permanece ativo; OFF nunca é automático.
 ---
 # Perfis de Operação — roteador de trabalho do wendkeep
 
 Use ao começar implementação, correção ou refatoração. **Keep Core permanece sempre ativo**
 em todos os perfis: Vault, sessão, identidade, memória, lessons e persistência. Na ausência de
 configuração válida, **GOVERN é o padrão** compatível.
+
+## Seleção temporária por solicitação
+
+Antes de editar, classifique a implementação atual e registre a escolha auditável com
+`wendkeep profile route <FLOW|GUIDE|GOVERN|ASSURE> --session <id> --reason <texto>`.
+A lease vale somente para a solicitação atual; ao encerrá-la, o perfil persistente da
+sessão/projeto volta a valer. **OFF nunca é uma escolha automática da LLM**: somente uma pessoa
+pode persistir `profile use OFF` explicitamente.
+
+- **FLOW:** ajuste local, reversível e de escopo fechado, sem contrato/spec, segurança,
+  dependência, CI/release ou policy.
+- **GUIDE:** mudança compacta de comportamento que precisa de change/spec, sem revisão formal.
+- **GOVERN:** escolha conservadora em caso de dúvida ou risco e para superfícies sensíveis.
+- **ASSURE:** GOVERN quando confirmação explícita e handoff fazem parte do contrato.
+
+O harness da LLM faz essa classificação semântica; o Wend Runtime valida e aplica a lease.
+Se não houver uma sessão causal identificada ou o comando falhar, não fabrique estado: use o
+perfil efetivo já injetado e trate `GOVERN` como fallback conservador quando ele for o padrão.
 
 <HARD-GATE>
 Antes de editar, leia o **perfil efetivo** injetado pelo WendKeep e siga somente sua rota:

--- a/.claude/skills/example-skill/.wendkeep-meta.json
+++ b/.claude/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.5",
+  "wendkeepVersion": "0.67.0",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.claude/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.claude/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.5",
+  "wendkeepVersion": "0.67.0",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.claude/skills/wk-debugging/.wendkeep-meta.json
+++ b/.claude/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.5",
+  "wendkeepVersion": "0.67.0",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.claude/skills/wk-planning/.wendkeep-meta.json
+++ b/.claude/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.5",
+  "wendkeepVersion": "0.67.0",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.claude/skills/wk-tdd/.wendkeep-meta.json
+++ b/.claude/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.5",
+  "wendkeepVersion": "0.67.0",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.claude/skills/wk-verify/.wendkeep-meta.json
+++ b/.claude/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.5",
+  "wendkeepVersion": "0.67.0",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.claude/skills/wk-workflow/.wendkeep-meta.json
+++ b/.claude/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.66.5",
-  "sourceHash": "c3299e94ce34103fb599744eabec7aec581aefc6fd7c6b959e0350293ee5d8bf"
+  "wendkeepVersion": "0.67.0",
+  "sourceHash": "ee0cb172a5b5bbd2ebb5c7e4039ba1a9081992f0461da98d508a5cba67ab23db"
 }

--- a/.claude/skills/wk-workflow/SKILL.md
+++ b/.claude/skills/wk-workflow/SKILL.md
@@ -1,12 +1,30 @@
 ---
 name: wk-workflow
-description: Use quando o usuário pedir para implementar, criar, corrigir, refatorar, adicionar ou alterar código: leia o perfil efetivo e roteie OFF/FLOW/GUIDE/GOVERN/ASSURE ANTES de editar. Keep Core permanece ativo; GOVERN é o padrão compatível.
+description: Use quando o usuário pedir para implementar, criar, corrigir, refatorar, adicionar ou alterar código: classifique e registre a rota temporária FLOW/GUIDE/GOVERN/ASSURE ANTES de editar, então siga o perfil efetivo. Keep Core permanece ativo; OFF nunca é automático.
 ---
 # Perfis de Operação — roteador de trabalho do wendkeep
 
 Use ao começar implementação, correção ou refatoração. **Keep Core permanece sempre ativo**
 em todos os perfis: Vault, sessão, identidade, memória, lessons e persistência. Na ausência de
 configuração válida, **GOVERN é o padrão** compatível.
+
+## Seleção temporária por solicitação
+
+Antes de editar, classifique a implementação atual e registre a escolha auditável com
+`wendkeep profile route <FLOW|GUIDE|GOVERN|ASSURE> --session <id> --reason <texto>`.
+A lease vale somente para a solicitação atual; ao encerrá-la, o perfil persistente da
+sessão/projeto volta a valer. **OFF nunca é uma escolha automática da LLM**: somente uma pessoa
+pode persistir `profile use OFF` explicitamente.
+
+- **FLOW:** ajuste local, reversível e de escopo fechado, sem contrato/spec, segurança,
+  dependência, CI/release ou policy.
+- **GUIDE:** mudança compacta de comportamento que precisa de change/spec, sem revisão formal.
+- **GOVERN:** escolha conservadora em caso de dúvida ou risco e para superfícies sensíveis.
+- **ASSURE:** GOVERN quando confirmação explícita e handoff fazem parte do contrato.
+
+O harness da LLM faz essa classificação semântica; o Wend Runtime valida e aplica a lease.
+Se não houver uma sessão causal identificada ou o comando falhar, não fabrique estado: use o
+perfil efetivo já injetado e trate `GOVERN` como fallback conservador quando ele for o padrão.
 
 <HARD-GATE>
 Antes de editar, leia o **perfil efetivo** injetado pelo WendKeep e siga somente sua rota:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,15 @@
 <!-- wendkeep:skills:start -->
-<!-- wendkeep-version: 0.66.5; skills-sha256: 36ebe0728fe02c48230802722405c3179cb460f289429505e341db582542b82d -->
+<!-- wendkeep-version: 0.67.0; skills-sha256: d170f56e18f94318178d4062b722c40275d07c10e76021f95d16f441d498328d -->
 ## wendkeep — Keep Core & operating profiles
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. **Keep Core is always active**
 in every profile: Vault, session, identity, memory, lessons, and persistence integrations.
-The effective profile is selected explicitly; missing or invalid configuration uses **GOVERN as the default**.
+The persistent profile is selected explicitly; missing or invalid configuration uses **GOVERN as the default**.
+
+Before an implementation, the native LLM harness classifies the current request and may create a
+task-scoped lease with `wendkeep profile route <FLOW|GUIDE|GOVERN|ASSURE> --session <id> --reason <text>`.
+The lease expires when that request ends and the persistent session/project profile becomes
+effective again. **OFF is never selected adaptively**; only a human can persist `profile use OFF`.
 
 Route work by the effective profile:
 - **OFF** — Wend Runtime is disabled and governance belongs to the native LLM harness; Keep Core stays active.
@@ -26,7 +31,7 @@ Process skills (full text in `.claude/skills/`, `.agents/skills/`, and the vault
 - **wk-planning** — Use após um design aprovado ou um plano aceito (inclusive plan mode) — decompõe em plano de tarefas TDD bite-sized e registra na change ativa.
 - **wk-tdd** — Use ao implementar qualquer comportamento — Red/Green/Refactor com testes que discriminam (derivados do spec, litmus não-raso, adequação).
 - **wk-verify** — Use no verify deep — passe independente read-only (autor≠verificador) que re-deriva a cobertura do spec e grava verdict.json.
-- **wk-workflow** — Use quando o usuário pedir para implementar, criar, corrigir, refatorar, adicionar ou alterar código: leia o perfil efetivo e roteie OFF/FLOW/GUIDE/GOVERN/ASSURE ANTES de editar. Keep Core permanece ativo; GOVERN é o padrão compatível.
+- **wk-workflow** — Use quando o usuário pedir para implementar, criar, corrigir, refatorar, adicionar ou alterar código: classifique e registre a rota temporária FLOW/GUIDE/GOVERN/ASSURE ANTES de editar, então siga o perfil efetivo. Keep Core permanece ativo; OFF nunca é automático.
 <!-- wendkeep:skills:end -->
 
 ## Contribuição — PR por implementação (regra do projeto)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.67.0] — 2026-08-01
+
+### Added
+
+- **O harness da LLM pode selecionar uma rota Wend temporária por solicitação.**
+  `profile route <FLOW|GUIDE|GOVERN|ASSURE> --session <id> --reason <texto>` grava uma lease
+  auditável ligada ao prompt atual, sem alterar o perfil persistente do projeto ou da sessão.
+  `OFF` permanece exclusivamente humano e é rejeitado na seleção adaptativa. Contexto sem prompt
+  causal completo e coincidente no registry falha antes de mutar, e `profile status --session`
+  mostra perfil-base e estado da lease também na saída humana.
+- **A lease expira causalmente sem interromper implementações longas.** Um Stop aceito a consome
+  por CAS; bloqueio/retry a preserva, e o próximo prompt restaura o perfil-base mesmo depois de
+  crash ou hook ausente. Skills e AGENTS gerados ensinam a matriz FLOW/GUIDE/GOVERN/ASSURE.
+
+### Fixed
+
+- **Sessões Obsidian não renderizam envelopes internos do assistente como HTML.** A captura remove
+  metadata completa ou truncada de citação somente das respostas do assistente e escapa tags
+  XML-like nas linhas geradas, preservando relatos do usuário e autolinks HTTP(S). Reimport e
+  `SessionStop` convergem no mesmo normalizador idempotente, e o encerramento migra somente campos
+  gerados reconhecíveis de notas antigas sem reescrever prosa autoral.
+- **README e guias bilíngues explicam as letras `P/R/E/V/C` e a duração das escolhas.** A
+  documentação distingue `profile use` persistente de `profile route` por solicitação e deixa
+  explícito que a classificação semântica pertence ao harness, não a heurísticas do runtime.
+- **Sensores vermelhos deixam diagnóstico acionável sem persistir logs verdes.** O runner captura
+  stdout/stderr com limite, redige segredos e grava no máximo 2.000 caracteres apenas na entrada
+  vermelha de `evidencia.json`, em vez de descartar a causa da falha.
+
 ## [0.66.5] — 2026-08-01
 
 ### Fixed

--- a/README.en.md
+++ b/README.en.md
@@ -15,6 +15,10 @@
 
 **Persistent memory for AI coding agents, built on your Obsidian vault.** Every Claude Code **and Codex** session is captured turn by turn into local Markdown — `init` wires both (Codex asks you to approve its hooks once; `import` backfills past sessions either way) — with token/cost tracking and automatically extracted decisions, bugs, and learnings. That always-on plane is **Keep Core**. On top of it, **Wend Runtime** provides a native, zero-dependency lifecycle (spec → change → TDD → sensor-gated archive), selected through the `OFF`, `FLOW`, `GUIDE`, `GOVERN`, and `ASSURE` Operating Profiles. 100% local, open-core.
 
+When projecting sessions, trailing internal metadata is removed only from assistant responses;
+user reports remain intact. XML-like tags are written as escaped text so Obsidian Reading view
+does not interpret them as HTML.
+
 The runtime is being separated into six physical boundaries — `cli`, `harness`, `vault`, `mcp`,
 `integrations`, and `pi` — without fragmenting installation. The private `cli`, `harness`,
 `vault`, `mcp`, and `integrations` workspaces now canonically own the executable runtime,
@@ -235,13 +239,82 @@ deliberate opt-in and runs that command's own validations:
 | `GOVERN` | P → R → E → V | Current a2 loop and compatible fallback. |
 | `ASSURE` | P → R → E → V → C | Governance with confirmation and handoff. |
 
+A route is a sequence of work stages, not a list of command names:
+
+- `P` = **Plan/Propose** — understand the request, bound the scope, and record the approach when a change is needed.
+- `R` = **Review** — inspect the proposal/design before execution; this is the formal a2-loop review.
+- `E` = **Execute** — edit the permitted code or artifacts.
+- `V` = **Validate** — run tests, sensors, and checks and record evidence.
+- `C` = **Confirm/hand off** — obtain explicit confirmation and complete the handoff.
+
+Thus, `P → R → E → V` means “plan/propose, review, execute, and validate”. `FLOW` starts at the
+execution/validation microcontract; `OFF` applies no automatic Wend route and returns process
+ownership to the native LLM harness.
+
+### Who selects the profile, and for how long?
+
+The LLM harness (Codex, Claude, or another agent) **classifies the current implementation** and can
+record a temporary choice with `wendkeep profile route`. Wend Runtime does not interpret prompt
+text or use diff size, heuristics, or environment variables: it validates the choice, applies the
+route in hooks, and expires the lease when the request ends. With no recorded route, the configured
+base profile remains effective.
+
+Resolution follows this order:
+
+1. a valid lease for the current request in `SESSION_REGISTRY.json`;
+2. a persistent session override in that registry;
+3. `harness.profile` in the project's `.wendkeep.json`;
+4. `GOVERN` when no valid setting exists.
+
+Without `--session`, `profile use` changes the **project default** for conversations/hooks that do
+not have a session override. With `--session <id>`, it changes only that session and leaves the
+project default untouched. Therefore, `profile use OFF` without `--session` is not an isolated
+test: it writes the project binding and can be shared if `.wendkeep.json` is committed.
+
+`profile route` is different: it requires `--session` and `--reason`, accepts only `FLOW`, `GUIDE`,
+`GOVERN`, or `ASSURE`, does not rewrite the project/persistent override, and applies only to the
+current causal prompt. An accepted `Stop` consumes the lease; if the process dies first, the next
+prompt advances the sequence and makes the old lease ineffective. `OFF` is never selected
+automatically.
+
+```bash
+npx wendkeep profile status
+npx wendkeep profile use GUIDE                 # project default
+npx wendkeep profile use FLOW --session <id>   # one session only
+npx wendkeep profile route FLOW --session <id> --reason "local fix"  # current request
+npx wendkeep profile status --session <id>     # session-effective profile
+```
+
+In human `status --session` output, `base=<profile>/<source>` and `lease=<state>` accompany the
+effective profile; `--json` exposes the same data as `base_profile`, `base_source`, and
+`task_lease`. `profile route` only accepts a session after `UserPromptSubmit` has recorded a
+positive causal turn and sequence that agree in the registry.
+
+### Which profile fits a simple request?
+
+“Small” describes size, not risk. The harness uses this matrix to choose and record a temporary
+route; semantic inference remains in the agent, not Wend Runtime:
+
+| Situation | Suggested profile |
+|---|---|
+| Question, inspection, or diagnosis with no mutation | No profile transition |
+| Local, reversible fix with an allowlist and no contract/spec change | `FLOW` (`E → V`) |
+| Small behavior change that needs a change but not formal Wend Runtime review | `GUIDE` (`P → E → V`) |
+| Normal, ambiguous, public-contract, security, dependency, CI/release, or policy change | `GOVERN` (`P → R → E → V`) |
+| Work requiring explicit confirmation and handoff | `ASSURE` (`P → R → E → V → C`) |
+
+If the harness does not record a lease, a small fix remains under the configured profile —
+`GOVERN` by default. `OFF` does not mean “simple task”: it is a persistent human choice that hands
+governance to the native harness. The LLM may temporarily elevate an `OFF` base to a Wend route,
+but it can never select `OFF` on its own.
+
 A corrupt binding never selects `OFF`: with one unambiguous explicit or legacy Vault, Keep Core
 remains active under `GOVERN`, the error stays visible, and mutation guards fail closed. Additional
 roots that FLOW must protect can be declared as project-relative paths under
 `harness.flow.protectedRoots` in `.wendkeep.json`; any change below them requires promotion.
 Invalid local config, marker, or identity never silently falls back to a parent/global Vault.
 
-`wendkeep profile status/use` makes the choice observable; `wendkeep flow
+`wendkeep profile status/use/route` makes the choice observable; `wendkeep flow
 start/finish/promote` handles local adjustments without manufacturing an ADR and fails closed on
 physical escapes, Git metadata/hidden flags, mutating sensors, protected surfaces, or incomplete
 session projection. Bounded no-follow discovery sees empty/ignored protected aliases; Vault writes
@@ -379,7 +452,7 @@ explore → propose → apply (TDD) → verify → archive
 
 - **Propose** — `wendkeep change new <slug>` scaffolds `08-Mudanças/<slug>/` (`proposta.md`, `design.md`, `tarefas.md`; `--simple` skips the design). It becomes the global *current* change. When the change declares `spec_impact: required`, you author the delta yourself at `specs/<capability>/spec.md` — there is no placeholder to delete. Multiple changes may remain open: `change list`/`status` and the hooks show every pending one, while commands without `--change` act on the current one alone. `change use <slug>` changes focus and `change continue <archived> <new>` creates an auditable continuation.
 - **Apply** — implement each `tarefas.md` task. Mark machine proof with one or more `[sensor:<id>]` tags on the same task: every distinct ID enters the gate once, in declaration order. Also mark satisfied requirements with one or more `[req:<ID>]` tags.
-- **Verify** — `wendkeep verify` runs the sensors your tasks declared (from `wendkeep.sensors.json` at the project root) and writes `evidencia.json`. A red `critical` fails the gate; a red `warning` is advisory. `verify --deep` builds a self-contained package with complete effective requirements (living contract + this change's delta), so the independent verifier never needs to reconstruct unarchived requirements from `07-Specs`. Every change needs a `verdict.json` to archive; `verify --deep` writes a trivial one automatically when the change declares no `[req:]`.
+- **Verify** — `wendkeep verify` runs the sensors your tasks declared (from `wendkeep.sensors.json` at the project root) and writes `evidencia.json`. A red `critical` fails the gate; a red `warning` is advisory. Failures retain only a bounded, sanitized diagnostic; green output is not persisted. `verify --deep` builds a self-contained package with complete effective requirements (living contract + this change's delta), so the independent verifier never needs to reconstruct unarchived requirements from `07-Specs`. Every change needs a `verdict.json` to archive; `verify --deep` writes a trivial one automatically when the change declares no `[req:]`.
 - **Archive** — `wendkeep change archive <slug>` **gates** on the evidence (blocks unless every declared critical sensor is green), promotes each capability's spec delta (`ADDED`/`MODIFIED`/`REMOVED`) into the living `07-Specs/<capability>.md`, moves the change to `_arquivo/`, and mints an ADR in `04-Decisões/`.
 
 > The gate blocks unless the scaffold is filled, no task is open, evidence is fresh, and every declared requirement is covered. **`--force` waives exactly one of those — the open-task check — and is the human's call, never the agent's.** An unfilled scaffold, a red critical sensor, stale evidence, an orphan requirement or a missing verdict block regardless.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 
 **Memória persistente para agentes de código, construída sobre o seu cofre Obsidian.** Cada sessão do Claude Code e do Codex é capturada turno a turno em Markdown local — o `init` wira os hooks dos dois agentes (no Codex, valendo depois que você aprovar o prompt de confiança dele); o `import` recupera as sessões passadas — com rastreio de tokens/custo, decisões, bugs e aprendizados extraídos automaticamente. Esse plano sempre ativo é o **Keep Core**. Sobre ele, o **Wend Runtime** oferece um ciclo nativo e sem dependências (spec → change → TDD → archive com gate por sensor), selecionável pelos Perfis de Operação `OFF`, `FLOW`, `GUIDE`, `GOVERN` e `ASSURE`. 100% local, open‑core.
 
+Na projeção das sessões, metadados internos terminais são removidos somente das respostas do
+assistente; relatos do usuário permanecem. Tags XML-like são gravadas como texto escapado para não
+serem interpretadas como HTML no modo de leitura do Obsidian.
+
 O runtime está sendo separado em seis fronteiras físicas — `cli`, `harness`, `vault`, `mcp`,
 `integrations` e `pi` — sem fragmentar a instalação. Os workspaces privados `cli`, `harness`,
 `vault`, `mcp` e `integrations` agora são donos canônicos do runtime do executável, dos Perfis de
@@ -231,13 +235,83 @@ invocá-los é uma escolha deliberada e executa as validações próprias do com
 | `GOVERN` | P → R → E → V | Loop a2 atual e fallback compatível. |
 | `ASSURE` | P → R → E → V → C | Governança com confirmação e handoff. |
 
+### Como ler a rota
+
+As letras da coluna **Rota** são etapas do trabalho, não nomes de comandos:
+
+- `P` = **Planejar/Propor** — entender o pedido, delimitar o escopo e registrar a abordagem quando houver change.
+- `R` = **Revisar** — conferir a proposta/design antes de executar; é a revisão formal do loop a2.
+- `E` = **Executar** — editar o código ou os artefatos permitidos.
+- `V` = **Validar** — rodar testes, sensores e verificações e registrar a evidência.
+- `C` = **Confirmar/entregar** — obter confirmação explícita e fazer o handoff final.
+
+Assim, `P → R → E → V` significa “planejar/propor, revisar, executar e validar”. `FLOW` começa
+direto no microcontrato de execução e validação; `OFF` não aplica uma rota Wend automática e
+devolve o processo ao harness nativo da LLM.
+
+### Quem escolhe o perfil e por quanto tempo
+
+O harness da LLM (Codex, Claude ou outro agente) **classifica a implementação atual** e pode
+registrar uma escolha temporária com `wendkeep profile route`. O Wend Runtime não interpreta o
+texto do prompt nem usa tamanho do diff, heurísticas ou variáveis de ambiente: ele valida a escolha,
+aplica a rota nos hooks e expira a lease ao encerrar a solicitação. Se nenhum roteamento for
+registrado, continua valendo o perfil-base configurado.
+
+A resolução segue esta ordem:
+
+1. lease válida da solicitação atual em `SESSION_REGISTRY.json`;
+2. override persistente da sessão no mesmo registry;
+3. `harness.profile` no `.wendkeep.json` do projeto;
+4. `GOVERN`, quando não há configuração válida.
+
+Sem `--session`, `profile use` altera o **padrão do projeto** e vale para as conversas/hooks que
+não tenham override de sessão. Com `--session <id>`, altera somente aquela sessão e não troca o
+padrão do projeto. Portanto, `profile use OFF` sem `--session` não é um teste isolado: ele grava
+o binding do projeto e pode ser compartilhado se `.wendkeep.json` for commitado.
+
+`profile route` é diferente: exige `--session` e `--reason`, aceita somente `FLOW`, `GUIDE`,
+`GOVERN` ou `ASSURE`, não reescreve o projeto/override persistente e vale apenas para o prompt
+causal atual. O `Stop` aceito consome a lease; se o processo morrer antes disso, o próximo prompt
+avança a sequência e torna a lease antiga inefetiva. `OFF` nunca é escolhido automaticamente.
+
+```bash
+npx wendkeep profile status
+npx wendkeep profile use GUIDE                 # padrão do projeto
+npx wendkeep profile use FLOW --session <id>   # somente uma sessão
+npx wendkeep profile route FLOW --session <id> --reason "correção local"  # pedido atual
+npx wendkeep profile status --session <id>     # perfil efetivo da sessão
+```
+
+Na saída humana de `status --session`, `base=<perfil>/<origem>` e `lease=<estado>` acompanham o
+perfil efetivo; `--json` expõe os mesmos dados como `base_profile`, `base_source` e `task_lease`.
+`profile route` só aceita uma sessão depois que `UserPromptSubmit` registrou turno e sequência
+causais positivos e coincidentes no registry.
+
+### Qual perfil usar numa solicitação simples?
+
+“Pequena” descreve o tamanho, não o risco. O harness usa a matriz abaixo para escolher e registrar
+a rota temporária; a inferência semântica continua no agente, não no Wend Runtime:
+
+| Situação | Perfil indicado |
+|---|---|
+| Pergunta, inspeção ou diagnóstico sem alteração | Nenhuma transição de perfil |
+| Correção local, reversível, com allowlist e sem mudança de contrato/spec | `FLOW` (`E → V`) |
+| Pequena mudança de comportamento que precisa de change, mas não de revisão formal do Wend Runtime | `GUIDE` (`P → E → V`) |
+| Mudança normal, ambígua, de contrato público, segurança, dependência, CI/release ou policy | `GOVERN` (`P → R → E → V`) |
+| Trabalho que exige confirmação e handoff explícitos | `ASSURE` (`P → R → E → V → C`) |
+
+Se o harness não registrar a lease, uma correção pequena continua sob o perfil configurado — por
+padrão, `GOVERN`. `OFF` não significa “tarefa simples”: é uma escolha humana persistente que entrega
+a governança ao harness nativo; a LLM pode elevar temporariamente uma base `OFF` para uma rota Wend,
+mas nunca selecionar `OFF` por conta própria.
+
 Binding corrompido nunca seleciona `OFF`: com um Vault explícito ou legado inequívoco, o Keep Core
 continua ativo sob `GOVERN`, o erro fica visível e guards mutáveis falham fechados. Raízes
 adicionais que FLOW deve proteger podem ser declaradas como caminhos relativos ao projeto em
 `harness.flow.protectedRoots` no `.wendkeep.json`; qualquer alteração sob elas exige promoção.
 Config, marcador ou identidade local inválidos nunca caem silenciosamente no Vault pai/global.
 
-`wendkeep profile status/use` torna a escolha observável; `wendkeep flow
+`wendkeep profile status/use/route` torna a escolha observável; `wendkeep flow
 start/finish/promote` resolve ajustes locais sem fabricar ADR e falha fechado em escapes físicos,
 metadata/flags ocultas do Git, sensores mutantes, superfícies protegidas ou projeção de sessão
 incompleta. Uma descoberta no-follow limitada enxerga aliases protegidos vazios/ignorados; escritas
@@ -373,7 +447,7 @@ explore → propose → apply (TDD) → verify → archive
 
 - **Propose** — `wendkeep change new <slug>` faz o scaffold de `08-Mudanças/<slug>/` (`proposta.md`, `design.md`, `tarefas.md`; o `--simple` pula o design). A change vira a *atual* global; `change use <slug>` troca o foco e `change continue <arquivada> <nova>` cria uma continuação auditável. Várias changes podem ficar abertas: hooks e `change list/status` mostram todas as pendências, enquanto comandos sem `--change` usam somente a atual. Quando a change declara `spec_impact: required`, você mesmo escreve o delta em `specs/<capability>/spec.md` — não há placeholder pra apagar.
 - **Apply** — implemente cada tarefa de `tarefas.md`. Marque a prova de máquina com uma ou mais tags `[sensor:<id>]` na mesma tarefa: todos os IDs distintos entram no gate uma vez, na ordem declarada. Marque também os requisitos satisfeitos com uma ou mais tags `[req:<ID>]`.
-- **Verify** — `wendkeep verify` roda os sensores que suas tarefas declararam (do `wendkeep.sensors.json` na raiz do projeto) e grava `evidencia.json`. Um vermelho crítico falha o gate; um vermelho `warning` é aviso. O `verify --deep` monta o pacote autocontido de verificação (contrato vivo + delta desta change). Toda change precisa de um `verdict.json` pra arquivar; quando ela não declara `[req:]`, o próprio `verify --deep` grava um verdict trivial.
+- **Verify** — `wendkeep verify` roda os sensores que suas tarefas declararam (do `wendkeep.sensors.json` na raiz do projeto) e grava `evidencia.json`. Um vermelho crítico falha o gate; um vermelho `warning` é aviso. Falhas guardam somente um diagnóstico limitado e sanitizado; saída verde não é persistida. O `verify --deep` monta o pacote autocontido de verificação (contrato vivo + delta desta change). Toda change precisa de um `verdict.json` pra arquivar; quando ela não declara `[req:]`, o próprio `verify --deep` grava um verdict trivial.
 - **Archive** — `wendkeep change archive <slug>` faz **gate** na evidência (bloqueia a não ser que todo sensor crítico declarado esteja verde), promove o delta de cada capability (`ADDED`/`MODIFIED`/`REMOVED`) pro `07-Specs/<capability>.md` vivo, move a change pro `_arquivo/` e cunha um ADR em `04-Decisões/`.
 
 > O gate bloqueia a não ser que o scaffold esteja preenchido, nenhuma tarefa aberta, evidência fresca e todo requisito declarado coberto. **O `--force` dispensa exatamente uma dessas — a checagem de tarefa aberta — e é decisão do humano, nunca do agente.** Scaffold não preenchido, sensor crítico vermelho, evidência stale, requisito órfão ou verdict ausente bloqueiam de qualquer jeito.

--- a/docs/en/commands/operating-profiles.md
+++ b/docs/en/commands/operating-profiles.md
@@ -14,9 +14,9 @@ opt-in and runs that command's own validations and gates.
 
 ## When to use
 
-Use `profile` to inspect or explicitly select an Operating Profile. Use `FLOW` for local,
-reversible `spec_impact:none` maintenance that fits an Execute → Validate microcontract without a
-change.
+Use `profile use` for a persistent human selection and `profile route` for the harness to record
+the temporary route for the current implementation. Use `FLOW` for local, reversible
+`spec_impact:none` maintenance that fits an Execute → Validate microcontract without a change.
 
 ## When not to use
 
@@ -28,7 +28,8 @@ change.
 ## Prerequisites
 
 - An initialized project whose `.wendkeep.json` is bound to the correct Vault.
-- For a session override, one unambiguous session in `SESSION_REGISTRY.json`.
+- For an override or temporary route, one unambiguous session in `SESSION_REGISTRY.json`; `route`
+  also requires the current prompt to have a recorded causal frontier.
 - For FLOW, a Git repository, a path allowlist, a reason, and at least one existing sensor in
   `wendkeep.sensors.json`.
 
@@ -37,6 +38,7 @@ change.
 ```bash
 npx wendkeep profile status [--project <path>] [--vault <path>] [--session <id>] [--json]
 npx wendkeep profile use <profile> [--project <path>] [--vault <path>] [--session <id>] [--json]
+npx wendkeep profile route <FLOW|GUIDE|GOVERN|ASSURE> --session <id> --reason <text> [--project <path>] [--vault <path>] [--json]
 npx wendkeep flow start <slug> --allow <path> [--allow <path>...] --sensor <id> [--sensor <id>...] --reason <text> [--session <id>]
 npx wendkeep flow status [<id>]
 npx wendkeep flow show <id> [--session <id>]
@@ -75,15 +77,42 @@ Harness. The workspaces remain private and are not published as independent npm 
 | `GOVERN` | P → R → E → V | Current a2 loop and conservative fallback. |
 | `ASSURE` | P → R → E → V → C | Governance plus confirmation and handoff. |
 
-- Resolution is explicit session override → project `harness.profile` → `GOVERN`. Heuristics,
-  diff size, prompt text, environment variables, or read failures never select `OFF`.
-- `profile status` prints the effective profile and source; `--json` emits structured output. When
-  an explicit Vault preserves the selection despite a corrupt binding, output includes
+### Route legend
+
+The letters are work stages, not individual commands:
+
+- `P` = **Plan/Propose** — understand the request, bound the scope, and record the approach.
+- `R` = **Review** — inspect the proposal/design before execution; this is the formal a2-loop review.
+- `E` = **Execute** — edit the permitted paths and artifacts.
+- `V` = **Validate** — run tests, sensors, and checks and record evidence.
+- `C` = **Confirm/hand off** — obtain explicit confirmation and complete the handoff.
+
+So, `P → R → E → V` means “plan/propose, review, execute, and validate”. `FLOW` starts at the
+execution/validation microcontract; `OFF` imposes no automatic Wend route and returns process
+ownership to the native LLM harness.
+
+- The LLM harness semantically classifies the request and records `profile route`; Wend Runtime
+  does not classify text, diff size, heuristics, or environment variables. It validates and applies
+  the deterministic lease.
+- For a local, reversible fix with no contract/spec change, choose `FLOW`. For a compact behavior
+  change that needs a change but no formal review, choose `GUIDE`. For uncertainty, risk, security,
+  public contracts, dependencies, CI/release, or policy, choose `GOVERN`. Use `ASSURE` when
+  confirmation and handoff are part of the contract.
+- `OFF` can never be an adaptive route; only a human persists it explicitly through
+  `profile use OFF`. An `OFF` base may still receive a temporary elevation to a Wend route.
+
+- Resolution is active prompt lease → persistent session override → project
+  `harness.profile` → `GOVERN`. Invalid/expired leases and read failures never select `OFF`.
+- `profile status` prints the effective profile and source. With `--session`, human output adds
+  `base=<profile>/<source>` and `lease=<state>`; `--json` emits the same data structurally. When an
+  explicit Vault preserves the selection despite a corrupt binding, output includes
   `binding_error` and the diagnostic is also written to stderr.
 - `profile use` validates names and flags strictly; a duplicate/incomplete singleton option or a
   value beginning with `--` fails before I/O. Without `--session`, it atomically changes the
   project binding; with `--session`, it records override, source, and timestamp without changing
   session identity.
+- `profile route` requires `--session` and `--reason`, accepts only the four adaptive profiles,
+  and records lease id, reason, turn/sequence, and timestamp without touching persistent profiles.
 - `.wendkeep.json` stays on `schemaVersion: 1`; the additive field is, for example,
   `"harness": { "profile": "GOVERN" }`. A legacy binding without it also resolves to `GOVERN`.
 - A corrupt binding never means `OFF`. When the payload or legacy integration identifies one
@@ -127,13 +156,39 @@ Harness. The workspaces remain private and are not published as independent npm 
 - Exit `0` means a successful query or transition; exit `1` means a policy/red-sensor block; exit
   `2` means invalid profile, session, flow, or arguments, with no partial mutation.
 
+### Selection scope
+
+Without `--session`, `profile use` writes `harness.profile` to `.wendkeep.json` and changes the
+project default for conversations/hooks that have no session override. With `--session <id>`, it
+writes an override only to that session's `SESSION_REGISTRY.json` and leaves the project default
+unchanged. Therefore, `profile use OFF` without `--session` is not an isolated test; if
+`.wendkeep.json` is committed, that choice is shared with other checkouts as well.
+
+`profile route` creates a lease only for the current request. An accepted `Stop` consumes it by
+CAS; if cleanup does not run, the next `UserPromptSubmit` advances the sequence and the lease is no
+longer effective. A blocked Stop preserves it for a retry of the same request. There is no
+wall-clock TTL that can interrupt long work. A session with no causal prompt recorded yet (missing
+turn, zero sequence, or missing/mismatched causal map entry) is rejected before any mutation.
+`status --session` includes the base profile and lease state in both human and `--json` output; in
+JSON the fields are `base_profile`, `base_source`, and `task_lease.state` (`active`, `consumed`,
+`expired`, `invalid`, or `absent`).
+
+```bash
+npx wendkeep profile status                       # project default
+npx wendkeep profile use GUIDE                   # change the project default
+npx wendkeep profile use FLOW --session <id>     # one session only
+npx wendkeep profile route FLOW --session <id> --reason "local adjustment"  # current request
+npx wendkeep profile status --session <id>       # session-effective profile
+```
+
 ## Examples
 
-Inspect the effective default and apply an override only to the current session:
+Inspect the effective default and route only the current implementation:
 
 ```bash
 npx wendkeep profile status
-npx wendkeep profile use OFF --session 019abc-session-id --json
+npx wendkeep profile route FLOW --session 019abc-session-id --reason "fix local typo" --json
+npx wendkeep profile status --session 019abc-session-id --json
 ```
 
 Run FLOW maintenance while capturing the `flow_id` returned by `start`:

--- a/docs/en/commands/sessions-and-import.md
+++ b/docs/en/commands/sessions-and-import.md
@@ -81,7 +81,13 @@ Each canonical session points to the matching provider, transcript, note file, a
 registry keeps one `SessionStart` epoch per activation plus the latest native turn; multiple
 `Stop` events may acknowledge turns in that epoch without closing it. Repeated imports of the
 same `session_id` deduplicate; human focus does not close or re-identify live hooks. Every
-automatic iteration remains valid Markdown even when a message must be truncated.
+automatic iteration remains valid Markdown even when a message must be truncated. Complete or
+truncated trailing internal metadata is removed only from assistant messages; a reproduction
+written by the user remains in the transcript. In the note, XML-like tags are encoded as visible
+text — including placeholders such as `<session>` — without changing `<https://...>` autolinks.
+Reimport and `SessionStop` share the same idempotent normalizer; when an older note is finalized,
+only recognized generated fields under `Iterações` and `Encerramento` are migrated, without rewriting
+authored prose.
 Duplicate/stale hooks converge on the same frontier, and imports may refresh only observability
 without creating a new turn block.
 

--- a/docs/en/commands/verify.md
+++ b/docs/en/commands/verify.md
@@ -73,15 +73,17 @@ npx wendkeep memory status --gate --vault .MyApp-vault
 ## Expected result
 
 `evidencia.json` contains sensor results and a seal binds proof to the current `tarefas.md` hash.
-Deep mode packages requirements, tasks, and evidence for read-only review; the verdict covers every
-`[req:]` before archive.
+When a sensor is red, its entry receives only a local, sanitized diagnostic bounded to 2,000
+characters; stdout/stderr from green sensors is not persisted. Deep mode packages requirements,
+tasks, and evidence for read-only review; the verdict covers every `[req:]` before archive.
 
 ## Common errors and diagnosis
 
 - `no change`: this is exit 2 and a valid idle state; create/use a change or skip verify.
 - Zero/missing sensors: inspect every same-line tag and `sensors list`; multiple tags on one task
   are valid and all of them enter the gate.
-- Red gate: fix the cause and rerun; never choose `archive --force` on your own.
+- Red gate: inspect the bounded `note` field on the `evidencia.json` entry, fix the cause, and
+  rerun; never choose `archive --force` on your own.
 - Missing/stale verdict: regenerate `--deep` and request a fresh independent pass.
 - Surviving mutants: strengthen the discriminating test; after three rounds, review manually.
 

--- a/docs/pt-BR/commands/operating-profiles.md
+++ b/docs/pt-BR/commands/operating-profiles.md
@@ -14,9 +14,9 @@ deliberado e executa as validações e gates próprios daquele comando.
 
 ## Quando usar
 
-Use `profile` para consultar ou selecionar explicitamente um Perfil de Operação. Use `FLOW` para
-manutenção local, reversível e com `spec_impact:none` que caiba num microcontrato Executar →
-Validar, sem change.
+Use `profile use` para uma seleção humana persistente e `profile route` para o harness registrar a
+rota temporária da implementação atual. Use `FLOW` para manutenção local, reversível e com
+`spec_impact:none` que caiba num microcontrato Executar → Validar, sem change.
 
 ## Quando não usar
 
@@ -28,7 +28,8 @@ gates/policies do WendKeep; promova o trabalho para uma change.
 ## Pré-requisitos
 
 - Projeto inicializado, com `.wendkeep.json` vinculado ao Vault correto.
-- Para override de sessão, uma sessão inequívoca no `SESSION_REGISTRY.json`.
+- Para override ou rota temporária, uma sessão inequívoca no `SESSION_REGISTRY.json`; `route`
+  também exige que o prompt atual já tenha fronteira causal registrada.
 - Para FLOW, repositório Git, allowlist de paths, motivo e ao menos um sensor existente em
   `wendkeep.sensors.json`.
 
@@ -37,6 +38,7 @@ gates/policies do WendKeep; promova o trabalho para uma change.
 ```bash
 npx wendkeep profile status [--project <path>] [--vault <path>] [--session <id>] [--json]
 npx wendkeep profile use <perfil> [--project <path>] [--vault <path>] [--session <id>] [--json]
+npx wendkeep profile route <FLOW|GUIDE|GOVERN|ASSURE> --session <id> --reason <texto> [--project <path>] [--vault <path>] [--json]
 npx wendkeep flow start <slug> --allow <path> [--allow <path>...] --sensor <id> [--sensor <id>...] --reason <texto> [--session <id>]
 npx wendkeep flow status [<id>]
 npx wendkeep flow show <id> [--session <id>]
@@ -76,15 +78,42 @@ independentes.
 | `GOVERN` | P → R → E → V | Loop a2 atual e fallback conservador. |
 | `ASSURE` | P → R → E → V → C | Governança acrescida de confirmação e handoff. |
 
-- A resolução segue override explícito da sessão → `harness.profile` do projeto → `GOVERN`.
-  Heurística, tamanho do diff, texto do prompt, variável de ambiente ou erro de leitura nunca
+### Legenda da rota
+
+As letras são etapas do trabalho, não comandos individuais:
+
+- `P` = **Planejar/Propor** — entender o pedido, delimitar o escopo e registrar a abordagem.
+- `R` = **Revisar** — revisar proposta/design antes da execução; é a revisão formal do loop a2.
+- `E` = **Executar** — editar os paths e artefatos permitidos.
+- `V` = **Validar** — rodar testes, sensores e verificações e registrar evidência.
+- `C` = **Confirmar/entregar** — obter confirmação explícita e fazer handoff.
+
+Logo, `P → R → E → V` é “planejar/propor, revisar, executar e validar”. `FLOW` começa no
+microcontrato de execução/validação; `OFF` não impõe rota Wend automática e entrega o processo ao
+harness nativo da LLM.
+
+- O harness da LLM classifica semanticamente o pedido e registra `profile route`; o Wend Runtime
+  não classifica texto, tamanho do diff, heurística ou variável de ambiente. Ele valida e aplica a
+  lease determinística.
+- Para correção local, reversível e sem contrato/spec, escolha `FLOW`. Para mudança compacta de
+  comportamento que precisa de change sem revisão formal, escolha `GUIDE`. Em dúvida, risco,
+  segurança, contrato público, dependências, CI/release ou policy, escolha `GOVERN`. Use `ASSURE`
+  quando confirmação e handoff forem parte do contrato.
+- `OFF` nunca pode ser uma rota adaptativa; somente uma pessoa o persiste explicitamente por
+  `profile use OFF`. Uma base `OFF` ainda pode receber uma elevação temporária para rota Wend.
+
+- A resolução segue lease ativa do prompt → override persistente da sessão →
+  `harness.profile` do projeto → `GOVERN`. Lease inválida/expirada e erro de leitura nunca
   selecionam `OFF`.
-- `profile status` mostra perfil efetivo e origem; `--json` produz saída estruturada. Quando um
-  Vault explícito preserva a escolha apesar de binding corrompido, a saída inclui `binding_error`
-  e o diagnóstico também vai para stderr.
+- `profile status` mostra perfil efetivo e origem. Com `--session`, a saída humana acrescenta
+  `base=<perfil>/<origem>` e `lease=<estado>`; `--json` produz os mesmos dados estruturados. Quando
+  um Vault explícito preserva a escolha apesar de binding corrompido, a saída inclui
+  `binding_error` e o diagnóstico também vai para stderr.
 - `profile use` valida nome e flags estritamente; opção singleton duplicada, incompleta ou com
   valor iniciado por `--` falha antes de I/O. Sem `--session`, altera atomicamente o binding do
   projeto; com `--session`, grava override, origem e timestamp sem trocar a identidade da sessão.
+- `profile route` exige `--session` e `--reason`, aceita somente os quatro perfis adaptativos e
+  grava `lease_id`, motivo, turno/sequência e timestamp sem tocar no perfil persistente.
 - `.wendkeep.json` continua em `schemaVersion: 1`; o campo aditivo usa, por exemplo,
   `"harness": { "profile": "GOVERN" }`. Binding legado sem o campo também resolve `GOVERN`.
 - Binding corrompido nunca equivale a `OFF`. Quando o payload ou a integração legada identifica
@@ -126,13 +155,39 @@ independentes.
 - Exit `0` indica consulta ou transição concluída; exit `1` indica política/sensor vermelho; exit
   `2` indica perfil, sessão, flow ou argumentos inválidos, sem mutação parcial.
 
+### Escopo da escolha
+
+Sem `--session`, `profile use` grava `harness.profile` no `.wendkeep.json` e muda o padrão do
+projeto para as conversas/hooks que não tenham override de sessão. Com `--session <id>`, grava o
+override somente no `SESSION_REGISTRY.json` daquela sessão e preserva o padrão do projeto. Por
+isso, `profile use OFF` sem `--session` não é um teste isolado; se o `.wendkeep.json` for commitado,
+essa escolha também será compartilhada com outros checkouts.
+
+`profile route` cria uma lease apenas para a solicitação atual. Um `Stop` aceito a consome por
+CAS; se o cleanup não rodar, o próximo `UserPromptSubmit` avança a sequência e a lease deixa de ser
+efetiva. Stop bloqueado preserva a lease para o retry do mesmo pedido. Não há TTL de relógio que
+interrompa trabalho longo. Sessão ainda sem prompt causal registrado (turno ausente, sequência
+zero, mapa causal ausente ou divergente) é rejeitada antes de qualquer mutação. `status --session`
+inclui o perfil-base e o estado da lease tanto na saída humana quanto em `--json`; neste, os campos
+são `base_profile`, `base_source` e `task_lease.state` (`active`, `consumed`, `expired`, `invalid` ou
+`absent`).
+
+```bash
+npx wendkeep profile status                       # padrão do projeto
+npx wendkeep profile use GUIDE                   # altera o padrão do projeto
+npx wendkeep profile use FLOW --session <id>     # altera somente uma sessão
+npx wendkeep profile route FLOW --session <id> --reason "ajuste local"  # pedido atual
+npx wendkeep profile status --session <id>       # consulta a sessão efetiva
+```
+
 ## Exemplos
 
-Consultar o padrão efetivo e aplicar override somente à sessão atual:
+Consultar o padrão efetivo e rotear somente a implementação atual:
 
 ```bash
 npx wendkeep profile status
-npx wendkeep profile use OFF --session 019abc-session-id --json
+npx wendkeep profile route FLOW --session 019abc-session-id --reason "corrige typo local" --json
+npx wendkeep profile status --session 019abc-session-id --json
 ```
 
 Executar uma manutenção FLOW capturando o `flow_id` retornado por `start`:

--- a/docs/pt-BR/commands/sessions-and-import.md
+++ b/docs/pt-BR/commands/sessions-and-import.md
@@ -80,7 +80,13 @@ Cada sessão canônica aponta para provider, transcript, arquivo de nota e custo
 O registry mantém um epoch de `SessionStart` por activation e o turno nativo mais recente; vários
 `Stop` podem confirmar turnos do mesmo epoch sem fechá-lo. Importações repetidas do mesmo
 `session_id` são deduplicadas; o foco humano não encerra nem altera a identidade dos hooks. Cada
-iteração automática permanece Markdown válido mesmo quando uma fala precisa ser truncada. Hooks
+iteração automática permanece Markdown válido mesmo quando uma fala precisa ser truncada.
+Metadados internos terminais completos ou truncados são removidos somente das mensagens do
+assistente; uma reprodução escrita pelo usuário permanece no transcript. Na nota, tags XML-like
+são codificadas como texto visível — inclusive placeholders como `<session>` — sem alterar
+autolinks `<https://...>`. Reimport e `SessionStop` compartilham o mesmo normalizador idempotente;
+ao finalizar uma nota antiga, somente campos gerados reconhecíveis em `Iterações` e
+`Encerramento` são migrados, sem reescrever a prosa autoral. Hooks
 duplicados/stale convergem no mesmo frontier, e importações podem atualizar só a observabilidade
 sem criar um novo bloco de turno.
 

--- a/docs/pt-BR/commands/verify.md
+++ b/docs/pt-BR/commands/verify.md
@@ -74,15 +74,18 @@ npx wendkeep memory status --gate --vault .MeuApp-vault
 ## Resultado esperado
 
 `evidencia.json` contém resultados dos sensores e um selo liga a prova ao hash atual de
-`tarefas.md`. No deep, o pacote contém requisitos, tarefas e evidência suficientes para revisão
-read-only; o verdict cobre cada `[req:]` antes do archive.
+`tarefas.md`. Quando um sensor fica vermelho, sua entrada recebe somente um diagnóstico local
+sanitizado e limitado a 2.000 caracteres; stdout/stderr de sensores verdes não é persistido. No
+deep, o pacote contém requisitos, tarefas e evidência suficientes para revisão read-only; o
+verdict cobre cada `[req:]` antes do archive.
 
 ## Erros comuns e diagnóstico
 
 - `no change`: isso é exit 2 e estado ocioso válido; crie/use uma change ou não rode verify.
 - Zero/sensores ausentes: confira todas as tags na mesma linha e `sensors list`; várias tags na
   mesma tarefa são válidas e todas entram no gate.
-- Gate vermelho: corrija a causa e repita; não use `archive --force` por conta própria.
+- Gate vermelho: consulte o campo `note` limitado da entrada em `evidencia.json`, corrija a causa
+  e repita; não use `archive --force` por conta própria.
 - Verdict stale/ausente: regenere `--deep` e peça novo passe independente.
 - Mutantes sobreviventes: fortaleça o teste discriminante; após três rodadas, revise manualmente.
 

--- a/hooks/change-nag.mjs
+++ b/hooks/change-nag.mjs
@@ -13,6 +13,7 @@ import {
   profileSentinelId,
   resolveHookOperatingProfile,
 } from './operating-profile-runtime.mjs';
+import { consumeSessionTaskOperatingProfile } from './operating-profile-task-store.mjs';
 
 export function nagDecision(input, vaultBase, { profile = 'GOVERN' } = {}) {
   if (input && input.stop_hook_active) return null; // anti-loop: sempre primeiro
@@ -39,6 +40,13 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       : runtime.bindingError
         ? { decision: 'block', reason: profileRuntimeError(runtime.bindingError) }
         : nagDecision(input, runtime.vaultBase, { profile: runtime.profile });
+    if (!decision && runtime.taskLease?.state === 'active') {
+      consumeSessionTaskOperatingProfile(
+        runtime.vaultBase,
+        runtime.identity?.canonicalConversationId || input?.session_id || input?.sessionId || '',
+        runtime.taskLease.lease_id,
+      );
+    }
     writeHookOutput(decision || {});
   } catch {
     writeHookOutput({});

--- a/hooks/operating-profile-runtime.mjs
+++ b/hooks/operating-profile-runtime.mjs
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 
 import {
   DEFAULT_OPERATING_PROFILE,
+  evaluateTaskOperatingProfileLease,
   normalizeOperatingProfile,
   operatingProfilePolicy,
   resolveOperatingProfile,
@@ -68,6 +69,22 @@ function sessionOverride(entry) {
   }
 }
 
+function nonNegativeSequence(value, fallback = null) {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function taskLeaseContext(entry, input, sessionId) {
+  return {
+    sessionId,
+    turnId: input?.turn_id || input?.turnId || entry?.last_prompt_turn_id || '',
+    turnSequence: nonNegativeSequence(
+      input?.turn_sequence ?? input?.turnSequence,
+      nonNegativeSequence(entry?.last_turn_sequence),
+    ),
+  };
+}
+
 function canonicalPath(value) {
   const path = resolve(value).replaceAll('\\', '/');
   return process.platform === 'win32' ? path.toLowerCase() : path;
@@ -105,7 +122,8 @@ function matchingProjectBinding(vaultResolution, input) {
   }
 }
 
-// Resolution precedence for hooks: explicit session override -> project binding -> GOVERN.
+// Resolution precedence for hooks: active request lease -> explicit session override
+// -> project binding -> GOVERN.
 // Binding corruption is never interpreted as OFF: an authoritative Vault keeps the Keep Core
 // alive under GOVERN and carries a visible diagnostic to each entrypoint.
 export function resolveHookOperatingProfile({
@@ -134,7 +152,20 @@ export function resolveHookOperatingProfile({
   const entry = identity.state === 'resolved'
     ? readSessionRegistry(vaultResolution.base).sessions?.[identity.canonicalConversationId] || null
     : null;
-  const selected = sessionOverride(entry) || project;
+  const base = sessionOverride(entry) || project;
+  const taskLease = evaluateTaskOperatingProfileLease(
+    entry?.operating_profile_task,
+    taskLeaseContext(entry, input, identity.canonicalConversationId || ''),
+  );
+  const selected = taskLease.state === 'active'
+    ? {
+      profile: taskLease.profile,
+      source: 'task-lease',
+      valid: true,
+      configured: true,
+      raw: taskLease.profile,
+    }
+    : base;
   return {
     ...selected,
     policy: operatingProfilePolicy(selected.profile),
@@ -142,6 +173,9 @@ export function resolveHookOperatingProfile({
     projectRoot: vaultResolution.projectRoot,
     identity,
     entry,
+    baseProfile: base.profile,
+    baseSource: base.source,
+    taskLease,
     resolution: vaultResolution,
     ...(bindingError ? { bindingError } : {}),
   };

--- a/hooks/operating-profile-task-store.mjs
+++ b/hooks/operating-profile-task-store.mjs
@@ -1,0 +1,77 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+  createTaskOperatingProfileLease,
+} from '../src/operating-profile.mjs';
+import { mutateSessionRegistry } from './obsidian-common.mjs';
+
+function isoTimestamp(now) {
+  if (typeof now === 'string') return now;
+  if (now instanceof Date) return now.toISOString();
+  return new Date().toISOString();
+}
+
+function missingSessionError(sessionId) {
+  const error = new Error(`sessão não encontrada: ${sessionId}`);
+  error.code = 'WENDKEEP_SESSION_NOT_FOUND';
+  return error;
+}
+
+export function setSessionTaskOperatingProfile(vaultBase, sessionId, profile, {
+  reason,
+  leaseId = randomUUID(),
+  now,
+} = {}) {
+  const issuedAt = isoTimestamp(now);
+  return mutateSessionRegistry(vaultBase, (registry) => {
+    const sessions = registry.sessions || (registry.sessions = {});
+    if (!Object.hasOwn(sessions, sessionId)) throw missingSessionError(sessionId);
+    const current = sessions[sessionId];
+    const turnId = typeof current.last_prompt_turn_id === 'string'
+      ? current.last_prompt_turn_id.trim()
+      : '';
+    const hasRegisteredTurn = Boolean(
+      turnId
+      && current.turn_sequences
+      && Object.hasOwn(current.turn_sequences, turnId)
+      && current.turn_sequences[turnId] === current.last_turn_sequence
+    );
+    const lease = createTaskOperatingProfileLease({
+      profile,
+      reason,
+      sessionId,
+      turnId,
+      turnSequence: hasRegisteredTurn ? current.last_turn_sequence : undefined,
+      leaseId,
+      issuedAt,
+    });
+    sessions[sessionId] = {
+      ...current,
+      operating_profile_task: lease,
+      updated_at: issuedAt,
+    };
+    return lease;
+  });
+}
+
+export function consumeSessionTaskOperatingProfile(vaultBase, sessionId, leaseId, {
+  now,
+} = {}) {
+  if (!sessionId || !leaseId) return false;
+  const consumedAt = isoTimestamp(now);
+  return mutateSessionRegistry(vaultBase, (registry) => {
+    const current = registry.sessions?.[sessionId];
+    const lease = current?.operating_profile_task;
+    if (!lease || lease.state !== 'active' || lease.lease_id !== leaseId) return false;
+    registry.sessions[sessionId] = {
+      ...current,
+      operating_profile_task: {
+        ...lease,
+        state: 'consumed',
+        consumed_at: consumedAt,
+      },
+      updated_at: consumedAt,
+    };
+    return true;
+  });
+}

--- a/hooks/session-stop.mjs
+++ b/hooks/session-stop.mjs
@@ -33,6 +33,7 @@ import {
   parseTranscriptContent,
   resolveTurnIdentity,
 } from '../packages/integrations/src/transcripts.mjs';
+import { sanitizeAssistantMessage } from '../packages/integrations/src/prompt-content.mjs';
 export { resolveTurnIdentity };
 import {
   ensureDir,
@@ -213,6 +214,13 @@ function escapeMarkdownBackticks(text) {
   return escaped;
 }
 
+function escapeMarkdownHtmlTags(text) {
+  return String(text || '').replace(
+    /<(\/?[\p{L}][\p{L}\p{N}_.-]*)(?=[\s/>])([^<>\n]*)>/gu,
+    '&lt;$1$2&gt;',
+  );
+}
+
 function compactText(text, max = 600) {
   const clean = redactSecrets(String(text || ''))
     .replace(/\r/g, '\n')
@@ -223,7 +231,8 @@ function compactText(text, max = 600) {
   const clipped = truncate(source, max);
   // Um corte no meio de código inline/fence pode casar com backticks da próxima
   // entrada gerada. Só snippets realmente truncados perdem a formatação incompleta.
-  return compact.length > max ? escapeMarkdownBackticks(clipped) : clipped;
+  const markdownSafe = compact.length > max ? escapeMarkdownBackticks(clipped) : clipped;
+  return escapeMarkdownHtmlTags(markdownSafe);
 }
 
 function selectTurn(tx, turnId) {
@@ -235,6 +244,11 @@ function selectTurn(tx, turnId) {
 
 function formatConversation(turn) {
   const entries = (turn.conversation || [])
+    .map((entry) => (
+      entry.role === 'Assistente'
+        ? { ...entry, text: sanitizeAssistantMessage(entry.text) }
+        : entry
+    ))
     .filter((entry) => entry.text && !shouldIgnoreUserText(entry.text));
   if (!entries.length) return '- Nenhuma mensagem útil capturada no transcript.';
 
@@ -304,7 +318,9 @@ export function buildIterationBlock(tx, input) {
   const now = Number.isFinite(parsedDate.getTime()) ? parsedDate : new Date();
   const promptText = turn.userPrompts.at(-1) || tx.latestUserPrompt || '';
   const latestAssistant = turn.assistantMessages.at(-1) || tx.latestAssistantMessage || '';
-  const heading = truncate(promptText.replace(/[\r\n#]+/g, ' ').replace(/\s+/g, ' ').trim() || 'Iteração', 80);
+  const heading = escapeMarkdownHtmlTags(
+    truncate(promptText.replace(/[\r\n#]+/g, ' ').replace(/\s+/g, ' ').trim() || 'Iteração', 80),
+  );
   const files = [...new Set([...(turn.consultedFiles || []), ...(turn.changedFiles || [])])];
   const model = turn.model || tx.model || '';
 
@@ -325,7 +341,7 @@ ${formatConversation(turn)}
 
 **Arquivos detectados no turno:** ${formatInlineList(files, 'Nenhum arquivo detectado automaticamente.')}
 
-**Estado ao final do turno:** ${compactText(latestAssistant || 'Checkpoint registrado automaticamente ao final do turno.', 900)}
+**Estado ao final do turno:** ${compactText(sanitizeAssistantMessage(latestAssistant) || 'Checkpoint registrado automaticamente ao final do turno.', 900)}
 `;
 }
 
@@ -649,6 +665,104 @@ function replaceClosingSection(content, closing) {
   return `${content.slice(0, index).trimEnd()}\n\n${closing}\n`;
 }
 
+const GENERATED_ITERATION_LINE_RULES = [
+  { pattern: /^(### \d{2}:\d{2} - )(.*)$/u, assistant: false },
+  { pattern: /^(\*\*Pedido:\*\* )(.*)$/u, assistant: false },
+  { pattern: /^(- \*\*Usuário:\*\* )(.*)$/u, assistant: false },
+  { pattern: /^(- \*\*Assistente:\*\* )(.*)$/u, assistant: true },
+  { pattern: /^(- \*\*Resumo:\*\* )(.*)$/u, assistant: true },
+  { pattern: /^(\*\*Estado ao final do turno:\*\* )(.*)$/u, assistant: true },
+];
+const GENERATED_CLOSING_LINE_RULES = [
+  { pattern: /^(- \*\*Resumo final:\*\* )(.*)$/u, assistant: true },
+];
+
+function generatedSessionLine(line, rules) {
+  for (const rule of rules) {
+    const match = rule.pattern.exec(line);
+    if (match) return { ...rule, prefix: match[1], value: match[2] };
+  }
+  return null;
+}
+
+function splitSessionMarkdownLines(source) {
+  const lines = [];
+  let cursor = 0;
+  while (cursor < source.length) {
+    const newline = source.indexOf('\n', cursor);
+    if (newline === -1) {
+      lines.push({ text: source.slice(cursor), eol: '' });
+      break;
+    }
+    const textEnd = source[newline - 1] === '\r' ? newline - 1 : newline;
+    lines.push({ text: source.slice(cursor, textEnd), eol: source.slice(textEnd, newline + 1) });
+    cursor = newline + 1;
+  }
+  return lines;
+}
+
+function generatedMetadataContinuation(line, mode = '') {
+  const clean = line.trim();
+  if (!clean) return null;
+  if (/^<\/?session\s*>/i.test(clean)) return mode;
+  if (/^<\/?(?:oai-mem-citation|citation_entries|rollout_ids)\b/i.test(clean)) {
+    const nested = [...clean.matchAll(/<(citation_entries|rollout_ids)\b[^>]*>/gi)].at(-1);
+    return nested ? nested[1].toLowerCase() : mode;
+  }
+  if (mode === 'citation_entries' && (
+    /\|note=\[[^\]]*\]\s*$/i.test(clean)
+      || /^[^\s<>]+:\d+(?:-\d+)?(?:\|[^\s].*)?$/i.test(clean)
+  )) return mode;
+  if (mode === 'rollout_ids' && /^(?:[0-9a-f]{8,}(?:-[0-9a-f-]+)*|019f-[A-Za-z0-9_-]+)$/i.test(clean)) {
+    return mode;
+  }
+  return null;
+}
+
+export function sanitizeGeneratedSessionMarkdown(content) {
+  const lines = splitSessionMarkdownLines(String(content || ''));
+  let section = '';
+  let output = '';
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^## /u.test(line.text)) {
+      section = line.text === '## Iterações'
+        ? 'iterations'
+        : (line.text === '## Encerramento' ? 'closing' : '');
+      output += `${line.text}${line.eol}`;
+      continue;
+    }
+
+    const rules = section === 'iterations'
+      ? GENERATED_ITERATION_LINE_RULES
+      : (section === 'closing' ? GENERATED_CLOSING_LINE_RULES : []);
+    const generated = generatedSessionLine(line.text, rules);
+    if (!generated) {
+      output += `${line.text}${line.eol}`;
+      continue;
+    }
+
+    let value = generated.value;
+    let last = index;
+    let mode = '';
+    if (generated.assistant) {
+      for (let next = index + 1; next < lines.length; next += 1) {
+        const nextMode = generatedMetadataContinuation(lines[next].text, mode);
+        if (nextMode === null) break;
+        value += `${lines[last].eol}${lines[next].text}`;
+        last = next;
+        mode = nextMode;
+      }
+      value = sanitizeAssistantMessage(value);
+    }
+
+    output += `${generated.prefix}${escapeMarkdownHtmlTags(value)}${lines[last].eol}`;
+    index = last;
+  }
+  return output;
+}
+
 export function finalizeSessionFile(sessionPath, tx, created, endedAt, vaultBase = '') {
   const pending = extractPending(tx.rawTextForDetection);
   const links = (items) => items.length ? items.map((rel) => `  - ${wikilinkFromRel(rel)}`).join('\n') : '  - Nenhuma';
@@ -673,7 +787,7 @@ ${formatPendingClosing(pending)}
     // As três seções derivadas saem do MESMO `created` que monta o Encerramento — antes
     // elas ficavam de fora deste write e a nota mentia no corpo (ver hooks/derived-sections.mjs).
     applyDerivedSections(
-      replacePendingSection(updateFrontmatter(content, endedAt), pending),
+      replacePendingSection(updateFrontmatter(sanitizeGeneratedSessionMarkdown(content), endedAt), pending),
       created,
     ),
     closing,
@@ -681,8 +795,9 @@ ${formatPendingClosing(pending)}
 }
 
 export function sessionFinalSummary(tx) {
-  return tx.latestAssistantMessage
-    ? truncate(tx.latestAssistantMessage, 500)
+  const assistantSummary = sanitizeAssistantMessage(tx.latestAssistantMessage);
+  return assistantSummary
+    ? compactText(assistantSummary, 500)
     : `Sessão encerrada com ${tx.userPrompts.length} prompts e ${tx.tools.length} ferramentas registradas.`;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.66.5",
+  "version": "0.67.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.66.5",
+      "version": "0.67.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "acorn": "^8.18.0",
-        "wendkeep": "^0.57.2"
+        "wendkeep": "^0.66.5"
       },
       "engines": {
         "node": ">=18"
@@ -61,11 +61,14 @@
       }
     },
     "node_modules/wendkeep": {
-      "version": "0.57.2",
-      "resolved": "https://registry.npmjs.org/wendkeep/-/wendkeep-0.57.2.tgz",
-      "integrity": "sha512-tpSFejz50xmk626obbt+GFP+UqcJdrN5AeSOeqV/1Q2ihmUjtg7kvk8qBx80ZP+qQ/q9RfDYB2LzWCJbxstJsA==",
+      "version": "0.66.5",
+      "resolved": "https://registry.npmjs.org/wendkeep/-/wendkeep-0.66.5.tgz",
+      "integrity": "sha512-qnVJOGKIvZtzeJteu3hhpr0nkMw1HvB+IPzMrJrwmeYLTH+NWaCusDnWfypX4ktedG6LCF8UY0XNlhKYBiqyQg==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "bin": {
         "wendkeep": "bin/wendkeep.mjs",
         "wk": "bin/wendkeep.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.66.5",
+  "version": "0.67.0",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [
@@ -40,7 +40,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "check": "node --check bin/wendkeep.mjs && node --check packages/cli/src/index.mjs && node --check src/init.mjs && node --check src/doctor.mjs && node --check src/project-vault.mjs && node --check src/operating-profile.mjs && node --check src/profile.mjs && node --check src/flow.mjs && node --check hooks/operating-profile-runtime.mjs && node --check hooks/flow-core.mjs && node --check hooks/flow-protected-policy.mjs && node --check hooks/git-snapshot.mjs && node --check hooks/vault-path-safety.mjs && node --check hooks/vault-runtime-store.mjs && node --check packages/harness/src/index.mjs && node --check packages/harness/src/flow-store.mjs && node --check packages/harness/src/operating-profile.mjs && node --check packages/harness/src/sensors-core.mjs && node --check packages/integrations/src/host-hooks.mjs && node --check packages/integrations/src/hook-envelope.mjs && node --check packages/integrations/src/prompt-content.mjs && node --check packages/integrations/src/transcript-usage.mjs && node --check packages/integrations/src/transcripts.mjs && node --check packages/integrations/src/session-identity.mjs && node --check packages/integrations/src/index.mjs && node --check packages/mcp/src/config.mjs && node --check packages/mcp/src/index.mjs && node --check packages/vault/src/index.mjs && node --check packages/vault/src/project-vault.mjs && node --check packages/vault/src/vault-path-safety.mjs && node --check packages/vault/src/locale.mjs && node --check packages/vault/src/memory-schema.mjs && node --check packages/vault/src/memory-mode.mjs && node --check packages/vault/src/memory-handoff.mjs && node --check packages/vault/src/memory-store.mjs && node --check packages/vault/src/validate-core.mjs && node --check packages/vault/src/validate-memory.mjs",
+    "check": "node --check bin/wendkeep.mjs && node --check packages/cli/src/index.mjs && node --check src/init.mjs && node --check src/doctor.mjs && node --check src/project-vault.mjs && node --check src/operating-profile.mjs && node --check src/profile.mjs && node --check src/flow.mjs && node --check hooks/operating-profile-runtime.mjs && node --check hooks/operating-profile-task-store.mjs && node --check hooks/flow-core.mjs && node --check hooks/flow-protected-policy.mjs && node --check hooks/git-snapshot.mjs && node --check hooks/vault-path-safety.mjs && node --check hooks/vault-runtime-store.mjs && node --check packages/harness/src/index.mjs && node --check packages/harness/src/flow-store.mjs && node --check packages/harness/src/operating-profile.mjs && node --check packages/harness/src/sensors-core.mjs && node --check packages/integrations/src/host-hooks.mjs && node --check packages/integrations/src/hook-envelope.mjs && node --check packages/integrations/src/prompt-content.mjs && node --check packages/integrations/src/transcript-usage.mjs && node --check packages/integrations/src/transcripts.mjs && node --check packages/integrations/src/session-identity.mjs && node --check packages/integrations/src/index.mjs && node --check packages/mcp/src/config.mjs && node --check packages/mcp/src/index.mjs && node --check packages/vault/src/index.mjs && node --check packages/vault/src/project-vault.mjs && node --check packages/vault/src/vault-path-safety.mjs && node --check packages/vault/src/locale.mjs && node --check packages/vault/src/memory-schema.mjs && node --check packages/vault/src/memory-mode.mjs && node --check packages/vault/src/memory-handoff.mjs && node --check packages/vault/src/memory-store.mjs && node --check packages/vault/src/validate-core.mjs && node --check packages/vault/src/validate-memory.mjs",
     "test": "node --test --test-concurrency=2",
     "release": "node scripts/release.mjs",
     "release:dry": "node scripts/release.mjs --dry-run",
@@ -70,6 +70,6 @@
   },
   "devDependencies": {
     "acorn": "^8.18.0",
-    "wendkeep": "^0.57.2"
+    "wendkeep": "^0.66.5"
   }
 }

--- a/packages/harness/src/operating-profile.mjs
+++ b/packages/harness/src/operating-profile.mjs
@@ -6,8 +6,16 @@ export const OPERATING_PROFILES = Object.freeze([
   'ASSURE',
 ]);
 export const DEFAULT_OPERATING_PROFILE = 'GOVERN';
+export const ADAPTIVE_OPERATING_PROFILES = Object.freeze([
+  'FLOW',
+  'GUIDE',
+  'GOVERN',
+  'ASSURE',
+]);
 
 const PROFILE_SET = new Set(OPERATING_PROFILES);
+const ADAPTIVE_PROFILE_SET = new Set(ADAPTIVE_OPERATING_PROFILES);
+export const TASK_PROFILE_REASON_MAX_LENGTH = 500;
 
 function policy(profile, route, options) {
   return Object.freeze({
@@ -68,6 +76,125 @@ function invalidProfileError(value) {
 function canonicalProfile(value) {
   if (typeof value !== 'string') return '';
   return value.trim().toUpperCase();
+}
+
+function taskProfileError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function taskProfile(value) {
+  const profile = canonicalProfile(value);
+  if (ADAPTIVE_PROFILE_SET.has(profile)) return profile;
+  throw taskProfileError(
+    'WENDKEEP_TASK_PROFILE_INVALID',
+    `Perfil temporário inválido: ${typeof value === 'string' ? `"${value}"` : String(value)}. `
+      + `Use ${ADAPTIVE_OPERATING_PROFILES.join(', ')}; OFF exige seleção humana persistente.`,
+  );
+}
+
+function taskReason(value) {
+  const reason = typeof value === 'string' ? value.trim() : '';
+  if (reason && reason.length <= TASK_PROFILE_REASON_MAX_LENGTH) return reason;
+  throw taskProfileError(
+    'WENDKEEP_TASK_PROFILE_REASON_INVALID',
+    `Motivo da rota temporária deve ter entre 1 e ${TASK_PROFILE_REASON_MAX_LENGTH} caracteres.`,
+  );
+}
+
+function taskSequence(value) {
+  const sequence = Number(value);
+  return Number.isSafeInteger(sequence) && sequence > 0 ? sequence : null;
+}
+
+function taskContextError() {
+  return taskProfileError(
+    'WENDKEEP_TASK_PROFILE_CONTEXT_INVALID',
+    'Rota temporária exige sessão, prompt causal, lease id e timestamp válidos.',
+  );
+}
+
+export function createTaskOperatingProfileLease({
+  profile,
+  reason,
+  sessionId,
+  turnId = '',
+  turnSequence,
+  leaseId,
+  issuedAt,
+} = {}) {
+  const selected = taskProfile(profile);
+  const auditedReason = taskReason(reason);
+  const session = typeof sessionId === 'string' ? sessionId.trim() : '';
+  const requestTurnId = typeof turnId === 'string' ? turnId.trim() : '';
+  const sequence = taskSequence(turnSequence);
+  const id = typeof leaseId === 'string' ? leaseId.trim() : '';
+  const issued = typeof issuedAt === 'string' ? issuedAt.trim() : '';
+  if (!session || !requestTurnId || sequence === null || !id || !issued || !Number.isFinite(Date.parse(issued))) {
+    throw taskContextError();
+  }
+  return {
+    lease_id: id,
+    state: 'active',
+    profile: selected,
+    requested_by: 'llm-harness',
+    reason: auditedReason,
+    session_id: session,
+    request_turn_id: requestTurnId,
+    request_turn_sequence: sequence,
+    issued_at: issued,
+    expires_on: 'request-stop',
+  };
+}
+
+export function evaluateTaskOperatingProfileLease(lease, {
+  sessionId = '',
+  turnId = '',
+  turnSequence,
+} = {}) {
+  if (lease === undefined || lease === null) return { state: 'absent' };
+  if (!lease || typeof lease !== 'object' || Array.isArray(lease)) return { state: 'invalid' };
+
+  let normalized;
+  try {
+    normalized = createTaskOperatingProfileLease({
+      profile: lease.profile,
+      reason: lease.reason,
+      sessionId: lease.session_id,
+      turnId: lease.request_turn_id,
+      turnSequence: lease.request_turn_sequence,
+      leaseId: lease.lease_id,
+      issuedAt: lease.issued_at,
+    });
+  } catch {
+    return {
+      state: 'invalid',
+      ...(typeof lease.lease_id === 'string' && lease.lease_id ? { lease_id: lease.lease_id } : {}),
+    };
+  }
+  if (lease.requested_by !== 'llm-harness' || lease.expires_on !== 'request-stop') {
+    return { state: 'invalid', lease_id: normalized.lease_id };
+  }
+  if (lease.state === 'consumed' || lease.state === 'expired') {
+    return { ...lease, ...normalized, state: lease.state };
+  }
+  if (lease.state !== 'active') return { state: 'invalid', lease_id: normalized.lease_id };
+
+  const currentSession = typeof sessionId === 'string' ? sessionId.trim() : '';
+  const currentTurnId = typeof turnId === 'string' ? turnId.trim() : '';
+  const currentSequence = taskSequence(turnSequence);
+  if (!currentSession || !currentTurnId || currentSequence === null) {
+    return { ...normalized, state: 'invalid' };
+  }
+  if (normalized.session_id !== currentSession) {
+    return { ...normalized, state: 'invalid' };
+  }
+  const turnIdMismatch = normalized.request_turn_id !== currentTurnId;
+  if (turnIdMismatch || normalized.request_turn_sequence !== currentSequence) {
+    return { ...normalized, state: 'expired' };
+  }
+  return normalized;
 }
 
 export function normalizeOperatingProfile(value, { strict = false } = {}) {

--- a/packages/harness/src/sensors-core.mjs
+++ b/packages/harness/src/sensors-core.mjs
@@ -6,6 +6,38 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 
 export const SENSOR_VAULT_ENV = 'WENDKEEP_SENSOR_VAULT';
+const SENSOR_OUTPUT_MAX_BUFFER = 8 * 1024 * 1024;
+const SENSOR_DIAGNOSTIC_MAX_LENGTH = 2000;
+
+function sanitizeSensorDiagnostic(value) {
+  return String(value || '')
+    .replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\b(gh[pousr]_[A-Za-z0-9_]{12,})\b/g, '[REDACTED_SECRET]')
+    .replace(/\b(sk-[A-Za-z0-9_-]{12,})\b/g, '[REDACTED_SECRET]')
+    .replace(/\b(whsec_[A-Za-z0-9_/-]{8,})\b/g, '[REDACTED_SECRET]')
+    .replace(/\b(xox[baprs]-[A-Za-z0-9-]{12,})\b/g, '[REDACTED_SECRET]')
+    .replace(/\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY)[A-Z0-9_]*)\s*[:=]\s*["']?[^"'\s]+/gi, '$1=[REDACTED_SECRET]')
+    .replace(/:\/\/([^:\s/@]+):([^@\s/]+)@/g, '://[REDACTED_SECRET]@')
+    .replace(/\r/g, '')
+    .trim();
+}
+
+function sensorFailureNote(result = {}) {
+  const status = result.status ?? 'null';
+  const header = [
+    `exit=${status}`,
+    ...(result.signal ? [`signal=${result.signal}`] : []),
+  ].join(' ');
+  const detail = sanitizeSensorDiagnostic([
+    result.error?.message,
+    result.stdout,
+    result.stderr,
+  ].filter(Boolean).join('\n'));
+  if (!detail) return header;
+  const room = SENSOR_DIAGNOSTIC_MAX_LENGTH - header.length - 1;
+  const bounded = detail.length > room ? `…${detail.slice(-(room - 1))}` : detail;
+  return `${header}\n${bounded}`;
+}
 
 export function sensorProcessEnv(vaultBase, inherited = process.env) {
   return {
@@ -59,8 +91,16 @@ export function runSensors(sensors, ids, { spawn = spawnSync, cwd, env, now } = 
   for (const id of ids) {
     const s = byId[id];
     if (!s) { evidence.push({ id, status: 'red', ts, severity: 'critical', note: 'sensor não definido' }); continue; }
-    const r = spawn(s.command, [], { cwd, shell: true, stdio: 'ignore', ...(env ? { env } : {}) });
+    const r = spawn(s.command, [], {
+      cwd,
+      shell: true,
+      encoding: 'utf8',
+      maxBuffer: SENSOR_OUTPUT_MAX_BUFFER,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...(env ? { env } : {}),
+    });
     const entry = { id, status: (r.status ?? 1) === 0 ? 'green' : 'red', ts, severity: s.severity || 'critical' };
+    if (entry.status === 'red') entry.note = sensorFailureNote(r);
     if (s.type === 'mutation' && s.report) {
       // Delegated mutation (Wave B): read the tool's mutation-testing-elements report and
       // attach surviving mutants so verify can turn them into fix tasks.

--- a/packages/integrations/src/prompt-content.mjs
+++ b/packages/integrations/src/prompt-content.mjs
@@ -18,3 +18,126 @@ export function redactSecrets(text) {
     .replace(/\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY)[A-Z0-9_]*)\s*[:=]\s*["']?[^"'\s]+/gi, '$1=[REDACTED_SECRET]')
     .replace(/:\/\/([^:\s/@]+):([^@\s/]+)@/g, '://[REDACTED_SECRET]@');
 }
+
+function metadataPayloadLine(name, line) {
+  if (name === 'citation_entries') {
+    return /\|note=\[[^\]]*\]\s*$/i.test(line)
+      || /^[^\s<>]+:\d+(?:-\d+)?(?:\|[^\s].*)?$/i.test(line);
+  }
+  if (name === 'rollout_ids') {
+    return /^(?:[0-9a-f]{8,}(?:-[0-9a-f-]+)*|019f-[A-Za-z0-9_-]+)$/i.test(line);
+  }
+  return false;
+}
+
+function consumeTruncatedMetadata(source, name, tagEnd) {
+  let cursor = tagEnd;
+  let mode = name;
+  let openingLine = true;
+
+  while (cursor < source.length) {
+    const newline = source.indexOf('\n', cursor);
+    const lineEnd = newline === -1 ? source.length : newline;
+    const line = source.slice(cursor, lineEnd).replace(/\r$/, '');
+    const clean = line.trim();
+
+    if (!clean) {
+      if (!openingLine) return cursor;
+    } else if (/^<\/?(?:oai-mem-citation|citation_entries|rollout_ids)\b/i.test(clean)) {
+      const nested = [...clean.matchAll(/<(citation_entries|rollout_ids)\b[^>]*>/gi)].at(-1);
+      if (nested) mode = nested[1].toLowerCase();
+    } else if (!(openingLine && name !== 'oai-mem-citation') && !metadataPayloadLine(mode, clean)) {
+      return cursor;
+    }
+
+    if (newline === -1) return source.length;
+    cursor = newline + 1;
+    openingLine = false;
+  }
+  return cursor;
+}
+
+function openingPayloadLooksStructural(source, opening) {
+  const name = opening[1].toLowerCase();
+  const tagEnd = opening.index + opening[0].length;
+  const rest = source.slice(tagEnd);
+  if (new RegExp(`<\/${name}\\s*>`, 'i').test(rest)) return true;
+
+  if (name === 'oai-mem-citation') {
+    const child = /^[\t\r\n ]*<(citation_entries|rollout_ids)\b[^>]*>/i.exec(rest);
+    if (!child) return !rest.trim();
+    const childRest = rest.slice(child[0].length);
+    const lineEnd = childRest.search(/\r?\n/u);
+    const sameLine = childRest.slice(0, lineEnd === -1 ? childRest.length : lineEnd);
+    if (!sameLine.trim()) return true;
+    if (!/^[\t ]/u.test(childRest)) return true;
+    if (/^<\/?(?:oai-mem-citation|citation_entries|rollout_ids)\b/i.test(sameLine.trim())) return true;
+    return metadataPayloadLine(child[1].toLowerCase(), sameLine.trim());
+  }
+
+  const lineEnd = rest.search(/\r?\n/u);
+  const sameLine = rest.slice(0, lineEnd === -1 ? rest.length : lineEnd);
+  if (!sameLine.trim()) return true;
+  if (!/^[\t ]/u.test(rest)) return true;
+  if (/^<\/?(?:oai-mem-citation|citation_entries|rollout_ids)\b/i.test(sameLine.trim())) return true;
+  return metadataPayloadLine(name, sameLine.trim());
+}
+
+function metadataStart(source, opening) {
+  const tagStart = opening.index;
+  const before = source.slice(0, tagStart);
+  const adjacentSession = /<\/session>[\t\r\n ]*$/i.exec(before);
+  if (adjacentSession) return adjacentSession.index;
+
+  if (!openingPayloadLooksStructural(source, opening)) return -1;
+
+  const lineStart = before.lastIndexOf('\n') + 1;
+  if (!before.slice(lineStart).trim()) return tagStart;
+
+  const name = opening[1].toLowerCase();
+  if (name === 'oai-mem-citation'
+    && tagStart > 0
+    && !/\s/u.test(source[tagStart - 1])) {
+    return tagStart;
+  }
+  return -1;
+}
+
+function findAssistantMetadataRemoval(source) {
+  const openings = source.matchAll(/<(oai-mem-citation|citation_entries|rollout_ids)\b[^>]*>/gi);
+  for (const opening of openings) {
+    const start = metadataStart(source, opening);
+    if (start < 0) continue;
+
+    const name = opening[1].toLowerCase();
+    const tagEnd = opening.index + opening[0].length;
+    const closing = new RegExp(`<\/${name}\\s*>`, 'i').exec(source.slice(tagEnd));
+    const end = closing
+      ? tagEnd + closing.index + closing[0].length
+      : consumeTruncatedMetadata(source, name, tagEnd);
+    return { start, end };
+  }
+  return null;
+}
+
+function removeAssistantMetadata(source, removal) {
+  const before = source.slice(0, removal.start).trimEnd();
+  const after = source.slice(removal.end).trimStart();
+  if (!before) return after;
+  if (!after) return before;
+  return `${before}\n${after}`;
+}
+
+export function sanitizeAssistantMessage(text) {
+  let source = String(text || '');
+  if (!source) return '';
+
+  while (source) {
+    const removal = findAssistantMetadataRemoval(source);
+    if (!removal) break;
+    const next = removeAssistantMetadata(source, removal);
+    if (next.length >= source.length) break;
+    source = next;
+  }
+  return source;
+}

--- a/packages/integrations/src/transcripts.mjs
+++ b/packages/integrations/src/transcripts.mjs
@@ -1,4 +1,8 @@
-import { isBootstrapPrompt, redactSecrets } from './prompt-content.mjs';
+import {
+  isBootstrapPrompt,
+  redactSecrets,
+  sanitizeAssistantMessage,
+} from './prompt-content.mjs';
 import {
   addUsage,
   emptyTokenUsage,
@@ -71,6 +75,14 @@ function addConversation(turn, role, value) {
   if (!turn.conversation.some((item) => item.role === role && item.text === text)) {
     turn.conversation.push({ role, text });
   }
+}
+
+function addAssistantMessage(result, turn, value) {
+  const text = sanitizeAssistantMessage(value);
+  if (!text) return;
+  addUnique(result.assistantMessages, text);
+  addUnique(turn.assistantMessages, text);
+  addConversation(turn, 'Assistente', text);
 }
 
 function normalizeRoot(value) {
@@ -207,9 +219,7 @@ export function parseCodexTranscriptContent(content, options = {}) {
       const text = event.payload.message || event.payload.text || '';
       if (text) {
         const turn = ensureTurn(event.payload.turn_id || result.latestTurnId, event.timestamp);
-        addUnique(result.assistantMessages, text);
-        addUnique(turn.assistantMessages, text);
-        addConversation(turn, 'Assistente', text);
+        addAssistantMessage(result, turn, text);
       }
       continue;
     }
@@ -234,9 +244,7 @@ export function parseCodexTranscriptContent(content, options = {}) {
         addConversation(turn, 'Usuário', text);
       }
       if (payload.role === 'assistant') {
-        addUnique(result.assistantMessages, text);
-        addUnique(turn.assistantMessages, text);
-        addConversation(turn, 'Assistente', text);
+        addAssistantMessage(result, turn, text);
       }
       continue;
     }
@@ -356,9 +364,7 @@ export function parseClaudeTranscriptContent(content, options = {}) {
       const blocks = Array.isArray(event.message?.content) ? event.message.content : [];
       for (const block of blocks) {
         if (block?.type === 'text' && block.text && block.text.trim()) {
-          addUnique(result.assistantMessages, block.text);
-          addUnique(turn.assistantMessages, block.text);
-          addConversation(turn, 'Assistente', block.text);
+          addAssistantMessage(result, turn, block.text);
         } else if (block?.type === 'tool_use') {
           const name = block.name || 'tool_use';
           addUnique(result.tools, name);

--- a/src/profile.mjs
+++ b/src/profile.mjs
@@ -3,10 +3,12 @@
 import { mutateSessionRegistry, readSessionRegistry } from '../hooks/obsidian-common.mjs';
 import {
   DEFAULT_OPERATING_PROFILE,
+  evaluateTaskOperatingProfileLease,
   normalizeOperatingProfile,
   resolveOperatingProfile,
   setOperatingProfile,
 } from './operating-profile.mjs';
+import { setSessionTaskOperatingProfile } from '../hooks/operating-profile-task-store.mjs';
 import { resolve } from 'node:path';
 import { findProjectBinding, resolveProjectVault, updateProjectBinding } from './project-vault.mjs';
 
@@ -14,12 +16,14 @@ export const PROFILE_HELP = `wendkeep profile <subcommand>
 
   status [--session <id>]
   use <OFF|FLOW|GUIDE|GOVERN|ASSURE> [--session <id>]
+  route <FLOW|GUIDE|GOVERN|ASSURE> --session <id> --reason <text>
 
-Common options: --project <path> --vault <path> --session <id> --json
+Common options: --project <path> --vault <path> --session <id> --json --reason <text>
+route creates a task-scoped choice for the current request; it never selects OFF.
 The Keep Core (Vault, session, and memory) remains active under every profile.
 `;
 
-const VALUE_OPTIONS = new Set(['--project', '--vault', '--session']);
+const VALUE_OPTIONS = new Set(['--project', '--vault', '--session', '--reason']);
 const FLAG_OPTIONS = new Set(['--json']);
 
 function optionValue(argv, name) {
@@ -32,8 +36,8 @@ function commandArgs(argv) {
   const values = [];
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
-    if (['--project', '--vault', '--session'].includes(value)) { index += 1; continue; }
-    if (value.startsWith('--project=') || value.startsWith('--vault=') || value.startsWith('--session=')) continue;
+    if (['--project', '--vault', '--session', '--reason'].includes(value)) { index += 1; continue; }
+    if (value.startsWith('--project=') || value.startsWith('--vault=') || value.startsWith('--session=') || value.startsWith('--reason=')) continue;
     if (value === '--json') continue;
     values.push(value);
   }
@@ -76,8 +80,15 @@ function canonicalPath(value) {
 function output(payload, json) {
   if (json) process.stdout.write(`${JSON.stringify(payload)}\n`);
   else {
-    const scope = payload.scope === 'session' ? `session ${payload.session_id}` : 'project';
-    process.stdout.write(`${payload.profile} (${scope}; ${payload.source})\n`);
+    const scope = payload.scope === 'task'
+      ? `task ${payload.session_id}`
+      : payload.scope === 'session' ? `session ${payload.session_id}` : 'project';
+    const details = [scope, payload.source];
+    if (payload.session_id && payload.base_profile && payload.task_lease?.state) {
+      details.push(`base=${payload.base_profile}/${payload.base_source}`);
+      details.push(`lease=${payload.task_lease.state}`);
+    }
+    process.stdout.write(`${payload.profile} (${details.join('; ')})\n`);
   }
   if (payload.binding_error) {
     const code = payload.binding_error.code || 'WENDKEEP_VAULT_CONFIG_INVALID';
@@ -129,10 +140,7 @@ export function setSessionOperatingProfile(vaultBase, sessionId, profile, { now 
   });
 }
 
-function sessionProfile(vaultBase, sessionId, projectResolved) {
-  const sessions = readSessionRegistry(vaultBase).sessions || {};
-  if (!Object.hasOwn(sessions, sessionId)) throw new Error(`sessão não encontrada: ${sessionId}`);
-  const entry = sessions[sessionId];
+function sessionBaseProfile(entry, projectResolved) {
   if (Object.hasOwn(entry, 'operating_profile')) {
     try {
       return {
@@ -149,6 +157,44 @@ function sessionProfile(vaultBase, sessionId, projectResolved) {
   return { profile: projectResolved.profile, source: projectResolved.source };
 }
 
+function sessionProfile(vaultBase, sessionId, projectResolved) {
+  const sessions = readSessionRegistry(vaultBase).sessions || {};
+  if (!Object.hasOwn(sessions, sessionId)) throw new Error(`sessão não encontrada: ${sessionId}`);
+  return sessionBaseProfile(sessions[sessionId], projectResolved);
+}
+
+function sessionProfileStatus(vaultBase, sessionId, projectResolved) {
+  const sessions = readSessionRegistry(vaultBase).sessions || {};
+  if (!Object.hasOwn(sessions, sessionId)) throw new Error(`sessão não encontrada: ${sessionId}`);
+  const entry = sessions[sessionId];
+  const base = sessionBaseProfile(entry, projectResolved);
+  const taskLease = evaluateTaskOperatingProfileLease(entry.operating_profile_task, {
+    sessionId,
+    turnId: entry.last_prompt_turn_id || '',
+    turnSequence: entry.last_turn_sequence,
+  });
+  return {
+    profile: taskLease.state === 'active' ? taskLease.profile : base.profile,
+    source: taskLease.state === 'active' ? 'task-lease' : base.source,
+    scope: taskLease.state === 'active' ? 'task' : 'session',
+    baseProfile: base.profile,
+    baseSource: base.source,
+    taskLease,
+  };
+}
+
+function sessionOutputPayload(effective, sessionId) {
+  return {
+    profile: effective.profile,
+    source: effective.source,
+    scope: effective.scope,
+    session_id: sessionId,
+    base_profile: effective.baseProfile,
+    base_source: effective.baseSource,
+    task_lease: effective.taskLease,
+  };
+}
+
 export function runProfile(argv = []) {
   try { validateArgv(argv); }
   catch (error) { return fail(error.message); }
@@ -156,6 +202,8 @@ export function runProfile(argv = []) {
   const sub = args[0] || 'status';
   const json = argv.includes('--json');
   const sessionId = optionValue(argv, '--session') || '';
+  const reason = optionValue(argv, '--reason');
+  if (sub !== 'route' && reason) return fail('--reason só é aceito por profile route');
 
   let state;
   try { state = context(argv); }
@@ -166,20 +214,50 @@ export function runProfile(argv = []) {
     if (args.length > 1) return fail(`${sub} não aceita argumentos posicionais adicionais`);
     try {
       const effective = sessionId
-        ? sessionProfile(state.vaultBase, sessionId, projectResolved)
-        : { profile: projectResolved.profile, source: projectResolved.source };
+        ? sessionProfileStatus(state.vaultBase, sessionId, projectResolved)
+        : { profile: projectResolved.profile, source: projectResolved.source, scope: 'project' };
       output({
-        profile: effective.profile,
-        source: effective.source,
-        scope: sessionId ? 'session' : 'project',
-        session_id: sessionId || null,
+        ...(sessionId ? sessionOutputPayload(effective, sessionId) : {
+          profile: effective.profile,
+          source: effective.source,
+          scope: 'project',
+          session_id: null,
+        }),
         ...(state.resolved.bindingError ? { binding_error: state.resolved.bindingError } : {}),
       }, json);
       return 0;
     } catch (error) { return fail(error.message); }
   }
 
-  if (sub !== 'use' && sub !== 'set') return fail('use status | use <OFF|FLOW|GUIDE|GOVERN|ASSURE>');
+  if (sub === 'route') {
+    if (args.length !== 2) return fail('route requer exatamente um perfil');
+    if (!sessionId) return fail('route requer --session <id>');
+    if (!reason) return fail('route requer --reason <text>');
+    try {
+      const base = sessionProfile(state.vaultBase, sessionId, projectResolved);
+      const lease = setSessionTaskOperatingProfile(
+        state.vaultBase,
+        sessionId,
+        args[1],
+        { reason },
+      );
+      output({
+        profile: lease.profile,
+        source: 'task-lease',
+        scope: 'task',
+        session_id: sessionId,
+        base_profile: base.profile,
+        base_source: base.source,
+        task_lease: lease,
+        ...(state.resolved.bindingError ? { binding_error: state.resolved.bindingError } : {}),
+      }, json);
+      return 0;
+    } catch (error) { return fail(error.message); }
+  }
+
+  if (sub !== 'use' && sub !== 'set') {
+    return fail('use status | use <OFF|FLOW|GUIDE|GOVERN|ASSURE> | route <FLOW|GUIDE|GOVERN|ASSURE>');
+  }
   if (args.length !== 2) return fail(`${sub} requer exatamente um perfil`);
   let profile;
   try { profile = normalizeOperatingProfile(args[1], { strict: true }); }

--- a/src/skills-seed.mjs
+++ b/src/skills-seed.mjs
@@ -17,6 +17,24 @@ Use ao começar implementação, correção ou refatoração. **Keep Core perman
 em todos os perfis: Vault, sessão, identidade, memória, lessons e persistência. Na ausência de
 configuração válida, **GOVERN é o padrão** compatível.
 
+## Seleção temporária por solicitação
+
+Antes de editar, classifique a implementação atual e registre a escolha auditável com
+\`wendkeep profile route <FLOW|GUIDE|GOVERN|ASSURE> --session <id> --reason <texto>\`.
+A lease vale somente para a solicitação atual; ao encerrá-la, o perfil persistente da
+sessão/projeto volta a valer. **OFF nunca é uma escolha automática da LLM**: somente uma pessoa
+pode persistir \`profile use OFF\` explicitamente.
+
+- **FLOW:** ajuste local, reversível e de escopo fechado, sem contrato/spec, segurança,
+  dependência, CI/release ou policy.
+- **GUIDE:** mudança compacta de comportamento que precisa de change/spec, sem revisão formal.
+- **GOVERN:** escolha conservadora em caso de dúvida ou risco e para superfícies sensíveis.
+- **ASSURE:** GOVERN quando confirmação explícita e handoff fazem parte do contrato.
+
+O harness da LLM faz essa classificação semântica; o Wend Runtime valida e aplica a lease.
+Se não houver uma sessão causal identificada ou o comando falhar, não fabrique estado: use o
+perfil efetivo já injetado e trate \`GOVERN\` como fallback conservador quando ele for o padrão.
+
 <HARD-GATE>
 Antes de editar, leia o **perfil efetivo** injetado pelo WendKeep e siga somente sua rota:
 - \`OFF\`: não imponha processo Wend; a governança pertence ao **harness nativo da LLM**.
@@ -267,6 +285,24 @@ const WORKFLOW_EN = `# Operating Profiles — wendkeep work router
 Use this when starting an implementation, fix, or refactor. **Keep Core is always active**
 in every profile: Vault, session, identity, memory, lessons, and persistence. With no valid
 configuration, **GOVERN is the default** for compatibility.
+
+## Temporary selection per request
+
+Before editing, classify the current implementation and record the auditable choice with
+\`wendkeep profile route <FLOW|GUIDE|GOVERN|ASSURE> --session <id> --reason <text>\`.
+The lease applies only to the current request; after it ends, the persistent session/project
+profile becomes effective again. **OFF is never an automatic LLM choice**: only a human can
+persist it explicitly through \`profile use OFF\`.
+
+- **FLOW:** a local, reversible, bounded adjustment with no contract/spec, security, dependency,
+  CI/release, or policy impact.
+- **GUIDE:** a compact behavior change that needs a change/spec but no formal review.
+- **GOVERN:** the conservative choice when uncertain or risky, and for sensitive surfaces.
+- **ASSURE:** GOVERN when explicit confirmation and handoff are part of the contract.
+
+The LLM harness owns semantic classification; Wend Runtime validates and applies the lease. If
+there is no causally identified session or the command fails, do not fabricate state: use the
+already injected effective profile, with \`GOVERN\` as the conservative configured fallback.
 
 <HARD-GATE>
 Before editing, read the injected **effective profile** and follow only its route:
@@ -619,7 +655,7 @@ size of the problem>
 // usuário ("implementa X", "corrige Y"), não com abstrações ("mudança não-trivial"). Gatilhos
 // concretos + instrução imperativa = a skill dispara sozinha (paridade Superpowers).
 const WK_SKILLS_PT = [
-  skill('wk-workflow', 'Use quando o usuário pedir para implementar, criar, corrigir, refatorar, adicionar ou alterar código: leia o perfil efetivo e roteie OFF/FLOW/GUIDE/GOVERN/ASSURE ANTES de editar. Keep Core permanece ativo; GOVERN é o padrão compatível.', WORKFLOW),
+  skill('wk-workflow', 'Use quando o usuário pedir para implementar, criar, corrigir, refatorar, adicionar ou alterar código: classifique e registre a rota temporária FLOW/GUIDE/GOVERN/ASSURE ANTES de editar, então siga o perfil efetivo. Keep Core permanece ativo; OFF nunca é automático.', WORKFLOW),
   skill('wk-tdd', 'Use ao implementar qualquer comportamento — Red/Green/Refactor com testes que discriminam (derivados do spec, litmus não-raso, adequação).', TDD),
   skill('wk-debugging', 'Use quando algo falha, quebra, dá erro ou regride — depuração sistemática por hipótese antes de corrigir.', DEBUGGING),
   skill('wk-brainstorming', 'Use quando a ideia ainda é vaga ou o usuário quer discutir/planejar uma feature (inclusive em plan mode) — vira design aprovado, com closure gate e tabela out-of-scope, antes de código.', BRAINSTORMING, [{ name: 'design-template.md', content: DESIGN_TEMPLATE_PT }]),
@@ -628,7 +664,7 @@ const WK_SKILLS_PT = [
 ];
 
 const WK_SKILLS_EN = [
-  skill('wk-workflow', 'Use when the user asks to implement, create, fix, refactor, add, or change code: read the effective profile and route OFF/FLOW/GUIDE/GOVERN/ASSURE BEFORE editing. Keep Core stays active; GOVERN is the compatible default.', WORKFLOW_EN),
+  skill('wk-workflow', 'Use when the user asks to implement, create, fix, refactor, add, or change code: classify and record the temporary FLOW/GUIDE/GOVERN/ASSURE route BEFORE editing, then follow the effective profile. Keep Core stays active; OFF is never automatic.', WORKFLOW_EN),
   skill('wk-tdd', 'Use when implementing any behaviour — Red/Green/Refactor with tests that discriminate (spec-derived, non-shallow litmus, adequacy).', TDD_EN),
   skill('wk-debugging', 'Use when something fails, breaks, errors or regresses — systematic hypothesis-driven debugging before fixing.', DEBUGGING_EN),
   skill('wk-brainstorming', 'Use when the idea is still vague or the user wants to discuss/plan a feature (plan mode included) — turns it into an approved design, with a closure gate and out-of-scope table, before code.', BRAINSTORMING_EN, [{ name: 'design-template.md', content: DESIGN_TEMPLATE_EN }]),

--- a/src/sync-defs.mjs
+++ b/src/sync-defs.mjs
@@ -62,7 +62,12 @@ function renderAgentsSection(skills, sourceHash = '') {
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. **Keep Core is always active**
 in every profile: Vault, session, identity, memory, lessons, and persistence integrations.
-The effective profile is selected explicitly; missing or invalid configuration uses **GOVERN as the default**.
+The persistent profile is selected explicitly; missing or invalid configuration uses **GOVERN as the default**.
+
+Before an implementation, the native LLM harness classifies the current request and may create a
+task-scoped lease with \`wendkeep profile route <FLOW|GUIDE|GOVERN|ASSURE> --session <id> --reason <text>\`.
+The lease expires when that request ends and the persistent session/project profile becomes
+effective again. **OFF is never selected adaptively**; only a human can persist \`profile use OFF\`.
 
 Route work by the effective profile:
 - **OFF** — Wend Runtime is disabled and governance belongs to the native LLM harness; Keep Core stays active.

--- a/tests/docs-bilingual.test.mjs
+++ b/tests/docs-bilingual.test.mjs
@@ -230,6 +230,7 @@ test('[req:OP-9] DOC-8: perfis, Keep Core e FLOW têm contrato público bilíngu
       sessions: readFileSync(join(GUIDE_DIR.pt, 'sessions-and-import.md'), 'utf8'),
       keepCore: /Keep Core[\s\S]*(?:sempre ativo|permanece ativo)/i,
       explicitOff: /OFF[\s\S]*(?:explicitamente|seleção explícita)/i,
+      taskLease: /profile route[\s\S]*(?:solicitação atual|temporária|lease)/i,
       flowNoChange: /FLOW[\s\S]*(?:sem change|não cria[^\n]*change)/i,
       simpleCompat: /--simple[\s\S]*(?:não é|não equivale)[\s\S]*FLOW/i,
       vaultAlways: /OFF[\s\S]*(?:Vault|cofre)[\s\S]*(?:continua|permanece|ativo)/i,
@@ -242,6 +243,7 @@ test('[req:OP-9] DOC-8: perfis, Keep Core e FLOW têm contrato público bilíngu
       sessions: readFileSync(join(GUIDE_DIR.en, 'sessions-and-import.md'), 'utf8'),
       keepCore: /Keep Core[\s\S]*(?:always active|remains active)/i,
       explicitOff: /OFF[\s\S]*(?:explicitly|explicit selection)/i,
+      taskLease: /profile route[\s\S]*(?:current request|temporary|lease)/i,
       flowNoChange: /FLOW[\s\S]*(?:without a change|does not create[^\n]*change)/i,
       simpleCompat: /--simple[\s\S]*(?:is not|does not equal)[\s\S]*FLOW/i,
       vaultAlways: /OFF[\s\S]*Vault[\s\S]*(?:continues|remains|active)/i,
@@ -254,10 +256,12 @@ test('[req:OP-9] DOC-8: perfis, Keep Core e FLOW têm contrato público bilíngu
       assert.match(docs.guide, new RegExp(`\\b${profile}\\b`), `${locale}: guia sem ${profile}`);
     }
     for (const command of [
-      'wendkeep profile status', 'wendkeep profile use',
+      'wendkeep profile status', 'wendkeep profile use', 'wendkeep profile route',
       'wendkeep flow start', 'wendkeep flow status', 'wendkeep flow show',
       'wendkeep flow finish', 'wendkeep flow promote',
     ]) assert.match(docs.guide, new RegExp(command), `${locale}: guia sem ${command}`);
+    assert.match(docs.readme, docs.taskLease, `${locale}: README sem lease por solicitação`);
+    assert.match(docs.guide, docs.taskLease, `${locale}: guia sem lease por solicitação`);
 
     assert.match(
       docs.guide,

--- a/tests/import-summary.test.mjs
+++ b/tests/import-summary.test.mjs
@@ -175,3 +175,142 @@ test('buildIterationBlock: truncamento mantém backticks confinados à própria 
   }
   assert.match(block, /\n\*\*Ferramentas usadas:\*\*/, 'a próxima seção continua fora de code span');
 });
+
+test('[req:IMPORT-6] buildIterationBlock limpa metadados internos sem apagar a menção do usuário', async () => {
+  const { buildIterationBlock } = await import('../hooks/session-stop.mjs');
+  const userMention = 'O erro exibiu <oai-mem-citation> <citation_entries> no Obsidian.';
+  const assistantWithMetadata = [
+    'A causa foi isolada.',
+    '</session>',
+    '<oai-mem-citation>',
+    '<citation_entries>',
+    'MEMORY.md:1-2|note=[internal]',
+    '</citation_entries>',
+    '<rollout_ids>019f-example</rollout_ids>',
+    '</oai-mem-citation>',
+  ].join('\n');
+  const tx = {
+    latestTurnId: 'metadata-turn',
+    latestUserPrompt: userMention,
+    latestAssistantMessage: assistantWithMetadata,
+    model: '',
+    tools: [],
+    turns: [{
+      turnId: 'metadata-turn',
+      timestamp: '2026-08-01T13:00:00.000Z',
+      userPrompts: [userMention],
+      assistantMessages: [assistantWithMetadata],
+      conversation: [
+        { role: 'Usuário', text: userMention },
+        { role: 'Assistente', text: assistantWithMetadata },
+      ],
+      tools: [],
+      consultedFiles: [],
+      changedFiles: [],
+      usage: {},
+      model: '',
+    }],
+  };
+
+  const block = buildIterationBlock(tx, { turn_id: 'metadata-turn' });
+  const userLine = block.split('\n').find((line) => line.startsWith('- **Usuário:**'));
+  const assistantLine = block.split('\n').find((line) => line.startsWith('- **Assistente:**'));
+  const stateLine = block.split('\n').find((line) => line.startsWith('**Estado ao final do turno:**'));
+
+  assert.match(userLine, /&lt;oai-mem-citation&gt; &lt;citation_entries&gt;/, 'a reprodução do usuário permanece visível');
+  assert.equal(assistantLine, '- **Assistente:** A causa foi isolada.');
+  assert.equal(stateLine, '**Estado ao final do turno:** A causa foi isolada.');
+});
+
+test('buildIterationBlock: placeholders XML-like ficam visíveis sem quebrar o Markdown', async () => {
+  const { buildIterationBlock } = await import('../hooks/session-stop.mjs');
+  const prompt = 'Valide <session>, </session> e o autolink <https://example.com>.';
+  const assistant = 'Use <sessão> como placeholder; </sessão> também deve aparecer.';
+  const tx = {
+    latestTurnId: 'xml-placeholder-turn',
+    latestUserPrompt: prompt,
+    latestAssistantMessage: assistant,
+    model: '',
+    tools: [],
+    turns: [{
+      turnId: 'xml-placeholder-turn',
+      timestamp: '2026-08-01T13:00:00.000Z',
+      userPrompts: [prompt],
+      assistantMessages: [assistant],
+      conversation: [
+        { role: 'Usuário', text: prompt },
+        { role: 'Assistente', text: assistant },
+      ],
+      tools: [],
+      consultedFiles: [],
+      changedFiles: [],
+      usage: {},
+      model: '',
+    }],
+  };
+
+  const block = buildIterationBlock(tx, { turn_id: 'xml-placeholder-turn' });
+
+  assert.match(block, /&lt;session&gt;/);
+  assert.match(block, /&lt;\/session&gt;/);
+  assert.match(block, /&lt;sessão&gt;/u);
+  assert.match(block, /&lt;\/sessão&gt;/u);
+  assert.match(block, /<https:\/\/example\.com>/, 'autolinks Markdown não devem ser codificados');
+});
+
+test('[req:IMPORT-6] sessionFinalSummary remove envelopes e escapa XML-like sem quebrar autolinks', async () => {
+  const { sessionFinalSummary } = await import('../hooks/session-stop.mjs');
+  const summary = sessionFinalSummary({
+    latestAssistantMessage: [
+      'Concluído com <session>estado</session> e <https://example.com/prova>.',
+      '<oai-mem-citation>',
+      '<citation_entries>MEMORY.md:1-2|note=[internal]</citation_entries>',
+      '<rollout_ids>019f-example</rollout_ids>',
+      '</oai-mem-citation>',
+    ].join('\n'),
+    userPrompts: [],
+    tools: [],
+  });
+
+  assert.equal(
+    summary,
+    'Concluído com &lt;session&gt;estado&lt;/session&gt; e <https://example.com/prova>.',
+  );
+  assert.doesNotMatch(summary, /oai-mem-citation|citation_entries|rollout_ids/);
+});
+
+test('[req:IMPORT-6] reimport e SessionStop convergem para sanitização idempotente', async () => {
+  const { parseCodexTranscriptContent } = await import('../packages/integrations/src/transcripts.mjs');
+  const { sanitizeAssistantMessage } = await import('../packages/integrations/src/prompt-content.mjs');
+  const { sessionFinalSummary } = await import('../hooks/session-stop.mjs');
+  const cases = [
+    'Resposta citation.\n<citation_entries>x',
+    'Resposta rollout.\n<rollout_ids>x',
+    'Resposta adjacente.\n</session><oai-mem-citation><citation_entries>x',
+    `Resposta múltipla.\n${Array.from({ length: 5 }, (_, index) => (
+      `<oai-mem-citation><citation_entries>${index}</citation_entries></oai-mem-citation>`
+    )).join('\n')}`,
+  ];
+
+  for (const [index, raw] of cases.entries()) {
+    const expected = raw.slice(0, raw.indexOf('\n'));
+    const turnId = `import-6-${index}`;
+    const transcript = [
+      { type: 'turn_context', timestamp: '2026-08-01T13:00:00.000Z', payload: { turn_id: turnId } },
+      { type: 'event_msg', payload: { type: 'agent_message', turn_id: turnId, message: raw } },
+    ].map((event) => JSON.stringify(event)).join('\n');
+    const reimported = parseCodexTranscriptContent(transcript, {
+      repoRoot: 'C:\\work\\demo',
+      vaultRoot: 'C:\\work\\demo\\.WendKeep-vault',
+    });
+    const stopSummary = sessionFinalSummary({
+      latestAssistantMessage: raw,
+      userPrompts: [],
+      tools: [],
+    });
+
+    assert.equal(reimported.latestAssistantMessage, expected);
+    assert.equal(stopSummary, expected);
+    assert.equal(sanitizeAssistantMessage(sanitizeAssistantMessage(raw)), expected);
+  }
+});

--- a/tests/integrations-kernel-boundary.test.mjs
+++ b/tests/integrations-kernel-boundary.test.mjs
@@ -29,7 +29,7 @@ const OWNED_BINDINGS = new Map([
     'salvageTruncatedJson', 'parseHookInput', 'stringifyHookOutput',
     'detectProvider', 'providerMeta', 'extractHookPrompt',
   ]],
-  ['src/prompt-content.mjs', ['isBootstrapPrompt', 'redactSecrets']],
+  ['src/prompt-content.mjs', ['isBootstrapPrompt', 'redactSecrets', 'sanitizeAssistantMessage']],
   ['src/transcript-usage.mjs', [
     'emptyTokenUsage', 'normalizeCodexUsage', 'normalizeClaudeUsage', 'addUsage',
   ]],

--- a/tests/integrations-transcripts.test.mjs
+++ b/tests/integrations-transcripts.test.mjs
@@ -427,3 +427,144 @@ test('[req:MOD-20] [req:MOD-21] parsers por conteúdo são determinísticos e n�
   assert.deepEqual(second, first);
   assert.equal(JSON.stringify(PARSE_OPTIONS), before);
 });
+
+test('[req:IMPORT-6] metadados internos são removidos apenas das mensagens do assistente no transcript Codex', () => {
+  const userMention = [
+    'Também encontrei este texto em outra sessão:',
+    '</session>',
+    '<oai-mem-citation> <citation_entries>',
+    '</citation_entries> <rollout_ids> exemplo </rollout_ids> </oai-mem-citation>',
+  ].join('\n');
+  const completeAssistant = [
+    'A correção foi validada.',
+    '</session>',
+    '<oai-mem-citation>',
+    '<citation_entries>',
+    'MEMORY.md:1-2|note=[internal]',
+    '</citation_entries>',
+    '<rollout_ids>019f-example</rollout_ids>',
+    '</oai-mem-citation>',
+  ].join('\n');
+  const truncatedAssistant = [
+    'O próximo passo está pronto.',
+    '<oai-mem-citation>',
+    '<citation_entries>',
+    'MEMORY.md:3-4|note=[truncated]',
+  ].join('\n');
+  const inlineMarkerMention = 'Os nomes <oai-mem-citation>, <citation_entries> e <rollout_ids> permanecem como exemplo.';
+  const adjacentInlineMention = 'A documentação usa <oai-mem-citation> <citation_entries> como exemplo.';
+  const attachedInlineMention = 'Docs:<oai-mem-citation> <citation_entries> são tags.';
+  const lineStartInlineMention = 'Marcadores:\n<oai-mem-citation> <citation_entries> são tags.';
+  const content = jsonl([
+    { type: 'turn_context', timestamp: '2026-08-01T13:00:00.000Z', payload: { turn_id: 'meta-1' } },
+    { type: 'event_msg', payload: { type: 'user_message', turn_id: 'meta-1', message: userMention } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-1', message: completeAssistant } },
+    { type: 'turn_context', timestamp: '2026-08-01T13:01:00.000Z', payload: { turn_id: 'meta-2' } },
+    { type: 'event_msg', payload: { type: 'user_message', turn_id: 'meta-2', message: 'Continue.' } },
+    {
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'assistant',
+        turn_id: 'meta-2',
+        content: [{ type: 'output_text', text: truncatedAssistant }],
+      },
+    },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Use </session> apenas como exemplo.' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Terceira resposta.\n<oai-mem-citation>' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Quarta resposta.\n<citation_entries>' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Quinta resposta.\n<citation_entries>\nMEMORY.md:5-6|note=[standalone]\n</citation_entries>' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Sexta resposta.\n<citation_entries>\nMEMORY.md:7-8|note=[standalone-truncated]' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Sétima resposta.\n<rollout_ids>019f-complete</rollout_ids>' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Oitava resposta.\n<rollout_ids>\n019f-truncated' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Nona resposta.\n<rollout_ids>' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Décima resposta.\n<citation_entries>x' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Décima primeira resposta.\n<rollout_ids>x' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Décima segunda resposta.\n</session><oai-mem-citation><citation_entries>x' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Décima terceira resposta.</session><oai-mem-citation><rollout_ids>x' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Décima quarta resposta.<oai-mem-citation> <citation_entries>x' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Décima quinta resposta.\n<citation_entries>\ntexto comum depois' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Décima sexta resposta.\n<rollout_ids>x</rollout_ids>\ntexto comum depois' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'Décima sétima resposta.\n<oai-mem-citation><citation_entries>x</citation_entries></oai-mem-citation>\ntexto comum depois' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: 'A tag <oai-mem-citation> citada sem payload permanece.' } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: inlineMarkerMention } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: adjacentInlineMention } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: attachedInlineMention } },
+    { type: 'event_msg', payload: { type: 'agent_message', turn_id: 'meta-2', message: lineStartInlineMention } },
+  ]);
+
+  const parsed = parseCodexTranscriptContent(content, PARSE_OPTIONS);
+
+  assert.ok(parsed.userPrompts.includes(userMention), 'a citação escrita pelo usuário deve permanecer intacta');
+  assert.deepEqual(parsed.assistantMessages, [
+    'A correção foi validada.',
+    'O próximo passo está pronto.',
+    'Use </session> apenas como exemplo.',
+    'Terceira resposta.',
+    'Quarta resposta.',
+    'Quinta resposta.',
+    'Sexta resposta.',
+    'Sétima resposta.',
+    'Oitava resposta.',
+    'Nona resposta.',
+    'Décima resposta.',
+    'Décima primeira resposta.',
+    'Décima segunda resposta.',
+    'Décima terceira resposta.',
+    'Décima quarta resposta.',
+    'Décima quinta resposta.\ntexto comum depois',
+    'Décima sexta resposta.\ntexto comum depois',
+    'Décima sétima resposta.\ntexto comum depois',
+    'A tag <oai-mem-citation> citada sem payload permanece.',
+    inlineMarkerMention,
+    adjacentInlineMention,
+    attachedInlineMention,
+    lineStartInlineMention,
+  ]);
+  const sanitizedMetadata = parsed.assistantMessages.filter((message) => (
+    message !== inlineMarkerMention
+      && message !== adjacentInlineMention
+      && message !== attachedInlineMention
+      && message !== lineStartInlineMention
+      && message !== 'A tag <oai-mem-citation> citada sem payload permanece.'
+  ));
+  assert.doesNotMatch(sanitizedMetadata.join('\n'), /oai-mem-citation|citation_entries|rollout_ids/);
+  assert.equal(parsed.latestAssistantMessage, lineStartInlineMention);
+});
+
+test('[req:IMPORT-6] metadados internos completos e truncados são removidos das mensagens Claude', () => {
+  const completeAssistant = [
+    'Resposta Claude preservada.',
+    '<oai-mem-citation>',
+    '<citation_entries></citation_entries>',
+    '<rollout_ids>019f-example</rollout_ids>',
+    '</oai-mem-citation>',
+  ].join('\n');
+  const truncatedAssistant = 'Segunda resposta.\n<oai-mem-citation> <citation_entries>';
+  const content = jsonl([
+    {
+      type: 'user',
+      uuid: 'claude-meta-turn',
+      timestamp: '2026-08-01T13:00:00.000Z',
+      message: { role: 'user', content: 'Valide a captura.' },
+    },
+    {
+      type: 'assistant',
+      uuid: 'claude-meta-answer',
+      timestamp: '2026-08-01T13:00:01.000Z',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: completeAssistant },
+          { type: 'text', text: truncatedAssistant },
+        ],
+      },
+    },
+  ]);
+
+  const parsed = parseClaudeTranscriptContent(content, PARSE_OPTIONS);
+
+  assert.deepEqual(parsed.assistantMessages, ['Resposta Claude preservada.', 'Segunda resposta.']);
+  assert.equal(parsed.latestAssistantMessage, 'Segunda resposta.');
+  assert.doesNotMatch(parsed.rawTextForDetection, /oai-mem-citation|citation_entries|rollout_ids/);
+});

--- a/tests/operating-profile-hooks.test.mjs
+++ b/tests/operating-profile-hooks.test.mjs
@@ -24,6 +24,7 @@ import { capturePlan } from '../hooks/plan-capture.mjs';
 import { setActiveChange } from '../hooks/change-core.mjs';
 import { upsertSessionRegistry } from '../hooks/obsidian-common.mjs';
 import { resolveHookOperatingProfile } from '../hooks/operating-profile-runtime.mjs';
+import { setSessionTaskOperatingProfile } from '../hooks/operating-profile-task-store.mjs';
 import { readMemoryLedger } from '../hooks/memory-store.mjs';
 import { seedMemoryV2 } from '../src/memory.mjs';
 import { bindProjectVault } from '../src/project-vault.mjs';
@@ -259,6 +260,99 @@ test('[req:OP-2] hook runtime resolves session override before project binding a
     assert.equal(invalid.profile, 'GOVERN');
     assert.equal(invalid.source, 'session-override-invalid');
     assert.equal(invalid.valid, false);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('[req:OP-2] [req:OP-12] hook aplica lease somente no prompt ligado e restaura a base no seguinte', () => {
+  const fixture = makeBoundProject('OFF');
+  try {
+    upsertSessionRegistry(fixture.vault, 'task-runtime', {
+      status: 'active',
+      provider: 'claude',
+      operating_profile: 'OFF',
+      advance_turn_sequence: true,
+      turn_id: 'turn-1',
+      turn_sequence: 1,
+    });
+    setSessionTaskOperatingProfile(fixture.vault, 'task-runtime', 'GOVERN', {
+      reason: 'mudança de policy', leaseId: 'lease-govern', now: '2026-08-01T17:00:00.000Z',
+    });
+
+    const active = resolveHookOperatingProfile({
+      input: {
+        cwd: fixture.project, session_id: 'task-runtime',
+        turn_id: 'turn-1', turn_sequence: 1,
+      },
+      provider: 'claude',
+    });
+    assert.equal(active.profile, 'GOVERN');
+    assert.equal(active.source, 'task-lease');
+    assert.equal(active.baseProfile, 'OFF');
+    assert.equal(active.taskLease.state, 'active');
+
+    const nextPrompt = resolveHookOperatingProfile({
+      input: {
+        cwd: fixture.project, session_id: 'task-runtime',
+        turn_id: 'turn-2', turn_sequence: 2,
+      },
+      provider: 'claude',
+    });
+    assert.equal(nextPrompt.profile, 'OFF');
+    assert.equal(nextPrompt.source, 'session-override');
+    assert.equal(nextPrompt.taskLease.state, 'expired');
+
+    upsertSessionRegistry(fixture.vault, 'task-runtime', {
+      advance_turn_sequence: true, turn_id: 'turn-2', turn_sequence: 2,
+    });
+    const advancedRegistry = resolveHookOperatingProfile({
+      input: { cwd: fixture.project, session_id: 'task-runtime' },
+      provider: 'claude',
+    });
+    assert.equal(advancedRegistry.profile, 'OFF');
+    assert.equal(advancedRegistry.taskLease.state, 'expired');
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('[req:OP-12] change-nag consome lease no Stop aceito e preserva durante bloqueio/retry', () => {
+  const fixture = makeBoundProject('OFF');
+  const sessionId = 'task-stop';
+  const input = {
+    cwd: fixture.project,
+    session_id: sessionId,
+    turn_id: 'turn-stop',
+    turn_sequence: 1,
+  };
+  try {
+    upsertSessionRegistry(fixture.vault, sessionId, {
+      status: 'active', provider: 'claude',
+      advance_turn_sequence: true, turn_id: 'turn-stop', turn_sequence: 1,
+    });
+    setSessionTaskOperatingProfile(fixture.vault, sessionId, 'FLOW', {
+      reason: 'ajuste local', leaseId: 'lease-stop-ok', now: '2026-08-01T17:00:00.000Z',
+    });
+    const accepted = runHookMain('change-nag', input, { cwd: fixture.project });
+    assert.equal(accepted.status, 0, accepted.stderr);
+    assert.deepEqual(JSON.parse(accepted.stdout), {});
+    let registry = JSON.parse(readFileSync(join(fixture.vault, '.brain', 'SESSION_REGISTRY.json'), 'utf8'));
+    assert.equal(registry.sessions[sessionId].operating_profile_task.state, 'consumed');
+
+    addOpenChange(fixture.vault, 'task-stop-open');
+    setSessionTaskOperatingProfile(fixture.vault, sessionId, 'GOVERN', {
+      reason: 'change governada', leaseId: 'lease-stop-block', now: '2026-08-01T17:01:00.000Z',
+    });
+    const blocked = runHookMain('change-nag', input, { cwd: fixture.project });
+    assert.equal(JSON.parse(blocked.stdout).decision, 'block');
+    registry = JSON.parse(readFileSync(join(fixture.vault, '.brain', 'SESSION_REGISTRY.json'), 'utf8'));
+    assert.equal(registry.sessions[sessionId].operating_profile_task.state, 'active');
+
+    const retry = runHookMain('change-nag', { ...input, stop_hook_active: true }, { cwd: fixture.project });
+    assert.deepEqual(JSON.parse(retry.stdout), {});
+    registry = JSON.parse(readFileSync(join(fixture.vault, '.brain', 'SESSION_REGISTRY.json'), 'utf8'));
+    assert.equal(registry.sessions[sessionId].operating_profile_task.state, 'consumed');
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }

--- a/tests/operating-profile-task-store.test.mjs
+++ b/tests/operating-profile-task-store.test.mjs
@@ -1,0 +1,99 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { readSessionRegistry } from '../hooks/obsidian-common.mjs';
+import {
+  consumeSessionTaskOperatingProfile,
+  setSessionTaskOperatingProfile,
+} from '../hooks/operating-profile-task-store.mjs';
+
+function fixture() {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-task-profile-store-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  const note = join(vault, 'session.md');
+  writeFileSync(note, '# bytes imutáveis\n', 'utf8');
+  writeFileSync(join(vault, '.brain', 'SESSION_REGISTRY.json'), `${JSON.stringify({
+    version: 2,
+    sessions: {
+      'session-1': {
+        status: 'active',
+        provider: 'codex',
+        session_file: 'session.md',
+        operating_profile: 'OFF',
+        operating_profile_source: 'explicit-cli',
+        last_prompt_turn_id: 'turn-5',
+        last_turn_sequence: 5,
+        turn_sequences: { 'turn-5': 5 },
+      },
+    },
+  }, null, 2)}\n`, 'utf8');
+  return { vault, note };
+}
+
+test('[req:OP-11] store cria lease no prompt atual sem alterar perfil persistente, identidade ou nota', () => {
+  const f = fixture();
+  try {
+    const noteBefore = readFileSync(f.note);
+    const lease = setSessionTaskOperatingProfile(f.vault, 'session-1', 'FLOW', {
+      reason: 'ajuste local reversível',
+      leaseId: 'lease-flow-1',
+      now: '2026-08-01T17:00:00.000Z',
+    });
+    assert.equal(lease.profile, 'FLOW');
+    assert.equal(lease.request_turn_id, 'turn-5');
+    assert.equal(lease.request_turn_sequence, 5);
+
+    const entry = readSessionRegistry(f.vault).sessions['session-1'];
+    assert.equal(entry.operating_profile, 'OFF');
+    assert.equal(entry.operating_profile_source, 'explicit-cli');
+    assert.deepEqual(entry.operating_profile_task, lease);
+    assert.equal(entry.session_file, 'session.md');
+    assert.deepEqual(readFileSync(f.note), noteBefore);
+  } finally { rmSync(f.vault, { recursive: true, force: true }); }
+});
+
+test('[req:OP-11] [req:OP-12] leases reais recebem ids distintos, substituem e usam CAS por lease_id', () => {
+  const f = fixture();
+  try {
+    const first = setSessionTaskOperatingProfile(f.vault, 'session-1', 'FLOW', {
+      reason: 'primeira rota', now: '2026-08-01T17:00:00.000Z',
+    });
+    const second = setSessionTaskOperatingProfile(f.vault, 'session-1', 'GOVERN', {
+      reason: 'risco descoberto', now: '2026-08-01T17:01:00.000Z',
+    });
+    assert.match(first.lease_id, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+    assert.match(second.lease_id, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+    assert.notEqual(first.lease_id, second.lease_id);
+    assert.equal(consumeSessionTaskOperatingProfile(
+      f.vault, 'session-1', first.lease_id, { now: '2026-08-01T17:02:00.000Z' },
+    ), false);
+    assert.equal(readSessionRegistry(f.vault).sessions['session-1'].operating_profile_task.state, 'active');
+    assert.equal(consumeSessionTaskOperatingProfile(
+      f.vault, 'session-1', second.lease_id, { now: '2026-08-01T17:03:00.000Z' },
+    ), true);
+    const consumed = readSessionRegistry(f.vault).sessions['session-1'].operating_profile_task;
+    assert.equal(consumed.state, 'consumed');
+    assert.equal(consumed.consumed_at, '2026-08-01T17:03:00.000Z');
+  } finally { rmSync(f.vault, { recursive: true, force: true }); }
+});
+
+test('[req:OP-11] store rejeita sessão sem prompt causal sem criar estado parcial', () => {
+  const f = fixture();
+  try {
+    const path = join(f.vault, '.brain', 'SESSION_REGISTRY.json');
+    const registry = JSON.parse(readFileSync(path, 'utf8'));
+    delete registry.sessions['session-1'].last_turn_sequence;
+    writeFileSync(path, `${JSON.stringify(registry, null, 2)}\n`, 'utf8');
+    const before = readFileSync(path, 'utf8');
+    assert.throws(
+      () => setSessionTaskOperatingProfile(f.vault, 'session-1', 'FLOW', {
+        reason: 'sem prompt', leaseId: 'lease-invalid', now: '2026-08-01T17:00:00.000Z',
+      }),
+      (error) => error?.code === 'WENDKEEP_TASK_PROFILE_CONTEXT_INVALID',
+    );
+    assert.equal(readFileSync(path, 'utf8'), before);
+  } finally { rmSync(f.vault, { recursive: true, force: true }); }
+});

--- a/tests/operating-profile.test.mjs
+++ b/tests/operating-profile.test.mjs
@@ -2,14 +2,141 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  ADAPTIVE_OPERATING_PROFILES,
   DEFAULT_OPERATING_PROFILE,
   OPERATING_PROFILES,
   OPERATING_PROFILE_POLICIES,
+  createTaskOperatingProfileLease,
+  evaluateTaskOperatingProfileLease,
   normalizeOperatingProfile,
   operatingProfilePolicy,
   resolveOperatingProfile,
   setOperatingProfile,
 } from '../src/operating-profile.mjs';
+
+test('[req:OP-11] seleção adaptativa aceita quatro rotas e nunca aceita OFF', () => {
+  assert.deepEqual(ADAPTIVE_OPERATING_PROFILES, ['FLOW', 'GUIDE', 'GOVERN', 'ASSURE']);
+  assert.equal(Object.isFrozen(ADAPTIVE_OPERATING_PROFILES), true);
+
+  for (const profile of ADAPTIVE_OPERATING_PROFILES) {
+    const lease = createTaskOperatingProfileLease({
+      profile,
+      reason: 'implementação classificada pelo harness',
+      sessionId: 'session-1',
+      turnId: 'turn-7',
+      turnSequence: 7,
+      leaseId: `lease-${profile.toLowerCase()}`,
+      issuedAt: '2026-08-01T17:00:00.000Z',
+    });
+    assert.equal(lease.profile, profile);
+    assert.equal(lease.state, 'active');
+    assert.equal(lease.requested_by, 'llm-harness');
+    assert.equal(lease.request_turn_id, 'turn-7');
+    assert.equal(lease.request_turn_sequence, 7);
+    assert.equal(lease.expires_on, 'request-stop');
+  }
+
+  for (const profile of ['OFF', 'AUTO', '', null]) {
+    assert.throws(
+      () => createTaskOperatingProfileLease({
+        profile,
+        reason: 'não deve persistir',
+        sessionId: 'session-1',
+        turnSequence: 7,
+        leaseId: 'lease-rejected',
+        issuedAt: '2026-08-01T17:00:00.000Z',
+      }),
+      (error) => error?.code === 'WENDKEEP_TASK_PROFILE_INVALID',
+    );
+  }
+});
+
+test('[req:OP-11] lease exige motivo auditável e identidade causal completa', () => {
+  const base = {
+    profile: 'FLOW', sessionId: 'session-1', turnId: 'turn-1', turnSequence: 1,
+    leaseId: 'lease-1', issuedAt: '2026-08-01T17:00:00.000Z',
+  };
+  for (const reason of ['', '   ', 'x'.repeat(501)]) {
+    assert.throws(
+      () => createTaskOperatingProfileLease({ ...base, reason }),
+      (error) => error?.code === 'WENDKEEP_TASK_PROFILE_REASON_INVALID',
+    );
+  }
+  for (const invalid of [
+    { ...base, reason: 'ok', sessionId: '' },
+    { ...base, reason: 'ok', turnId: '' },
+    { ...base, reason: 'ok', turnSequence: undefined },
+    { ...base, reason: 'ok', turnSequence: -1 },
+    { ...base, reason: 'ok', turnSequence: 0 },
+    { ...base, reason: 'ok', leaseId: '' },
+    { ...base, reason: 'ok', issuedAt: '' },
+  ]) {
+    assert.throws(
+      () => createTaskOperatingProfileLease(invalid),
+      (error) => error?.code === 'WENDKEEP_TASK_PROFILE_CONTEXT_INVALID',
+    );
+  }
+});
+
+test('[req:OP-12] avaliação causal distingue active, expired, consumed e invalid', () => {
+  const lease = createTaskOperatingProfileLease({
+    profile: 'GUIDE',
+    reason: 'change compacta',
+    sessionId: 'session-1',
+    turnId: 'turn-3',
+    turnSequence: 3,
+    leaseId: 'lease-guide',
+    issuedAt: '2026-08-01T17:00:00.000Z',
+  });
+
+  assert.equal(evaluateTaskOperatingProfileLease(lease, {
+    sessionId: 'session-1', turnId: 'turn-3', turnSequence: 3,
+  }).state, 'active');
+  assert.equal(evaluateTaskOperatingProfileLease(lease, {
+    sessionId: 'session-1', turnSequence: 3,
+  }).state, 'invalid', 'sem o turnId atual não há identidade causal suficiente');
+  assert.equal(evaluateTaskOperatingProfileLease(lease, {
+    sessionId: 'session-1', turnId: 'turn-4', turnSequence: 4,
+  }).state, 'expired');
+  assert.equal(evaluateTaskOperatingProfileLease({
+    ...lease, state: 'consumed', consumed_at: '2026-08-01T17:10:00.000Z',
+  }, { sessionId: 'session-1', turnId: 'turn-3', turnSequence: 3 }).state, 'consumed');
+  assert.equal(evaluateTaskOperatingProfileLease({ ...lease, profile: 'OFF' }, {
+    sessionId: 'session-1', turnId: 'turn-3', turnSequence: 3,
+  }).state, 'invalid');
+  assert.equal(evaluateTaskOperatingProfileLease(null, {
+    sessionId: 'session-1', turnId: 'turn-3', turnSequence: 3,
+  }).state, 'absent');
+});
+
+test('[req:OP-12] lease é isolada por sessão e nunca expira por relógio', () => {
+  const lease = createTaskOperatingProfileLease({
+    profile: 'FLOW',
+    reason: 'ajuste local ligado ao prompt',
+    sessionId: 'session-origin',
+    turnId: 'turn-1',
+    turnSequence: 1,
+    leaseId: 'lease-causal-only',
+    issuedAt: '2000-01-01T00:00:00.000Z',
+  });
+
+  assert.deepEqual(
+    Object.keys(lease).filter((key) => /expires|ttl|deadline/i.test(key)),
+    ['expires_on'],
+    'a lease só declara o evento causal de expiração, sem deadline/TTL',
+  );
+  assert.equal(evaluateTaskOperatingProfileLease(lease, {
+    sessionId: 'session-origin',
+    turnId: 'turn-1',
+    turnSequence: 1,
+    now: '2099-12-31T23:59:59.999Z',
+  }).state, 'active', 'tempo de parede não expira uma solicitação ainda causalmente ativa');
+  assert.equal(evaluateTaskOperatingProfileLease(lease, {
+    sessionId: 'session-other',
+    turnId: 'turn-1',
+    turnSequence: 1,
+  }).state, 'invalid', 'uma sessão diferente nunca herda a lease');
+});
 
 test('[req:OP-1] Perfis de Operação expõem somente os cinco nomes canônicos', () => {
   assert.deepEqual(OPERATING_PROFILES, ['OFF', 'FLOW', 'GUIDE', 'GOVERN', 'ASSURE']);

--- a/tests/profile-cli.test.mjs
+++ b/tests/profile-cli.test.mjs
@@ -41,6 +41,9 @@ function fixture() {
         status: 'active',
         provider: 'codex',
         session_file: sessionRel,
+        last_prompt_turn_id: 'turn-1',
+        last_turn_sequence: 1,
+        turn_sequences: { 'turn-1': 1 },
       },
     },
   }, null, 2)}\n`);
@@ -113,6 +116,146 @@ test('[req:OP-3] session override is audited without replacing project default, 
   } finally { rmSync(f.root, { recursive: true, force: true }); }
 });
 
+test('[req:OP-3] [req:OP-11] profile route cria lease temporária sem reescrever bases persistentes', () => {
+  const f = fixture();
+  try {
+    assert.equal(run(f.project, 'use', 'OFF').status, 0);
+    assert.equal(run(f.project, 'use', 'GOVERN', '--session', 'session-1').status, 0);
+    const absentStatus = run(f.project, 'status', '--session', 'session-1');
+    assert.equal(absentStatus.status, 0, absentStatus.stderr);
+    assert.equal(
+      absentStatus.stdout.trim(),
+      'GOVERN (session session-1; session-registry; base=GOVERN/session-registry; lease=absent)',
+    );
+    const configBefore = readFileSync(join(f.project, '.wendkeep.json'), 'utf8');
+    const noteBefore = readFileSync(f.sessionPath);
+
+    const routed = run(
+      f.project, 'route', 'FLOW', '--session', 'session-1',
+      '--reason', 'correção local e reversível', '--json',
+    );
+    assert.equal(routed.status, 0, routed.stderr);
+    const payload = JSON.parse(routed.stdout);
+    assert.equal(payload.profile, 'FLOW');
+    assert.equal(payload.source, 'task-lease');
+    assert.equal(payload.scope, 'task');
+    assert.equal(payload.base_profile, 'GOVERN');
+    assert.equal(payload.base_source, 'session-registry');
+    assert.equal(payload.task_lease.state, 'active');
+    assert.equal(payload.task_lease.request_turn_id, 'turn-1');
+    assert.equal(payload.task_lease.request_turn_sequence, 1);
+    assert.match(payload.task_lease.lease_id, /^[0-9a-f-]{36}$/i);
+    assert.equal(payload.task_lease.reason, 'correção local e reversível');
+    assert.equal(payload.task_lease.requested_by, 'llm-harness');
+    assert.match(payload.task_lease.issued_at, /^\d{4}-\d{2}-\d{2}T/);
+    assert.equal(payload.task_lease.expires_on, 'request-stop');
+
+    const registry = JSON.parse(readFileSync(join(f.vault, '.brain', 'SESSION_REGISTRY.json'), 'utf8'));
+    assert.equal(registry.sessions['session-1'].operating_profile, 'GOVERN');
+    const auditedLease = registry.sessions['session-1'].operating_profile_task;
+    assert.equal(auditedLease.profile, 'FLOW');
+    assert.equal(auditedLease.reason, 'correção local e reversível');
+    assert.equal(auditedLease.requested_by, 'llm-harness');
+    assert.match(auditedLease.issued_at, /^\d{4}-\d{2}-\d{2}T/);
+    assert.equal(auditedLease.expires_on, 'request-stop');
+    assert.equal(readFileSync(join(f.project, '.wendkeep.json'), 'utf8'), configBefore);
+    assert.deepEqual(readFileSync(f.sessionPath), noteBefore);
+
+    const status = run(f.project, 'status', '--session', 'session-1', '--json');
+    const current = JSON.parse(status.stdout);
+    assert.equal(current.profile, 'FLOW');
+    assert.equal(current.source, 'task-lease');
+    assert.equal(current.scope, 'task');
+    const humanStatus = run(f.project, 'status', '--session', 'session-1');
+    assert.equal(humanStatus.status, 0, humanStatus.stderr);
+    assert.equal(
+      humanStatus.stdout.trim(),
+      'FLOW (task session-1; task-lease; base=GOVERN/session-registry; lease=active)',
+    );
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('[req:OP-3] profile route rejeita sessão sem prompt causal registrado sem mutação parcial', () => {
+  const f = fixture();
+  try {
+    const registryPath = join(f.vault, '.brain', 'SESSION_REGISTRY.json');
+    const original = JSON.parse(readFileSync(registryPath, 'utf8'));
+    const invalidContexts = [
+      { last_prompt_turn_id: '', last_turn_sequence: 1, turn_sequences: { 'turn-1': 1 } },
+      { last_prompt_turn_id: 'turn-1', last_turn_sequence: 0, turn_sequences: { 'turn-1': 0 } },
+      { last_prompt_turn_id: 'turn-1', last_turn_sequence: 1, turn_sequences: undefined },
+      { last_prompt_turn_id: 'turn-1', last_turn_sequence: 1, turn_sequences: {} },
+      { last_prompt_turn_id: 'turn-1', last_turn_sequence: 1, turn_sequences: { 'turn-1': 2 } },
+    ];
+
+    for (const context of invalidContexts) {
+      const registry = structuredClone(original);
+      Object.assign(registry.sessions['session-1'], context);
+      writeFileSync(registryPath, `${JSON.stringify(registry, null, 2)}\n`, 'utf8');
+      const before = readFileSync(registryPath, 'utf8');
+      const result = run(
+        f.project, 'route', 'FLOW', '--session', 'session-1', '--reason', 'contexto causal incompleto',
+      );
+
+      assert.equal(result.status, 2, JSON.stringify(context));
+      assert.match(result.stderr, /prompt causal|contexto|Rota temporária exige/i);
+      assert.equal(readFileSync(registryPath, 'utf8'), before);
+    }
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('[req:OP-12] profile status restaura a base quando a sequência causal avança', () => {
+  const f = fixture();
+  try {
+    assert.equal(run(f.project, 'use', 'GUIDE', '--session', 'session-1').status, 0);
+    assert.equal(run(
+      f.project, 'route', 'FLOW', '--session', 'session-1', '--reason', 'pedido um',
+    ).status, 0);
+    const path = join(f.vault, '.brain', 'SESSION_REGISTRY.json');
+    const registry = JSON.parse(readFileSync(path, 'utf8'));
+    Object.assign(registry.sessions['session-1'], {
+      last_prompt_turn_id: 'turn-2',
+      last_turn_sequence: 2,
+      turn_sequences: { 'turn-1': 1, 'turn-2': 2 },
+    });
+    writeFileSync(path, `${JSON.stringify(registry, null, 2)}\n`, 'utf8');
+
+    const status = run(f.project, 'status', '--session', 'session-1', '--json');
+    assert.equal(status.status, 0, status.stderr);
+    const payload = JSON.parse(status.stdout);
+    assert.equal(payload.profile, 'GUIDE');
+    assert.equal(payload.source, 'session-registry');
+    assert.equal(payload.scope, 'session');
+    assert.equal(payload.base_profile, 'GUIDE');
+    assert.equal(payload.task_lease.state, 'expired');
+    const humanStatus = run(f.project, 'status', '--session', 'session-1');
+    assert.equal(humanStatus.status, 0, humanStatus.stderr);
+    assert.equal(
+      humanStatus.stdout.trim(),
+      'GUIDE (session session-1; session-registry; base=GUIDE/session-registry; lease=expired)',
+    );
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('[req:OP-11] profile route rejeita OFF, motivo/sessão ausentes e flags inválidas sem mutar', () => {
+  const f = fixture();
+  try {
+    const registryPath = join(f.vault, '.brain', 'SESSION_REGISTRY.json');
+    const before = readFileSync(registryPath, 'utf8');
+    for (const args of [
+      ['route', 'OFF', '--session', 'session-1', '--reason', 'não pode'],
+      ['route', 'FLOW', '--reason', 'sem sessão'],
+      ['route', 'FLOW', '--session', 'session-1'],
+      ['route', 'FLOW', '--session', 'session-1', '--reason', ''],
+      ['route', 'FLOW', '--session', 'session-1', '--reason', 'a', '--reason', 'b'],
+    ]) {
+      const result = run(f.project, ...args);
+      assert.equal(result.status, 2, `${args.join(' ')}\n${result.stderr}`);
+      assert.equal(readFileSync(registryPath, 'utf8'), before);
+    }
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
 test('invalid profile or unknown session exits 2 without partial mutation', () => {
   const f = fixture();
   try {
@@ -143,6 +286,8 @@ test('unknown or incomplete flags fail closed instead of mutating project scope'
     assert.equal(run(f.project, 'use', 'OFF', '--json', '--json').status, 2);
     assert.equal(run(f.project, 'use', 'OFF', '--session=--project', '--json').status, 2);
     assert.equal(run(f.project, 'use', 'OFF', 'extra').status, 2);
+    assert.equal(run(f.project, 'use', 'OFF', '--reason', 'somente route').status, 2);
+    assert.equal(run(f.project, 'status', '--reason', 'somente route').status, 2);
     assert.equal(readFileSync(join(f.project, '.wendkeep.json'), 'utf8'), before);
     assert.equal(readFileSync(registryPath, 'utf8'), beforeRegistry);
   } finally { rmSync(f.root, { recursive: true, force: true }); }
@@ -251,5 +396,7 @@ test('[req:OP-9] ajuda pública de profile documenta resolução explícita de p
   });
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /--project <path> --vault <path> --session <id> --json/);
+  assert.match(result.stdout, /route <FLOW\|GUIDE\|GOVERN\|ASSURE>.*--reason <text>/s);
+  assert.match(result.stdout, /task|request/i);
   assert.match(result.stdout, /Keep Core.*remains active/i);
 });

--- a/tests/readme-packaging.test.mjs
+++ b/tests/readme-packaging.test.mjs
@@ -116,6 +116,7 @@ test('[req:OP-9] npm pack leva módulos de profile/FLOW, docs bilíngues e resta
       'src/profile.mjs',
       'src/flow.mjs',
       'hooks/flow-core.mjs',
+      'hooks/operating-profile-task-store.mjs',
       'hooks/vault-path-safety.mjs',
     ]) {
       assert.ok(
@@ -131,7 +132,7 @@ test('[req:OP-9] npm pack leva módulos de profile/FLOW, docs bilíngues e resta
       const profiles = readFileSync(join(pkg, 'docs', locale, 'commands', 'operating-profiles.md'), 'utf8');
       for (const token of [
         'OFF', 'FLOW', 'GUIDE', 'GOVERN', 'ASSURE', 'Keep Core',
-        'wendkeep profile status', 'wendkeep flow finish', 'wendkeep flow promote',
+        'wendkeep profile status', 'wendkeep profile route', 'wendkeep flow finish', 'wendkeep flow promote',
       ]) assert.match(profiles, new RegExp(token), `guia empacotado ${locale} sem ${token}`);
     }
     const expectedDocs = ['pt-BR', 'en']

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -68,16 +68,16 @@ test('extractReleaseNotes: throws when the version is absent', () => {
   assert.throws(() => extractReleaseNotes(FIXTURE, '9.9.9'), /9\.9\.9/);
 });
 
-test('[sensor:release-tests] 0.66.5 notes are extractable and match the package', () => {
-  const release = extractReleaseNotes(CHANGELOG, '0.66.5');
-  assert.equal(PACKAGE.version, '0.66.5');
+test('[sensor:release-tests] 0.67.0 notes are extractable and match the package', () => {
+  const release = extractReleaseNotes(CHANGELOG, '0.67.0');
+  assert.equal(PACKAGE.version, '0.67.0');
   assert.equal(release.date, '2026-08-01');
-  assert.match(release.notes, /Codex/i);
-  assert.match(release.notes, /rebuild/i);
-  assert.match(release.notes, /import/i);
-  assert.match(release.notes, /doctor/i);
-  assert.match(release.notes, /privacidade|diagnostic/i);
-  assert.doesNotMatch(release.notes, /memory recover-attempt/);
+  assert.match(release.notes, /profile route/i);
+  assert.match(release.notes, /FLOW.*GUIDE.*GOVERN.*ASSURE/is);
+  assert.match(release.notes, /OFF.*humano|humano.*OFF/i);
+  assert.match(release.notes, /Obsidian/i);
+  assert.match(release.notes, /P\/R\/E\/V\/C/i);
+  assert.doesNotMatch(release.notes, /observabilidade Codex/i);
 });
 
 test('auto-tag: existing tag still refreshes the GitHub Release from CHANGELOG', () => {

--- a/tests/sensors-core.test.mjs
+++ b/tests/sensors-core.test.mjs
@@ -129,6 +129,35 @@ test('runSensors: green/red by exit code; carries severity (undefined sensor = c
   assert.equal(ev[0].ts, '2026-07-05T00:00:00Z');
 });
 
+test('runSensors: sensor vermelho guarda diagnóstico limitado e sanitizado', () => {
+  let receivedOptions;
+  const spawn = (command, _args, options) => {
+    receivedOptions = options;
+    if (command === 'ok') return { status: 0, stdout: 'saída verde privada', stderr: '' };
+    return {
+      status: 1,
+      signal: null,
+      stdout: '✖ teste discriminante\n',
+      stderr: `AssertionError: falhou\nwhsec_abcdefghijk\nAPI_TOKEN=${'segredo-'.repeat(500)}`,
+    };
+  };
+
+  const evidence = runSensors([
+    { id: 'ok', command: 'ok' },
+    { id: 'bad', command: 'bad' },
+  ], ['ok', 'bad'], { spawn });
+
+  assert.deepEqual(receivedOptions.stdio, ['ignore', 'pipe', 'pipe']);
+  assert.equal(receivedOptions.encoding, 'utf8');
+  assert.equal(receivedOptions.maxBuffer, 8 * 1024 * 1024, 'captura do processo permanece limitada a 8 MiB');
+  assert.equal(evidence[0].note, undefined, 'saída verde não é persistida');
+  assert.match(evidence[1].note, /exit=1/);
+  assert.match(evidence[1].note, /AssertionError/);
+  assert.doesNotMatch(evidence[1].note, /segredo-/);
+  assert.doesNotMatch(evidence[1].note, /whsec_/);
+  assert.ok(evidence[1].note.length <= 2000, 'diagnóstico permanece limitado');
+});
+
 test('[req:OP-10] runSensors forwards the selected Vault environment to the sensor process', () => {
   let options;
   const env = { PATH: 'synthetic', OBSIDIAN_VAULT_PATH: 'C:\\synthetic-vault' };

--- a/tests/session-derived-sections.test.mjs
+++ b/tests/session-derived-sections.test.mjs
@@ -6,7 +6,7 @@ import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { finalizeSessionFile } from '../hooks/session-stop.mjs';
+import { finalizeSessionFile, sanitizeGeneratedSessionMarkdown } from '../hooks/session-stop.mjs';
 import { repairDerivedSections } from '../hooks/derived-sections.mjs';
 import { checkStaleDerivedSections, renderStaleDerivedSectionLines } from '../hooks/harness-doctor.mjs';
 
@@ -78,6 +78,105 @@ test('finalize escreve as três seções com o mesmo created do Encerramento', (
     assert.equal(linksIn(out, 'Aprendizados gerados nesta sessão').length, 2);
     assert.doesNotMatch(sectionOf(out, 'Aprendizados gerados nesta sessão'), /Nenhum aprendizado/,
       'placeholder sai quando há itens');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('[req:IMPORT-6] finalize grava Resumo final sanitizado no Markdown', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'wk-derived-'));
+  try {
+    const note = join(dir, 'note.md');
+    writeFileSync(note, NOTE);
+    const tx = {
+      ...TX,
+      latestAssistantMessage: [
+        'Fechado com </session> e <https://example.com/prova>.',
+        '<oai-mem-citation><citation_entries>interno</citation_entries></oai-mem-citation>',
+      ].join('\n'),
+    };
+
+    finalizeSessionFile(note, tx, { decisions: [], bugs: [], learnings: [] }, '2026-08-01T18:00:00');
+    const closing = sectionOf(readFileSync(note, 'utf8'), 'Encerramento');
+
+    assert.match(closing, /Resumo final:.*&lt;\/session&gt;.*<https:\/\/example\.com\/prova>/);
+    assert.doesNotMatch(closing, /oai-mem-citation|citation_entries/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('[req:IMPORT-6] migração no finalize toca somente linhas geradas e é idempotente', () => {
+  const authoredIteration = 'Parágrafo autoral com <oai-mem-citation> permanece byte a byte.';
+  const authoredClosing = '- Observação autoral com <citation_entries> permanece byte a byte.';
+  const contaminated = `---
+type: session
+date: 2026-08-01
+ended_at:
+status: active
+---
+
+# sessão
+
+## Iterações
+
+### 13:02 - Pedido com <session>
+
+**Pedido:** Relatei <oai-mem-citation> no Obsidian.
+
+**Contexto conversado:**
+- **Usuário:** Vi <citation_entries> como texto.
+- **Assistente:** Corrigido.
+<oai-mem-citation>
+<citation_entries>x
+
+**Estado ao final do turno:** Corrigido. </session><oai-mem-citation><rollout_ids>x
+
+${authoredIteration}
+
+## Decisões geradas nesta sessão
+
+Nenhuma decisão registrada ainda.
+
+## Bugs gerados nesta sessão
+
+Nenhum bug registrado ainda.
+
+## Aprendizados gerados nesta sessão
+
+Nenhum aprendizado registrado ainda.
+
+## Pendências
+
+Nenhuma.
+
+## Encerramento
+
+- **Resumo final:** Antigo. </session><oai-mem-citation><citation_entries>x
+${authoredClosing}
+`;
+
+  const migrated = sanitizeGeneratedSessionMarkdown(contaminated);
+  assert.equal(sanitizeGeneratedSessionMarkdown(migrated), migrated, 'a migração deve convergir em uma passada');
+  assert.match(migrated, /### 13:02 - Pedido com &lt;session&gt;/);
+  assert.match(migrated, /\*\*Pedido:\*\* Relatei &lt;oai-mem-citation&gt; no Obsidian\./);
+  assert.match(migrated, /- \*\*Usuário:\*\* Vi &lt;citation_entries&gt; como texto\./);
+  assert.match(migrated, /- \*\*Assistente:\*\* Corrigido\./);
+  assert.doesNotMatch(migrated, /^<oai-mem-citation>|^<citation_entries>x$/m);
+  assert.match(migrated, /\*\*Estado ao final do turno:\*\* Corrigido\./);
+  assert.match(migrated, /- \*\*Resumo final:\*\* Antigo\./);
+  assert.ok(migrated.includes(authoredIteration));
+  assert.ok(migrated.includes(authoredClosing));
+
+  const dir = mkdtempSync(join(tmpdir(), 'wk-generated-migration-'));
+  try {
+    const note = join(dir, 'note.md');
+    writeFileSync(note, contaminated);
+    finalizeSessionFile(note, TX, { decisions: [], bugs: [], learnings: [] }, '2026-08-01T18:00:00');
+    const finalized = readFileSync(note, 'utf8');
+    assert.match(finalized, /- \*\*Assistente:\*\* Corrigido\./);
+    assert.doesNotMatch(finalized, /- \*\*Assistente:\*\*.*(?:oai-mem-citation|citation_entries)/);
+    assert.ok(finalized.includes(authoredIteration));
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/skills-seed.test.mjs
+++ b/tests/skills-seed.test.mjs
@@ -63,6 +63,20 @@ test('[req:OP-4] [req:OP-5] wk-workflow routes by profile without a universal ch
   }
 });
 
+test('[req:OP-13] wk-workflow ensina seleção adaptativa temporária sem permitir OFF', () => {
+  for (const locale of ['pt-BR', 'en']) {
+    const body = wkSkills(locale).find((skill) => skill.name === 'wk-workflow').body;
+    assert.match(body, /wendkeep profile route <FLOW\|GUIDE\|GOVERN\|ASSURE>/);
+    assert.match(body, /--session <id>.*--reason/s);
+    assert.match(body, /tempor|request|solicita/i);
+    assert.match(body, /OFF[\s\S]{0,180}(?:nunca|never|human|humana)/i);
+    assert.match(body, /FLOW[\s\S]{0,240}(?:local|revers)/i);
+    assert.match(body, /GUIDE[\s\S]{0,240}(?:compact|compacta)/i);
+    assert.match(body, /GOVERN[\s\S]{0,240}(?:dúvida|uncertain|risk|risco)/i);
+    assert.match(body, /ASSURE[\s\S]{0,240}(?:confirm|handoff)/i);
+  }
+});
+
 // REQ-4 — o template do workflow documenta o formato de heading de requisito e
 // o suporte a múltiplos [req:] por tarefa (pt e en).
 test('wk-workflow teaches the requirement heading format and multi-[req:] support', () => {

--- a/tests/sync-defs.test.mjs
+++ b/tests/sync-defs.test.mjs
@@ -36,6 +36,12 @@ test('syncDefs: writes the managed AGENTS.md section, idempotent, user content p
     for (const profile of ['FLOW', 'GUIDE', 'GOVERN', 'ASSURE']) {
       assert.match(md, new RegExp(`\\b${profile}\\b`), `[req:OP-5] ${profile} route is declared`);
     }
+    assert.match(md, /profile route <FLOW\|GUIDE\|GOVERN\|ASSURE>/,
+      '[req:OP-13] managed block exposes task-scoped routing');
+    assert.match(md, /OFF[\s\S]{0,180}(?:never|human)/i,
+      '[req:OP-13] managed block forbids automatic OFF');
+    assert.match(md, /request|task-scoped|temporary/i,
+      '[req:OP-13] managed block explains lease scope');
     assert.doesNotMatch(md, /Work\s+through its change loop/i,
       '[req:OP-5] the managed block must not impose GOVERN on every profile');
     // idempotente: re-run = 1 seção só


### PR DESCRIPTION
## Resumo

- permite que o harness da LLM escolha `FLOW`, `GUIDE`, `GOVERN` ou `ASSURE` por solicitação usando uma lease causal e temporária, sem alterar o perfil persistente e sem selecionar `OFF` automaticamente;
- documenta em PT-BR e inglês as rotas `P/R/E/V/C`, a precedência e a duração dos perfis;
- saneia metadados internos completos ou truncados na captura de sessões Obsidian, preservando conteúdo autoral do usuário;
- mantém diagnóstico limitado e redigido somente para sensores vermelhos.

## Motivação e impacto

O perfil persistente do projeto era insuficiente para adaptar a governança ao risco de cada implementação. A nova lease permite seleção auditável por tarefa e expira de forma causal no encerramento aceito. Em paralelo, envelopes internos do assistente podiam quebrar a renderização das notas de sessão; o normalizador agora converge importação e `SessionStop` sem reescrever prosa autoral.

Esta é uma mudança retrocompatível e prepara a release `0.67.0`.

## Validação

- `npm run check` — verde;
- `npm test` — verde, exit `0`, quatro testes ignorados esperados;
- `npm publish --dry-run` — `wendkeep@0.67.0`, 146 arquivos;
- `git diff --check` — verde;
- changes arquivadas com verdicts independentes: observabilidade `7/7` e perfis adaptativos `6/6`.

## Changelog 0.67.0

### Added

- seleção temporária e auditável de rota Wend por solicitação;
- expiração causal da lease sem interromper implementações longas.

### Fixed

- saneamento de envelopes internos em sessões Obsidian;
- documentação bilíngue das rotas e duração dos perfis;
- diagnóstico acionável, limitado e redigido para sensores vermelhos.
