### PR TITLE
fix: corrige captura causal e reforça rotas adaptativas (0.67.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,25 @@
 <!-- wendkeep:skills:start -->
-<!-- wendkeep-version: 0.67.0; skills-sha256: d170f56e18f94318178d4062b722c40275d07c10e76021f95d16f441d498328d -->
+<!-- wendkeep-version: 0.67.1; skills-sha256: d170f56e18f94318178d4062b722c40275d07c10e76021f95d16f441d498328d -->
 ## wendkeep — Keep Core & operating profiles
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. **Keep Core is always active**
 in every profile: Vault, session, identity, memory, lessons, and persistence integrations.
 The persistent profile is selected explicitly; missing or invalid configuration uses **GOVERN as the default**.
 
-Before an implementation, the native LLM harness classifies the current request and may create a
-task-scoped lease with `wendkeep profile route <FLOW|GUIDE|GOVERN|ASSURE> --session <id> --reason <text>`.
-The lease expires when that request ends and the persistent session/project profile becomes
-effective again. **OFF is never selected adaptively**; only a human can persist `profile use OFF`.
+Before every implementation, the native LLM harness **MUST run the routing gate**:
+1. Inspect `wendkeep profile status`.
+2. Classify the request and choose FLOW, GUIDE, GOVERN, or ASSURE from its scope and risk.
+3. Register the choice with
+   `wendkeep profile route <FLOW|GUIDE|GOVERN|ASSURE> --session <id> --reason <text>`.
+4. Re-check `wendkeep profile status` and follow the effective profile before editing.
+
+The persistent profile is only the base restored after the task lease; it is not an immutable
+decision for the current task. A base OFF does not block a temporary FLOW/GUIDE/GOVERN/ASSURE
+lease, while a base GOVERN does not prevent choosing FLOW or GUIDE for bounded work. An explicit
+user choice for the request takes precedence. If no causal session is available or routing fails,
+do not invent lease state: follow the effective profile and use GOVERN only as the conservative
+fallback when configuration is missing or invalid. The lease expires when the request ends.
+**OFF is never selected adaptively**; only a human can persist `profile use OFF`.
 
 Route work by the effective profile:
 - **OFF** — Wend Runtime is disabled and governance belongs to the native LLM harness; Keep Core stays active.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.67.1] — 2026-08-02
+
+### Fixed
+
+- **Turnos de subagents não bloqueiam mais a captura da sessão-mãe.** `UserPromptSubmit` de rollout
+  filho registra o path para observabilidade sem avançar a sequência principal, e `SessionStop`
+  prefere o mapeamento causal `turn_sequences[turn_id]` antes da ordem local do transcript. Isso
+  preserva os marcadores `wk-turn`, o encerramento e a memória mesmo com filhos intercalados.
+- **`SubagentStop` consome o transcript correto do payload Codex.** O hook resolve o filho por
+  `agent_transcript_path`/`agentTranscriptPath`, valida identidade, sessão e `parent_thread_id`
+  contra um root comprovado e mantém `transcript_path` como contexto da sessão-mãe, permitindo
+  preencher `Subagents e workflows` no último filho sem aceitar sinais de outra cadeia.
+- **O backfill não grava o turno Codex ainda em execução.** `hook session-backfill` exige
+  `task_complete`, separa `missingTurns` de `incompleteTurns`, permanece dry-run por padrão e aplica
+  somente turnos concluídos de forma idempotente. A CLI agora encaminha `--session`, `--vault`,
+  `--write` e demais argumentos ao hook executado. README e guias PT-BR/EN documentam o reparo.
+
 ## [0.67.0] — 2026-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ All notable changes to **wendkeep** are documented here. Format based on
   `task_complete`, separa `missingTurns` de `incompleteTurns`, permanece dry-run por padrão e aplica
   somente turnos concluídos de forma idempotente. A CLI agora encaminha `--session`, `--vault`,
   `--write` e demais argumentos ao hook executado. README e guias PT-BR/EN documentam o reparo.
+- **O bloco gerenciado do `AGENTS.md` exige roteamento adaptativo antes de editar.** O harness
+  inspeciona o perfil-base, classifica a solicitação, registra uma lease temporária entre `FLOW`,
+  `GUIDE`, `GOVERN` e `ASSURE` e confirma o perfil efetivo; `OFF` nunca é escolhido pela LLM e a
+  escolha explícita do usuário prevalece.
+- **O scanner de privacidade distingue configuração pública de identificadores privados.** Comandos
+  longos legítimos em `wendkeep.sensors.json` deixam de gerar falso positivo, sem permitir que UUID,
+  hash, token compacto, campo desconhecido ou path absoluto sejam ocultados pela exceção.
 
 ## [0.67.0] — 2026-08-01
 

--- a/README.en.md
+++ b/README.en.md
@@ -385,7 +385,7 @@ acknowledgement pending on 0.66.4 or later, first run the targeted dry run
 registry/checkpoint. See syntax, preconditions, and fail-closed behavior in
 [memory and curation](docs/en/commands/memory.md).
 
-Session notes use one live `## Agentes, tokens e custos` snapshot. Main-agent and subagent hooks recompose it atomically, with costs, token dimensions, reasoning tokens and effort per model/source. Every hook that rewrites a session note takes a per-file lock and writes through a temp file + rename, so the `SubagentStop` fan-out (one hook run per subagent) can never leave a note half-written; a note whose frontmatter reads back damaged is left untouched rather than patched.
+Session notes use one live `## Agentes, tokens e custos` snapshot. Main-agent and subagent hooks recompose it atomically, with costs, token dimensions, reasoning tokens and effort per model/source. On Codex, subagent prompts register their rollout for observability without advancing the main agent's sequence; `SubagentStop` reads the child from `agent_transcript_path` and persists its signal only when `parent_thread_id` matches a validated session root. The main Stop uses the registry's causal `turn_id` mapping before falling back to local transcript order. To recover missing markers while a conversation is open, `hook session-backfill` is a dry-run by default and never writes a Codex turn without `task_complete`. Every hook that rewrites a session note takes a per-file lock and writes through a temp file + rename, so the `SubagentStop` fan-out (one hook run per subagent) can never leave a note half-written; a note whose frontmatter reads back damaged is left untouched rather than patched.
 
 ## Retroactive memory (`import`) — install today, remember yesterday
 

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ dirigido `memory recover-attempt <sessão> --vault <cofre>` e só então autoriz
 altera apenas registry/checkpoint. O doctor apenas diagnostica. Veja sintaxe, pré-condições e
 falhas fechadas em [memória e curadoria](docs/pt-BR/commands/memory.md).
 
-As notas de sessão usam um único snapshot vivo `## Agentes, tokens e custos`. Os hooks do agente principal e dos subagents recompõem o bloco atomicamente, incluindo custo, dimensões de tokens, reasoning e effort por modelo/origem.
+As notas de sessão usam um único snapshot vivo `## Agentes, tokens e custos`. Os hooks do agente principal e dos subagents recompõem o bloco atomicamente, incluindo custo, dimensões de tokens, reasoning e effort por modelo/origem. No Codex, prompts de subagents registram o rollout para observabilidade sem avançar a sequência do agente principal; `SubagentStop` lê o filho em `agent_transcript_path` e só persiste o sinal quando seu `parent_thread_id` corresponde a um root validado da sessão. O Stop principal usa o mapeamento causal de `turn_id` do registry antes da ordem local do transcript. Para recuperar marcadores ausentes com a conversa aberta, `hook session-backfill` é dry-run por padrão e nunca grava um turno Codex sem `task_complete`.
 
 ## Memória retroativa (`import`) — instale hoje, lembre de ontem
 

--- a/docs/en/commands/sessions-and-import.md
+++ b/docs/en/commands/sessions-and-import.md
@@ -30,6 +30,7 @@ npx wendkeep hook <name>
 npx wendkeep session list
 npx wendkeep session show <id>
 npx wendkeep session use <id>
+npx wendkeep hook session-backfill --session <id> [--write]
 npx wendkeep import [options]
 ```
 
@@ -38,19 +39,27 @@ npx wendkeep import [options]
 - `wendkeep hook <name>` reads the agent payload from stdin; valid names are listed by `--help`.
 - `SessionStart` opens an activation: an epoch that remains active across multiple `Stop` events;
   only a new `SessionStart` supersedes the previous epoch.
-- `UserPromptSubmit` advances the active activation's native turn. If it finds a legacy registry
-  with a closed epoch, it opens exactly one recovery activation; replaying the same prompt does
-  not open another one.
-- On Codex, `session_id`, the native `turn_id`, and observed transcript order are enough to resolve
-  the turn. Hook payloads do not need invented `activation_id` or `turn_sequence` fields.
+- Main-agent `UserPromptSubmit` advances the active activation's native turn. A Codex rollout
+  prompt with `source.subagent` only registers its path for observability: it does not advance the
+  sequence, enter `turn_sequences`, or replace the main transcript. If a main prompt finds a
+  legacy registry with a closed epoch, it opens exactly one recovery activation; replaying the
+  same prompt does not open another one.
+- On Codex, `session_id` and the native `turn_id` are enough to resolve the turn. Stop proves the
+  ID in the transcript and prefers `SESSION_REGISTRY.turn_sequences[turn_id]`; local transcript
+  order is the legacy-registry fallback. Interleaved subagent turns therefore cannot make the
+  parent's Stop artificially `stale_turn`. Hook payloads need no invented `activation_id` or
+  `turn_sequence` fields.
 - `Stop` accepts only a transcript-proven turn from the compatible active activation. Duplicates
   are no-ops; stale/superseded Stops neither publish memory nor overwrite a newer epoch's
   checkpoint.
 - `Stop` receives an absolute **45 s** deadline from hook entry. Reads check the clock between
   rollouts and on every chunk; reaching the limit returns `degraded` before the host timeout.
-- `SubagentStop` receives an absolute **15 s** deadline. Signals arriving within the **250 ms**
-  window are coalesced: only the highest sequence recomposes/publishes, without losing the last
-  child.
+- `SubagentStop` receives an absolute **15 s** deadline and resolves the child rollout from Codex's
+  official `agent_transcript_path` field (`agentTranscriptPath` is also accepted);
+  `transcript_path` continues to identify the parent session. Before any write, `source.subagent`,
+  ID, canonical session, and `parent_thread_id` are validated; the parent must match a proven
+  session root. Signals arriving within the **250 ms** window are coalesced: only the highest
+  sequence recomposes/publishes, without losing the last child.
 - Observability is tri-state: `complete` publishes the full snapshot; `none` means zero proven by
   a causal Stop or stable offline scan; `degraded` preserves the previous snapshot and allowlisted
   diagnostics. An isolated `SubagentStop` never publishes `none`.
@@ -64,6 +73,10 @@ npx wendkeep import [options]
 - `import` reconciles observability even when no `wk-turn` is missing: a legacy schema, stale
   frontier, or unproven manifest triggers recomposition without duplicating iterations. A fresh
   checkpoint remains byte-identical; `degraded` is reported and does not change the note.
+- `hook session-backfill` recovers missing `wk-turn` markers for the selected session. Without
+  `--write`, it only reports. On Codex, `missingTurns` contains only turns with `task_complete`;
+  open turns appear under `incompleteTurns` and are never written. `--write` applies only completed
+  candidates, and a second run is idempotent.
 - Exit `0` means consistent processing; non-zero reports invalid source/config/write instead of
   presenting silent partial success.
 
@@ -72,6 +85,8 @@ npx wendkeep import [options]
 ```bash
 npx wendkeep session list
 npx wendkeep session show 019abc-session-id
+npx wendkeep hook session-backfill --session 019abc-session-id
+npx wendkeep hook session-backfill --session 019abc-session-id --write
 npx wendkeep import --source codex --since 2026-07-01 --dry-run --json
 ```
 
@@ -98,6 +113,10 @@ without creating a new turn block.
   was found; the attempt remains observable but does not publish memory.
 - A late Stop reports `stale_turn`/`superseded`: the newer epoch and checkpoint are preserved; do
   not force the old payload to apply.
+- `session-backfill` lists `incompleteTurns`: wait for that turn's `task_complete`/Stop and retry;
+  do not edit the note or force the partial turn. Once that turn receives `task_complete`, the next
+  run may treat it as eligible. Claude transcripts preserve their historical contract and do not
+  require this Codex event.
 - Fork duplicates: bound source/date and inspect `forked_from_id`/`source.subagent`.
 - Codex does not capture: approve hooks and start a new session after `sync`.
 - Contaminated cost: validate `session_id → session_file → transcript_path → provider`.

--- a/docs/pt-BR/commands/sessions-and-import.md
+++ b/docs/pt-BR/commands/sessions-and-import.md
@@ -30,6 +30,7 @@ npx wendkeep hook <nome>
 npx wendkeep session list
 npx wendkeep session show <id>
 npx wendkeep session use <id>
+npx wendkeep hook session-backfill --session <id> [--write]
 npx wendkeep import [opções]
 ```
 
@@ -38,18 +39,26 @@ npx wendkeep import [opções]
 - `wendkeep hook <name>` lê o payload do agente em stdin; nomes válidos aparecem em `--help`.
 - `SessionStart` abre uma activation, isto é, um epoch que continua ativo por vários `Stop`; só um
   novo `SessionStart` torna o epoch anterior superseded.
-- `UserPromptSubmit` avança o turno nativo da activation ativa. Se encontrar um registry legado
-  com o epoch fechado, abre exatamente uma activation de recuperação; repetir o mesmo prompt não
-  abre outra.
-- No Codex, `session_id`, o `turn_id` nativo e a ordem observada no transcript bastam para resolver
-  o turno. O payload do hook não precisa inventar `activation_id` nem `turn_sequence`.
+- `UserPromptSubmit` do agente principal avança o turno nativo da activation ativa. Um prompt de
+  rollout Codex com `source.subagent` apenas registra o path para observabilidade: não avança a
+  sequência, não entra em `turn_sequences` e não substitui o transcript principal. Se o prompt
+  principal encontra um registry legado com o epoch fechado, abre exatamente uma activation de
+  recuperação; repetir o mesmo prompt não abre outra.
+- No Codex, `session_id` e o `turn_id` nativo bastam para resolver o turno. O Stop prova o ID no
+  transcript e prefere `SESSION_REGISTRY.turn_sequences[turn_id]`; a ordem local do transcript é
+  fallback para registry legado. Assim, turnos intercalados de subagents não tornam o Stop da mãe
+  artificialmente `stale_turn`. O payload não precisa inventar `activation_id` ou `turn_sequence`.
 - `Stop` aceita somente o turno comprovado pelo transcript e pela activation ativa compatível.
   Duplicatas são no-op; Stops stale/superseded não publicam memória nem sobrescrevem o checkpoint
   de um epoch mais novo.
 - `Stop` recebe deadline absoluto de **45 s** desde a entrada do hook. A leitura verifica o relógio
   entre rollouts e a cada chunk; ao atingir o limite, devolve `degraded` antes do timeout do host.
-- `SubagentStop` recebe deadline absoluto de **15 s**. Sinais que chegam na janela de **250 ms**
-  são coalescidos: somente a maior sequência recompõe/publica, sem perder o último filho.
+- `SubagentStop` recebe deadline absoluto de **15 s** e resolve o rollout filho pelo campo oficial
+  Codex `agent_transcript_path` (também aceita `agentTranscriptPath`); `transcript_path` continua
+  identificando a sessão-mãe. Antes de qualquer escrita, `source.subagent`, ID, sessão canônica e
+  `parent_thread_id` são validados; o pai deve corresponder a um root comprovado da sessão. Sinais
+  que chegam na janela de **250 ms** são coalescidos: somente a maior sequência
+  recompõe/publica, sem perder o último filho.
 - A observabilidade usa tri-state: `complete` publica o snapshot integral; `none` representa zero
   comprovado por Stop causal ou scan offline estável; `degraded` preserva o snapshot anterior e
   diagnostics allowlisted. `SubagentStop` isolado nunca publica `none`.
@@ -63,6 +72,10 @@ npx wendkeep import [opções]
 - `import` reconcilia a observabilidade mesmo quando nenhum `wk-turn` está ausente: schema legado,
   frontier stale ou manifest não comprovado disparam recomposição sem duplicar iterações. Um
   checkpoint fresco permanece byte-idêntico; `degraded` é reportado e não altera a nota.
+- `hook session-backfill` recupera `wk-turn` ausente da sessão selecionada. Sem `--write`, apenas
+  relata. Em Codex, `missingTurns` contém somente turnos com `task_complete`; turnos ainda abertos
+  aparecem em `incompleteTurns` e nunca são gravados. `--write` aplica apenas os candidatos
+  concluídos e uma segunda execução é idempotente.
 - Exit `0` indica processamento consistente; exit não zero indica configuração, fonte ou escrita
   inválida sem transformar isso em sucesso parcial silencioso.
 
@@ -71,6 +84,8 @@ npx wendkeep import [opções]
 ```bash
 npx wendkeep session list
 npx wendkeep session show 019abc-session-id
+npx wendkeep hook session-backfill --session 019abc-session-id
+npx wendkeep hook session-backfill --session 019abc-session-id --write
 npx wendkeep import --source codex --since 2026-07-01 --dry-run --json
 ```
 
@@ -97,6 +112,10 @@ sem criar um novo bloco de turno.
   compatível foi encontrada; o attempt fica observável, mas não publica memória.
 - Stop atrasado aparece como `stale_turn`/`superseded`: o epoch mais novo e seu checkpoint são
   preservados; não force a reaplicação do payload antigo.
+- `session-backfill` lista `incompleteTurns`: aguarde o `task_complete`/Stop desse turno e repita;
+  não edite a nota nem force o turno parcial. Quando o mesmo turno recebe `task_complete`, a
+  próxima execução passa a considerá-lo elegível. Transcripts Claude preservam o contrato
+  histórico e não exigem esse evento Codex.
 - Duplicatas de forks: limite por fonte/data e revise `forked_from_id`/`source.subagent`.
 - Codex não captura: aprove os hooks e reinicie a sessão após `sync`.
 - Custo contaminado: valide `session_id → session_file → transcript_path → provider`.

--- a/hooks/obsidian-common.mjs
+++ b/hooks/obsidian-common.mjs
@@ -321,6 +321,13 @@ function nonNegativeSequence(value, fallback = null) {
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
+export function resolveRegisteredTurnSequence(entry = {}, turnId = '', fallback = 0) {
+  const registered = turnId
+    ? nonNegativeSequence(entry?.turn_sequences?.[String(turnId)])
+    : null;
+  return registered === null ? nonNegativeSequence(fallback, 0) : registered;
+}
+
 function cloneRegistry(registry = {}) {
   const sessions = Object.fromEntries(Object.entries(registry.sessions || {}).map(([id, entry]) => [
     id,

--- a/hooks/session-backfill.mjs
+++ b/hooks/session-backfill.mjs
@@ -7,6 +7,7 @@ import {
   insertIteration,
   parseTranscript,
 } from './session-stop.mjs';
+import { completedCodexTurnIdsContent } from '../packages/integrations/src/transcripts.mjs';
 import {
   getVaultBase,
   readControl,
@@ -63,6 +64,7 @@ export function backfillSessions({ vaultBase, write = false, limit = 0, session 
     scanned: 0,
     candidates: 0,
     inserted: 0,
+    incomplete: 0,
     skipped: 0,
     missing: [],
     sessions: [],
@@ -85,13 +87,35 @@ export function backfillSessions({ vaultBase, write = false, limit = 0, session 
       continue;
     }
 
+    const transcriptContent = readFileSync(entry.transcript_path, 'utf-8');
     const tx = parseTranscript(entry.transcript_path);
-    const turns = tx.turns.filter((turn) => turn.turnId && turn.userPrompts.length);
+    const allTurns = tx.turns.filter((turn) => turn.turnId && turn.userPrompts.length);
+    const completedCodexTurns = tx.provider === 'codex'
+      ? completedCodexTurnIdsContent(transcriptContent)
+      : null;
+    const turns = completedCodexTurns
+      ? allTurns.filter((turn) => completedCodexTurns.has(turn.turnId))
+      : allTurns;
     const content = readFileSync(sessionPath, 'utf-8');
     const missingTurns = turns.filter((turn) => !hasTurnMarker(content, turn.turnId));
+    const incompleteTurns = completedCodexTurns
+      ? allTurns.filter((turn) => (
+        !completedCodexTurns.has(turn.turnId) && !hasTurnMarker(content, turn.turnId)
+      ))
+      : [];
+    report.incomplete += incompleteTurns.length;
 
     if (!missingTurns.length) {
       report.skipped += 1;
+      if (incompleteTurns.length) {
+        report.sessions.push({
+          session: entry.session_file,
+          transcript: entry.transcript_path,
+          missingTurns: [],
+          incompleteTurns: incompleteTurns.map((turn) => turn.turnId),
+          inserted: 0,
+        });
+      }
       continue;
     }
 
@@ -100,6 +124,7 @@ export function backfillSessions({ vaultBase, write = false, limit = 0, session 
       session: entry.session_file,
       transcript: entry.transcript_path,
       missingTurns: missingTurns.map((turn) => turn.turnId),
+      incompleteTurns: incompleteTurns.map((turn) => turn.turnId),
       inserted: 0,
     };
 

--- a/hooks/session-ensure.mjs
+++ b/hooks/session-ensure.mjs
@@ -32,6 +32,7 @@ import {
   yamlQuote,
 } from './obsidian-common.mjs';
 import { resolveSessionIdentity } from './session-identity.mjs';
+import { readCodexRolloutMeta } from './codex-rollout-meta.mjs';
 import { mutateSessionNote } from './session-note-io.mjs';
 
 function sessionIdFromInput(input) {
@@ -52,6 +53,12 @@ function causalTurnPatch(input, now) {
     recovery_activation_id: randomUUID(),
     recovery_started_at: formatLocalIso(now),
   };
+}
+
+function isCodexSubagentTranscript(identity) {
+  if (identity?.provider !== 'codex' || !identity.transcriptPath) return false;
+  const inspected = readCodexRolloutMeta(identity.transcriptPath);
+  return Boolean(inspected?.ok && inspected.meta?.source?.subagent);
 }
 
 function buildSessionContent({ relPath, now, summary = 'session', sessionId = '', reason = 'Sessão criada automaticamente pelo hook UserPromptSubmit.' }) {
@@ -340,6 +347,21 @@ function main() {
     return;
   }
   const sessionId = identity.canonicalConversationId;
+
+  // UserPromptSubmit also fires inside Codex subagents. The child belongs to the parent's
+  // observability graph, but it is not a new main turn: registering it through causalTurnPatch
+  // permanently inflated the parent's sequence and made every later main Stop stale.
+  if (isCodexSubagentTranscript(identity)) {
+    const registered = readSessionRegistry(vaultBase).sessions?.[sessionId];
+    if (registered) {
+      upsertSessionRegistry(vaultBase, sessionId, {
+        transcript_paths: [identity.transcriptPath],
+        provider: identity.provider,
+      });
+    }
+    writeHookOutput({});
+    return;
+  }
 
   // Fast path: skip all writes if control file touched < 5 min ago and session matches
   try {

--- a/hooks/session-stop.mjs
+++ b/hooks/session-stop.mjs
@@ -61,6 +61,7 @@ import {
   hasTurnMarker,
   normalizeTurnMarkers,
   mutateSessionRegistry,
+  resolveRegisteredTurnSequence,
   resolveStopActivation,
   applyStopActivation,
 } from './obsidian-common.mjs';
@@ -1180,9 +1181,13 @@ export async function main({
   const turnId = turnIdentity.id;
   const now = finalizing ? new Date() : null;
   const endedAt = finalizing ? formatLocalIso(now) : '';
-  const stopTurnSequence = turnIdentity.order;
   const causalStop = finalizing
     ? mutateSessionRegistry(vaultBase, (registry) => {
+      const stopTurnSequence = resolveRegisteredTurnSequence(
+        registry.sessions?.[sessionId],
+        turnId,
+        turnIdentity.order,
+      );
       const activationId = resolveStopActivation(registry, {
         session_id: sessionId,
         activation_id: input.activation_id || input.activationId || '',
@@ -1214,9 +1219,11 @@ export async function main({
         activation,
         stopDisposition: cas.stopDisposition,
         canPromoteMemory: cas.canPromoteMemory,
+        turnSequence: stopTurnSequence,
       };
     })
     : null;
+  const stopTurnSequence = causalStop?.turnSequence ?? turnIdentity.order;
   let memoryHandoff = null;
   let memoryAttempt = null;
   if (finalizing) {

--- a/hooks/subagent-stop.mjs
+++ b/hooks/subagent-stop.mjs
@@ -82,6 +82,32 @@ function claudeRoots(entry) {
   return { state: 'complete', rootPaths: [...paths], descendantPaths: [], diagnostics: [] };
 }
 
+export function subagentIdentityInput(input = {}) {
+  const agentTranscriptPath = input.agent_transcript_path || input.agentTranscriptPath || '';
+  if (!agentTranscriptPath) return input;
+  return {
+    ...input,
+    transcript_path: agentTranscriptPath,
+    transcriptPath: agentTranscriptPath,
+  };
+}
+
+function validatedCodexRootIds(entry, canonicalConversationId, { resolveRoots, readMeta }) {
+  const roots = resolveRoots(entry, { readMeta });
+  if (roots?.state !== 'complete' || !roots.rootPaths?.length) return null;
+
+  const ids = new Set();
+  for (const rootPath of roots.rootPaths) {
+    const result = readMeta(rootPath);
+    const meta = result?.meta;
+    const rootId = String(meta?.id || '');
+    if (!result?.ok || !rootId || meta?.source?.subagent) return null;
+    if (meta.session_id && meta.session_id !== canonicalConversationId) return null;
+    ids.add(rootId);
+  }
+  return ids;
+}
+
 export async function refreshSubagents(vaultBase, input, {
   now = Date.now,
   hookStartedAt = now(),
@@ -100,7 +126,8 @@ export async function refreshSubagents(vaultBase, input, {
 } = {}) {
   const deadlineAt = hookStartedAt + deadlineMs;
   const provider = providerMeta(input.provider).id;
-  const { identity, entry } = resolveEntry(vaultBase, input, provider);
+  const identityInput = subagentIdentityInput(input);
+  const { identity, entry } = resolveEntry(vaultBase, identityInput, provider);
   if (identity.state !== 'resolved') return false;
   const childTranscriptPath = identity.transcriptPath;
   const sessionRel = entry?.session_file || '';
@@ -118,6 +145,11 @@ export async function refreshSubagents(vaultBase, input, {
       || childMeta.meta.source?.subagent?.thread_spawn?.parent_thread_id
       || '',
     );
+    const rootIds = validatedCodexRootIds(entry, identity.canonicalConversationId, {
+      resolveRoots,
+      readMeta,
+    });
+    if (!childParentThreadId || !rootIds?.has(childParentThreadId)) return false;
   }
 
   const observed = causalSnapshot(entry);
@@ -168,7 +200,7 @@ export async function refreshSubagents(vaultBase, input, {
 
   try {
     if (now() >= deadlineAt) return true;
-    const fresh = resolveEntry(vaultBase, input, provider);
+    const fresh = resolveEntry(vaultBase, identityInput, provider);
     if (fresh.identity?.state !== 'resolved'
       || fresh.identity.canonicalConversationId !== identity.canonicalConversationId
       || !fresh.entry?.session_file
@@ -197,7 +229,7 @@ export async function refreshSubagents(vaultBase, input, {
       const currentEntry = guardContext?.entry;
       const currentResolved = currentEntry
         ? { identity: { state: 'resolved', canonicalConversationId: identity.canonicalConversationId }, entry: currentEntry }
-        : resolveEntry(vaultBase, input, provider);
+        : resolveEntry(vaultBase, identityInput, provider);
       if (currentResolved.identity?.state !== 'resolved'
         || currentResolved.identity.canonicalConversationId !== identity.canonicalConversationId
         || !currentResolved.entry) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.67.0",
+  "version": "0.67.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.67.0",
+      "version": "0.67.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "acorn": "^8.18.0",
-        "wendkeep": "^0.66.5"
+        "wendkeep": "^0.67.0"
       },
       "engines": {
         "node": ">=18"
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/wendkeep": {
-      "version": "0.66.5",
-      "resolved": "https://registry.npmjs.org/wendkeep/-/wendkeep-0.66.5.tgz",
-      "integrity": "sha512-qnVJOGKIvZtzeJteu3hhpr0nkMw1HvB+IPzMrJrwmeYLTH+NWaCusDnWfypX4ktedG6LCF8UY0XNlhKYBiqyQg==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/wendkeep/-/wendkeep-0.67.0.tgz",
+      "integrity": "sha512-rF6z8bOZp3AfQoA/ve5GOcA5lj5jvN6Fsl7o8FSQ/j+nyoep8QL0ZT4B6D8s+1OPmcD2fQ5Z3+5VER+gu17V+g==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.67.0",
+  "version": "0.67.1",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [
@@ -70,6 +70,6 @@
   },
   "devDependencies": {
     "acorn": "^8.18.0",
-    "wendkeep": "^0.66.5"
+    "wendkeep": "^0.67.0"
   }
 }

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -117,7 +117,7 @@ Usage:
   wendkeep --help              Show this help.
 `;
 
-function runHook(name) {
+function runHook(name, args = []) {
   if (!name) {
     process.stderr.write('wendkeep hook: missing hook name\n');
     process.exit(2);
@@ -133,7 +133,7 @@ function runHook(name) {
   }
   // Spawn exactly as the agent would run `node <hook>.mjs`: stdio inherited so the
   // hook's stdin (agent JSON) and stdout (hookSpecificOutput) pass through untouched.
-  const r = spawnSync(process.execPath, [file], { stdio: 'inherit' });
+  const r = spawnSync(process.execPath, [file, ...args], { stdio: 'inherit' });
   process.exit(r.status ?? 0);
 }
 
@@ -207,7 +207,7 @@ async function main(argv) {
       break;
     }
     case 'hook':
-      runHook(rest[0]);
+      runHook(rest[0], rest.slice(1));
       break;
     case 'doctor': {
       const { runDoctor } = await import('../../../src/doctor.mjs');

--- a/packages/integrations/src/transcripts.mjs
+++ b/packages/integrations/src/transcripts.mjs
@@ -170,6 +170,16 @@ function jsonLines(content) {
   }).filter(Boolean);
 }
 
+export function completedCodexTurnIdsContent(content = '') {
+  const completed = new Set();
+  for (const event of jsonLines(content)) {
+    if (event.type !== 'event_msg' || event.payload?.type !== 'task_complete') continue;
+    const turnId = String(event.payload?.turn_id || event.turn_id || '').trim();
+    if (turnId) completed.add(turnId);
+  }
+  return completed;
+}
+
 export function parseCodexTranscriptContent(content, options = {}) {
   const result = createResult('codex');
   const eventUserPrompts = [];

--- a/scripts/privacy-hygiene.mjs
+++ b/scripts/privacy-hygiene.mjs
@@ -82,6 +82,18 @@ const GENERATED_INTEGRITY_FIELDS = new Map([
   ['tasksHash', 12],
   ['effectiveSpecHash', 64],
 ]);
+const SENSOR_CONFIG_FIELDS = new Set([
+  '$schema',
+  'command',
+  'description',
+  'id',
+  'name',
+  'report',
+  'severity',
+  'source',
+  'type',
+  'version',
+]);
 
 function normalizeRelativePath(path) {
   return String(path).split(sep).join('/').replace(/^\.\//, '');
@@ -154,6 +166,16 @@ function allowedGeneratedEvidence(relativePath, field, value) {
   ));
 }
 
+function allowedStaticSensorIdentifier(relativePath, field, value) {
+  if (normalizeRelativePath(relativePath) !== 'wendkeep.sensors.json'
+    || !SENSOR_CONFIG_FIELDS.has(field)) return false;
+
+  const opaqueTokens = String(value ?? '').match(/\b[A-Za-z0-9_-]{32,}\b/g) ?? [];
+  return opaqueTokens.length > 0 && opaqueTokens.every((token) => (
+    /^[A-Za-z]+(?:-[A-Za-z]+){2,}$/.test(token)
+  ));
+}
+
 function allowedSyntheticLifecyclePath(relativePath, value) {
   if (!MEMORY_FIXTURE_SOURCES.has(normalizeRelativePath(relativePath))) return false;
   const expanded = String(value).replaceAll(
@@ -184,7 +206,8 @@ function structuralCategories(value) {
 function categoriesForLiteral(value, field, relativePath) {
   const categories = structuralCategories(value).filter((category) => (
     category !== 'opaque-identifier'
-    || (!allowedGeneratedIntegrityHash(relativePath, field, value)
+    || (!allowedStaticSensorIdentifier(relativePath, field, value)
+      && !allowedGeneratedIntegrityHash(relativePath, field, value)
       && !allowedGeneratedEvidence(relativePath, field, value))
   ));
   const approvedFixtureValue = allowedFixtureValue(value)

--- a/src/sync-defs.mjs
+++ b/src/sync-defs.mjs
@@ -64,10 +64,20 @@ This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harne
 in every profile: Vault, session, identity, memory, lessons, and persistence integrations.
 The persistent profile is selected explicitly; missing or invalid configuration uses **GOVERN as the default**.
 
-Before an implementation, the native LLM harness classifies the current request and may create a
-task-scoped lease with \`wendkeep profile route <FLOW|GUIDE|GOVERN|ASSURE> --session <id> --reason <text>\`.
-The lease expires when that request ends and the persistent session/project profile becomes
-effective again. **OFF is never selected adaptively**; only a human can persist \`profile use OFF\`.
+Before every implementation, the native LLM harness **MUST run the routing gate**:
+1. Inspect \`wendkeep profile status\`.
+2. Classify the request and choose FLOW, GUIDE, GOVERN, or ASSURE from its scope and risk.
+3. Register the choice with
+   \`wendkeep profile route <FLOW|GUIDE|GOVERN|ASSURE> --session <id> --reason <text>\`.
+4. Re-check \`wendkeep profile status\` and follow the effective profile before editing.
+
+The persistent profile is only the base restored after the task lease; it is not an immutable
+decision for the current task. A base OFF does not block a temporary FLOW/GUIDE/GOVERN/ASSURE
+lease, while a base GOVERN does not prevent choosing FLOW or GUIDE for bounded work. An explicit
+user choice for the request takes precedence. If no causal session is available or routing fails,
+do not invent lease state: follow the effective profile and use GOVERN only as the conservative
+fallback when configuration is missing or invalid. The lease expires when the request ends.
+**OFF is never selected adaptively**; only a human can persist \`profile use OFF\`.
 
 Route work by the effective profile:
 - **OFF** — Wend Runtime is disabled and governance belongs to the native LLM harness; Keep Core stays active.

--- a/tests/integrations-transcripts.test.mjs
+++ b/tests/integrations-transcripts.test.mjs
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  completedCodexTurnIdsContent,
   parseClaudeTranscriptContent,
   parseCodexTranscriptContent,
   parseTranscriptContent,
@@ -418,6 +419,15 @@ test('[req:MOD-21] resolveTurnIdentity usa id solicitado, latest e ordem observa
   });
   assert.equal(resolveTurnIdentity(EXPECTED_CODEX, 'turno-ausente'), null);
   assert.equal(resolveTurnIdentity({ turns: [] }), null);
+});
+
+test('[req:IMPORT-7] completude Codex vem somente de task_complete do mesmo turn_id', () => {
+  const content = jsonl([
+    { type: 'event_msg', payload: { type: 'task_started', turn_id: 'turn-completo' } },
+    { type: 'event_msg', payload: { type: 'task_complete', turn_id: 'turn-completo' } },
+    { type: 'event_msg', payload: { type: 'task_started', turn_id: 'turn-em-execucao' } },
+  ]);
+  assert.deepEqual([...completedCodexTurnIdsContent(content)], ['turn-completo']);
 });
 
 test('[req:MOD-20] [req:MOD-21] parsers por conteúdo são determinísticos e não mutam opções', () => {

--- a/tests/memory-activation.test.mjs
+++ b/tests/memory-activation.test.mjs
@@ -329,3 +329,64 @@ test('[req:HOOK-MEM-1] SessionStart opens epochs and UserPromptSubmit only advan
     rmSync(vault, { recursive: true, force: true });
   }
 });
+
+test('[req:MEM-STOP-2] UserPromptSubmit de subagent registra o path sem avançar o turno principal', () => {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-subagent-prompt-causality-'));
+  const sessionId = 'wk-fixture-session-subagent-causality';
+  const parentTranscript = join(vault, 'wk-fixture-parent-rollout.jsonl');
+  const childTranscript = join(vault, 'wk-fixture-child-rollout.jsonl');
+  try {
+    writeFileSync(parentTranscript, `${JSON.stringify({
+      type: 'session_meta',
+      payload: {
+        id: 'wk-fixture-parent-rollout', session_id: sessionId, model_provider: 'openai',
+      },
+    })}\n`);
+    writeFileSync(childTranscript, `${JSON.stringify({
+      type: 'session_meta',
+      payload: {
+        id: 'wk-fixture-child-rollout',
+        session_id: sessionId,
+        parent_thread_id: 'wk-fixture-parent-rollout',
+        model_provider: 'openai',
+        source: {
+          subagent: {
+            thread_spawn: { parent_thread_id: 'wk-fixture-parent-rollout', depth: 1 },
+          },
+        },
+      },
+    })}\n`);
+
+    const start = runHook('hooks/session-start.mjs', vault, {
+      session_id: sessionId,
+      transcript_path: parentTranscript,
+      activation_id: 'parent-activation',
+    });
+    assert.equal(start.status, 0, start.stderr);
+
+    const parentPrompt = runHook('hooks/session-ensure.mjs', vault, {
+      session_id: sessionId,
+      transcript_path: parentTranscript,
+      turn_id: 'parent-turn-1',
+      prompt: '[wk-fixture] Prompt principal sintético.',
+    });
+    assert.equal(parentPrompt.status, 0, parentPrompt.stderr);
+
+    const childPrompt = runHook('hooks/session-ensure.mjs', vault, {
+      session_id: sessionId,
+      transcript_path: childTranscript,
+      turn_id: 'child-turn-1',
+      prompt: '[wk-fixture] Prompt filho sintético.',
+    });
+    assert.equal(childPrompt.status, 0, childPrompt.stderr);
+
+    const entry = readSessionRegistry(vault).sessions[sessionId];
+    assert.equal(entry.last_turn_sequence, 1);
+    assert.equal(entry.turn_sequences['parent-turn-1'], 1);
+    assert.equal(entry.turn_sequences['child-turn-1'], undefined);
+    assert.equal(entry.transcript_path, parentTranscript);
+    assert.deepEqual(new Set(entry.transcript_paths), new Set([parentTranscript, childTranscript]));
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});

--- a/tests/privacy-hygiene.test.mjs
+++ b/tests/privacy-hygiene.test.mjs
@@ -54,6 +54,46 @@ test('[req:MEM-STOP-7] privacy scanner accepts only the synthetic fixture namesp
   assert.deepEqual(inspectFixtureSource('virtual.test.mjs', source), []);
 });
 
+test('[req:OBS-14] sensor schema fields are public config without bypassing unknown fields', () => {
+  const sample = runtimeSamples();
+  const longCommand = [
+    'node --test tests/memory-activation.test.mjs',
+    ' tests/session-stop-',
+    'migration-lifecycle.test.mjs',
+  ].join('');
+  const sensor = {
+    id: 'session-causality',
+    name: 'Session causality',
+    description: longCommand,
+    severity: 'critical',
+    type: 'command',
+    command: longCommand,
+  };
+
+  assert.deepEqual(inspectFixtureSource(
+    'wendkeep.sensors.json',
+    JSON.stringify(sensor, null, 2),
+  ), []);
+  assert.deepEqual(inspectFixtureSource(
+    'wendkeep.sensors.json',
+    JSON.stringify({
+      ...sensor,
+      description: `Session causality ${sample.opaqueId}`,
+      command: `node --test --session ${sample.opaqueId}`,
+    }, null, 2),
+  ), [
+    'wendkeep.sensors.json:4:opaque-identifier',
+    'wendkeep.sensors.json:7:opaque-identifier',
+  ]);
+  assert.deepEqual(inspectFixtureSource(
+    'wendkeep.sensors.json',
+    JSON.stringify({ ...sensor, session_id: sample.opaqueId }, null, 2),
+  ), [
+    'wendkeep.sensors.json:8:opaque-identifier',
+    'wendkeep.sensors.json:8:unapproved-fixture-value',
+  ]);
+});
+
 test('[req:MEM-STOP-7] privacy diagnostics never disclose rejected values', () => {
   const sample = runtimeSamples();
   const source = `const projectId = ${JSON.stringify(sample.consumerLabel)};`;

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -68,16 +68,16 @@ test('extractReleaseNotes: throws when the version is absent', () => {
   assert.throws(() => extractReleaseNotes(FIXTURE, '9.9.9'), /9\.9\.9/);
 });
 
-test('[sensor:release-tests] 0.67.0 notes are extractable and match the package', () => {
-  const release = extractReleaseNotes(CHANGELOG, '0.67.0');
-  assert.equal(PACKAGE.version, '0.67.0');
-  assert.equal(release.date, '2026-08-01');
-  assert.match(release.notes, /profile route/i);
-  assert.match(release.notes, /FLOW.*GUIDE.*GOVERN.*ASSURE/is);
-  assert.match(release.notes, /OFF.*humano|humano.*OFF/i);
-  assert.match(release.notes, /Obsidian/i);
-  assert.match(release.notes, /P\/R\/E\/V\/C/i);
-  assert.doesNotMatch(release.notes, /observabilidade Codex/i);
+test('[sensor:release-tests] 0.67.1 notes are extractable and match the package', () => {
+  const release = extractReleaseNotes(CHANGELOG, '0.67.1');
+  assert.equal(PACKAGE.version, '0.67.1');
+  assert.equal(release.date, '2026-08-02');
+  assert.match(release.notes, /turn_sequences\[turn_id\]/i);
+  assert.match(release.notes, /agent_transcript_path/i);
+  assert.match(release.notes, /session-backfill/i);
+  assert.match(release.notes, /task_complete/i);
+  assert.match(release.notes, /incompleteTurns/i);
+  assert.doesNotMatch(release.notes, /019f[0-9a-f-]+/i);
 });
 
 test('auto-tag: existing tag still refreshes the GitHub Release from CHANGELOG', () => {

--- a/tests/session-backfill.test.mjs
+++ b/tests/session-backfill.test.mjs
@@ -1,0 +1,182 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  appendFileSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { backfillSessions } from '../hooks/session-backfill.mjs';
+
+const SESSION_ID = 'wk-fixture-session-backfill';
+const BIN = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'wendkeep.mjs');
+
+function fixture() {
+  const vaultBase = mkdtempSync(join(tmpdir(), 'wk-session-backfill-complete-'));
+  const brain = join(vaultBase, '.brain');
+  const sessionRel = '03-Sessões/wk-fixture-session-backfill.md';
+  const sessionPath = join(vaultBase, ...sessionRel.split('/'));
+  const transcriptPath = join(vaultBase, 'wk-fixture-rollout.jsonl');
+  mkdirSync(brain, { recursive: true });
+  mkdirSync(join(sessionPath, '..'), { recursive: true });
+  writeFileSync(sessionPath, [
+    '---',
+    'type: session',
+    `session_id: "${SESSION_ID}"`,
+    'provider: codex',
+    'status: active',
+    '---',
+    '',
+    '# Synthetic session',
+    '',
+    '## Iterações',
+    '',
+    '## Pendências',
+    '',
+    'Nenhuma pendência identificada automaticamente.',
+    '',
+  ].join('\n'));
+  const events = [
+    { type: 'session_meta', payload: { id: 'wk-fixture-rollout', session_id: SESSION_ID } },
+    { type: 'event_msg', timestamp: '2026-08-02T10:00:00.000Z', payload: { type: 'task_started', turn_id: 'turn-completo' } },
+    { type: 'event_msg', timestamp: '2026-08-02T10:00:01.000Z', payload: { type: 'user_message', turn_id: 'turn-completo', message: '[wk-fixture] Pedido completo.' } },
+    { type: 'event_msg', timestamp: '2026-08-02T10:00:02.000Z', payload: { type: 'agent_message', turn_id: 'turn-completo', message: '[wk-fixture] Resposta completa.' } },
+    { type: 'event_msg', timestamp: '2026-08-02T10:00:03.000Z', payload: { type: 'task_complete', turn_id: 'turn-completo' } },
+    { type: 'event_msg', timestamp: '2026-08-02T10:01:00.000Z', payload: { type: 'task_started', turn_id: 'turn-em-execucao' } },
+    { type: 'event_msg', timestamp: '2026-08-02T10:01:01.000Z', payload: { type: 'user_message', turn_id: 'turn-em-execucao', message: '[wk-fixture] Pedido ainda ativo.' } },
+    { type: 'event_msg', timestamp: '2026-08-02T10:01:02.000Z', payload: { type: 'agent_message', turn_id: 'turn-em-execucao', message: '[wk-fixture] Resposta parcial.' } },
+  ];
+  writeFileSync(transcriptPath, `${events.map((event) => JSON.stringify(event)).join('\n')}\n`);
+  writeFileSync(join(brain, 'SESSION_REGISTRY.json'), `${JSON.stringify({
+    version: 2,
+    sessions: {
+      [SESSION_ID]: {
+        session_file: sessionRel,
+        transcript_path: transcriptPath,
+        transcript_id: 'wk-fixture-rollout',
+        provider: 'codex',
+        status: 'active',
+      },
+    },
+  }, null, 2)}\n`);
+  return { vaultBase, sessionPath, transcriptPath };
+}
+
+test('[req:IMPORT-7] CLI encaminha flags do hook session-backfill até o script', () => {
+  const fx = fixture();
+  try {
+    const run = spawnSync(process.execPath, [
+      BIN,
+      'hook',
+      'session-backfill',
+      '--session',
+      SESSION_ID,
+      '--vault',
+      fx.vaultBase,
+      '--write',
+    ], {
+      cwd: fx.vaultBase,
+      env: { ...process.env, OBSIDIAN_VAULT_PATH: fx.vaultBase },
+      encoding: 'utf8',
+    });
+    assert.equal(run.status, 0, run.stderr);
+    const report = JSON.parse(run.stdout);
+    assert.equal(report.mode, 'write');
+    assert.equal(report.inserted, 1);
+    assert.match(readFileSync(fx.sessionPath, 'utf8'), /<!-- wk-turn: turn-completo -->/);
+    assert.doesNotMatch(readFileSync(fx.sessionPath, 'utf8'), /<!-- wk-turn: turn-em-execucao -->/);
+  } finally {
+    rmSync(fx.vaultBase, { recursive: true, force: true });
+  }
+});
+
+test('[req:IMPORT-7] session-backfill insere concluído e apenas reporta turno Codex ativo', () => {
+  const fx = fixture();
+  try {
+    const dry = backfillSessions({ vaultBase: fx.vaultBase, session: SESSION_ID });
+    assert.equal(dry.candidates, 1);
+    assert.deepEqual(dry.sessions[0].missingTurns, ['turn-completo']);
+    assert.deepEqual(dry.sessions[0].incompleteTurns, ['turn-em-execucao']);
+    assert.doesNotMatch(readFileSync(fx.sessionPath, 'utf8'), /wk-turn:/);
+
+    const applied = backfillSessions({ vaultBase: fx.vaultBase, session: SESSION_ID, write: true });
+    assert.equal(applied.inserted, 1);
+    const content = readFileSync(fx.sessionPath, 'utf8');
+    assert.match(content, /<!-- wk-turn: turn-completo -->/);
+    assert.doesNotMatch(content, /<!-- wk-turn: turn-em-execucao -->/);
+
+    const again = backfillSessions({ vaultBase: fx.vaultBase, session: SESSION_ID, write: true });
+    assert.equal(again.inserted, 0);
+    assert.deepEqual(again.sessions[0].incompleteTurns, ['turn-em-execucao']);
+
+    appendFileSync(fx.transcriptPath, `${JSON.stringify({
+      type: 'event_msg',
+      timestamp: '2026-08-02T10:01:03.000Z',
+      payload: { type: 'task_complete', turn_id: 'turn-em-execucao' },
+    })}\n`);
+    const completedLater = backfillSessions({
+      vaultBase: fx.vaultBase,
+      session: SESSION_ID,
+      write: true,
+    });
+    assert.equal(completedLater.inserted, 1);
+    assert.deepEqual(completedLater.sessions[0].missingTurns, ['turn-em-execucao']);
+    assert.deepEqual(completedLater.sessions[0].incompleteTurns, []);
+    assert.match(
+      readFileSync(fx.sessionPath, 'utf8'),
+      /<!-- wk-turn: turn-em-execucao -->/,
+    );
+  } finally {
+    rmSync(fx.vaultBase, { recursive: true, force: true });
+  }
+});
+
+test('[req:IMPORT-7] session-backfill preserva elegibilidade histórica de transcript Claude', () => {
+  const fx = fixture();
+  try {
+    const claudeEvents = [
+      {
+        type: 'user',
+        uuid: 'claude-turn-sem-task-complete',
+        timestamp: '2026-08-02T11:00:00.000Z',
+        sessionId: SESSION_ID,
+        message: { role: 'user', content: 'Pedido Claude histórico.' },
+      },
+      {
+        type: 'assistant',
+        uuid: 'claude-answer',
+        timestamp: '2026-08-02T11:00:01.000Z',
+        sessionId: SESSION_ID,
+        message: {
+          role: 'assistant',
+          model: 'claude-sonnet-5',
+          content: [{ type: 'text', text: 'Resposta Claude histórica.' }],
+        },
+      },
+    ];
+    writeFileSync(
+      fx.transcriptPath,
+      `${claudeEvents.map((event) => JSON.stringify(event)).join('\n')}\n`,
+    );
+    const registryPath = join(fx.vaultBase, '.brain', 'SESSION_REGISTRY.json');
+    const registry = JSON.parse(readFileSync(registryPath, 'utf8'));
+    registry.sessions[SESSION_ID].provider = 'claude';
+    writeFileSync(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+
+    const applied = backfillSessions({ vaultBase: fx.vaultBase, session: SESSION_ID, write: true });
+    assert.equal(applied.inserted, 1);
+    assert.equal(applied.incomplete, 0);
+    assert.match(
+      readFileSync(fx.sessionPath, 'utf8'),
+      /<!-- wk-turn: claude-turn-sem-task-complete -->/,
+    );
+  } finally {
+    rmSync(fx.vaultBase, { recursive: true, force: true });
+  }
+});

--- a/tests/session-stop-migration-lifecycle.test.mjs
+++ b/tests/session-stop-migration-lifecycle.test.mjs
@@ -337,6 +337,61 @@ test('[req:MEM-STOP-6] unverifiable v2 Stop is durably observable as ambiguous',
   }
 });
 
+test('[req:MEM-STOP-2] Stop principal usa turn_sequences quando filhos intercalam a ordem global', () => {
+  const { project, vault, brain, transcript } = seedLegacyFixture();
+  try {
+    const start = runHook(join(ROOT, 'hooks', 'session-start.mjs'), project, vault, {
+      hook_event_name: 'SessionStart',
+      session_id: SESSION_ID,
+      transcript_path: transcript,
+      source: 'startup',
+    });
+    assertHookSucceeded(start, 'SessionStart before mapped Stop');
+
+    for (let index = 1; index <= 5; index += 1) {
+      writeTurn(
+        transcript,
+        `wk-parent-turn-${index}`,
+        `Synthetic parent prompt ${index}.`,
+        `Synthetic parent answer ${index}.`,
+      );
+    }
+
+    const polluted = readRegistry(brain);
+    const pollutedEntry = polluted.sessions[SESSION_ID];
+    const activationId = pollutedEntry.active_activation_id;
+    pollutedEntry.last_turn_sequence = 17;
+    pollutedEntry.activations[activationId].last_turn_sequence = 17;
+    writeFileSync(join(brain, 'SESSION_REGISTRY.json'), `${JSON.stringify(polluted, null, 2)}\n`);
+
+    const ensure = runHook(join(ROOT, 'hooks', 'session-ensure.mjs'), project, vault, {
+      hook_event_name: 'UserPromptSubmit',
+      session_id: SESSION_ID,
+      transcript_path: transcript,
+      turn_id: 'wk-parent-turn-5',
+      prompt: '[wk-fixture] Synthetic parent prompt 5.',
+    });
+    assertHookSucceeded(ensure, 'mapped UserPromptSubmit');
+    assert.equal(readRegistry(brain).sessions[SESSION_ID].turn_sequences['wk-parent-turn-5'], 18);
+
+    const stop = runHook(join(ROOT, 'hooks', 'session-stop.mjs'), project, vault, {
+      hook_event_name: 'Stop',
+      session_id: SESSION_ID,
+      transcript_path: transcript,
+      turn_id: 'wk-parent-turn-5',
+    });
+    assertHookSucceeded(stop, 'mapped Stop');
+
+    const after = readRegistry(brain).sessions[SESSION_ID];
+    const active = after.activations[after.active_activation_id];
+    const note = readFileSync(join(vault, after.session_file), 'utf8');
+    assert.equal(active.last_stop_turn_sequence, 18);
+    assert.match(note, /<!-- wk-turn: wk-parent-turn-5 -->/);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
 test('[req:MEM-STOP-4] v2 staging revalidation aborts an older Stop before finalization', () => {
   const stopAcceptedBeforeConcurrentStart = {
     stopDisposition: 'applied',

--- a/tests/subagent-observability-lifecycle.test.mjs
+++ b/tests/subagent-observability-lifecycle.test.mjs
@@ -55,7 +55,7 @@ function resolved(input, entry) {
     identity: {
       state: 'resolved',
       provider: 'codex',
-      canonicalConversationId: 'session-alpha',
+      canonicalConversationId: 'wk-fixture-session-alpha',
       transcriptPath: input.transcript_path,
       transcriptId: basename(input.transcript_path, '.jsonl'),
     },
@@ -64,17 +64,24 @@ function resolved(input, entry) {
 }
 
 function registryMutation(entry) {
-  const registry = { version: 2, sessions: { 'session-alpha': entry } };
+  const registry = { version: 2, sessions: { 'wk-fixture-session-alpha': entry } };
   return (_vault, mutator) => mutator(registry);
 }
 
 function childMeta(path) {
   const id = basename(path, '.jsonl');
+  if (id.startsWith('root-')) {
+    return {
+      ok: true,
+      meta: { id, session_id: 'wk-fixture-session-alpha' },
+      lineBytes: 96,
+    };
+  }
   return {
     ok: true,
     meta: {
       id,
-      session_id: 'session-alpha',
+      session_id: 'wk-fixture-session-alpha',
       source: {
         subagent: {
           thread_spawn: { parent_thread_id: 'root-a', depth: 1 },
@@ -84,6 +91,93 @@ function childMeta(path) {
     lineBytes: 128,
   };
 }
+
+test('[req:OBS-11] alias agentTranscriptPath resolve o filho sem substituir o root principal', async () => {
+  const fx = fixture();
+  try {
+    const entry = registryEntry(fx);
+    const childPath = join(fx.vaultBase, 'child-alias.jsonl');
+    let signals = 0;
+
+    const result = await refreshSubagents(fx.vaultBase, {
+      provider: 'codex',
+      transcript_path: fx.rootA,
+      agentTranscriptPath: childPath,
+    }, {
+      resolveEntry: (_vault, input) => {
+        assert.equal(input.transcript_path, childPath);
+        return resolved(input, entry);
+      },
+      readMeta: childMeta,
+      mutateRegistry: registryMutation(entry),
+      resolveRoots: () => ({ state: 'complete', rootPaths: [fx.rootA], descendantPaths: [] }),
+      recordSignal: (_vault, _sessionId, signal) => {
+        signals += 1;
+        assert.equal(signal.rollout_id, 'child-alias');
+        assert.equal(signal.transcript_path, childPath);
+        return {
+          recorded: true,
+          sequence: 1,
+          state: { observability_dirty: false, observability_signal_sequence: 1 },
+        };
+      },
+    });
+
+    assert.equal(result, true);
+    assert.equal(signals, 1);
+    assert.equal(entry.transcript_path, fx.rootA);
+  } finally {
+    rmSync(fx.vaultBase, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-11] metadado filho inválido ou pai alheio é rejeitado sem escrita', async () => {
+  const fx = fixture();
+  try {
+    const entry = registryEntry(fx);
+    const cases = [
+      ['source.subagent ausente', (meta) => { delete meta.source; }],
+      ['id divergente', (meta) => { meta.id = 'outro-filho'; }],
+      ['sessão canônica divergente', (meta) => { meta.session_id = 'wk-fixture-session-other'; }],
+      ['parent_thread_id alheio', (meta) => {
+        meta.source.subagent.thread_spawn.parent_thread_id = 'root-alheio';
+      }],
+    ];
+
+    for (const [label, corrupt] of cases) {
+      const childPath = join(fx.vaultBase, `child-${label.replace(/\W+/g, '-')}.jsonl`);
+      let registryMutations = 0;
+      let signals = 0;
+      const result = await refreshSubagents(fx.vaultBase, {
+        provider: 'codex',
+        transcript_path: fx.rootA,
+        agent_transcript_path: childPath,
+      }, {
+        resolveEntry: (_vault, input) => resolved(input, entry),
+        readMeta: (path) => {
+          const resultMeta = childMeta(path);
+          if (path === childPath) corrupt(resultMeta.meta);
+          return resultMeta;
+        },
+        resolveRoots: () => ({ state: 'complete', rootPaths: [fx.rootA], descendantPaths: [] }),
+        mutateRegistry: (_vault, mutator) => {
+          registryMutations += 1;
+          return registryMutation(entry)(_vault, mutator);
+        },
+        recordSignal: () => {
+          signals += 1;
+          return { state: { observability_dirty: false }, sequence: 1 };
+        },
+      });
+
+      assert.equal(result, false, label);
+      assert.equal(registryMutations, 0, `${label}: registry permanece intocado`);
+      assert.equal(signals, 0, `${label}: nenhum sinal é persistido`);
+    }
+  } finally {
+    rmSync(fx.vaultBase, { recursive: true, force: true });
+  }
+});
 
 test('[req:OBS-11] rajada de SubagentStop publica uma vez pela maior sequence após 250 ms', async () => {
   const fx = fixture();
@@ -168,7 +262,8 @@ test('[req:OBS-11] rajada de SubagentStop publica uma vez pela maior sequence ap
     const pending = ['child-a', 'child-b', 'child-c'].map((id) => (
       refreshSubagents(fx.vaultBase, {
         provider: 'codex',
-        transcript_path: join(fx.vaultBase, `${id}.jsonl`),
+        transcript_path: fx.rootA,
+        agent_transcript_path: join(fx.vaultBase, `${id}.jsonl`),
       }, deps)
     ));
     await Promise.resolve();
@@ -283,7 +378,7 @@ test('[req:OBS-12] SessionStop usa gate causal, todos os roots e deadline entry 
       vaultBase: fx.vaultBase,
       input: { provider: 'codex', transcript_path: fx.rootA },
       sessionPath: fx.sessionPath,
-      sessionId: 'session-alpha',
+      sessionId: 'wk-fixture-session-alpha',
       entry,
       causalStop: {
         canPromoteMemory: true,
@@ -338,7 +433,7 @@ test('[req:OBS-12] SessionStop stale ou no limite do deadline não publica', asy
       vaultBase: fx.vaultBase,
       input: { provider: 'codex', transcript_path: fx.rootA },
       sessionPath: fx.sessionPath,
-      sessionId: 'session-alpha',
+      sessionId: 'wk-fixture-session-alpha',
       entry: original,
       causalStop: {
         canPromoteMemory: true,

--- a/tests/sync-defs.test.mjs
+++ b/tests/sync-defs.test.mjs
@@ -42,6 +42,21 @@ test('syncDefs: writes the managed AGENTS.md section, idempotent, user content p
       '[req:OP-13] managed block forbids automatic OFF');
     assert.match(md, /request|task-scoped|temporary/i,
       '[req:OP-13] managed block explains lease scope');
+    assert.match(md, /MUST run the routing gate/i,
+      '[req:OP-13] every implementation performs explicit adaptive routing');
+    assert.match(md, /persistent profile is only the base/i,
+      '[req:OP-13] persistent profile is not the immutable task decision');
+    assert.match(md, /base OFF does not block[^.]+FLOW\/GUIDE\/GOVERN\/ASSURE/i,
+      '[req:OP-13] OFF base still allows a temporary route');
+    assert.match(md, /base GOVERN does not prevent[^.]+FLOW or GUIDE/i,
+      '[req:OP-13] GOVERN base may adapt to lower-ceremony bounded work');
+    assert.match(md, /re-check[^.]+before editing/i,
+      '[req:OP-13] effective route is confirmed before files change');
+    assert.match(md, /explicit\s+user choice[\s\S]{0,100}takes precedence/i,
+      '[req:OP-13] an explicit user route overrides automatic classification');
+    assert.match(md,
+      /no causal session[\s\S]{0,180}do not invent lease state[\s\S]{0,220}GOVERN only[\s\S]{0,120}missing or invalid/i,
+      '[req:OP-13] failed routing preserves effective state and conservative fallback');
     assert.doesNotMatch(md, /Work\s+through its change loop/i,
       '[req:OP-5] the managed block must not impose GOVERN on every profile');
     // idempotente: re-run = 1 seção só

--- a/wendkeep.sensors.json
+++ b/wendkeep.sensors.json
@@ -112,6 +112,46 @@
       "severity": "critical",
       "type": "command",
       "command": "node --test tests/memory-cli.test.mjs tests/memory-attempt-recovery.test.mjs tests/memory-attempt-recovery-topology.test.mjs tests/vault-health-memory.test.mjs"
+    },
+    {
+      "id": "session-causality",
+      "name": "session-causality",
+      "description": "node --test tests/memory-activation.test.mjs tests/session-stop-migration-lifecycle.test.mjs",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test tests/memory-activation.test.mjs tests/session-stop-migration-lifecycle.test.mjs"
+    },
+    {
+      "id": "subagent-stop-input",
+      "name": "subagent-stop-input",
+      "description": "node --test tests/subagent-observability-lifecycle.test.mjs",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test tests/subagent-observability-lifecycle.test.mjs"
+    },
+    {
+      "id": "session-backfill-complete",
+      "name": "session-backfill-complete",
+      "description": "node --test tests/integrations-transcripts.test.mjs tests/session-backfill.test.mjs",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test tests/integrations-transcripts.test.mjs tests/session-backfill.test.mjs"
+    },
+    {
+      "id": "profile-routing-guidance",
+      "name": "Profile routing guidance",
+      "description": "Proves the managed AGENTS routing gate and profile skill projections",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test tests/sync-defs.test.mjs tests/skills-seed.test.mjs tests/operating-profile-boundaries.test.mjs"
+    },
+    {
+      "id": "tests-serial",
+      "name": "tests-serial",
+      "description": "node --test --test-concurrency=1",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test --test-concurrency=1"
     }
   ]
 }


### PR DESCRIPTION
## Resumo

- corrige a captura causal de turnos quando subagents intercalam eventos na sessão principal
- completa `Subagents e workflows`, marcadores `wk-turn`, encerramento e backfill idempotente
- reforça no bloco gerenciado do `AGENTS.md` o gate obrigatório de escolha temporária entre FLOW, GUIDE, GOVERN e ASSURE
- endurece o scanner de privacidade sem falsos positivos para comandos públicos longos

## Validação

- `npm run check` verde
- suíte completa: 1.341 aprovados, 0 falhas e 4 ignorados
- suíte afetada final: 40/40
- testes finais de release, sync-defs e privacidade: 25/25
- `verify --deep` e revisões independentes GREEN
- changes arquivadas em ADR-0076, ADR-0077 e ADR-0078

## CHANGELOG
### Fixed

- **Turnos de subagents não bloqueiam mais a captura da sessão-mãe.** `UserPromptSubmit` de rollout
  filho registra o path para observabilidade sem avançar a sequência principal, e `SessionStop`
  prefere o mapeamento causal `turn_sequences[turn_id]` antes da ordem local do transcript. Isso
  preserva os marcadores `wk-turn`, o encerramento e a memória mesmo com filhos intercalados.
- **`SubagentStop` consome o transcript correto do payload Codex.** O hook resolve o filho por
  `agent_transcript_path`/`agentTranscriptPath`, valida identidade, sessão e `parent_thread_id`
  contra um root comprovado e mantém `transcript_path` como contexto da sessão-mãe, permitindo
  preencher `Subagents e workflows` no último filho sem aceitar sinais de outra cadeia.
- **O backfill não grava o turno Codex ainda em execução.** `hook session-backfill` exige
  `task_complete`, separa `missingTurns` de `incompleteTurns`, permanece dry-run por padrão e aplica
  somente turnos concluídos de forma idempotente. A CLI agora encaminha `--session`, `--vault`,
  `--write` e demais argumentos ao hook executado. README e guias PT-BR/EN documentam o reparo.
- **O bloco gerenciado do `AGENTS.md` exige roteamento adaptativo antes de editar.** O harness
  inspeciona o perfil-base, classifica a solicitação, registra uma lease temporária entre `FLOW`,
  `GUIDE`, `GOVERN` e `ASSURE` e confirma o perfil efetivo; `OFF` nunca é escolhido pela LLM e a
  escolha explícita do usuário prevalece.
- **O scanner de privacidade distingue configuração pública de identificadores privados.** Comandos
  longos legítimos em `wendkeep.sensors.json` deixam de gerar falso positivo, sem permitir que UUID,
  hash, token compacto, campo desconhecido ou path absoluto sejam ocultados pela exceção.