### PR TITLE
feat: guided memory curation (0.67.3 + 0.68.0)

### DIFF
--- a/.agents/skills/example-skill/.wendkeep-meta.json
+++ b/.agents/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.67.2",
+  "wendkeepVersion": "0.68.0",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.agents/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.agents/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.67.2",
+  "wendkeepVersion": "0.68.0",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.agents/skills/wk-debugging/.wendkeep-meta.json
+++ b/.agents/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.67.2",
+  "wendkeepVersion": "0.68.0",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.agents/skills/wk-planning/.wendkeep-meta.json
+++ b/.agents/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.67.2",
+  "wendkeepVersion": "0.68.0",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.agents/skills/wk-tdd/.wendkeep-meta.json
+++ b/.agents/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.67.2",
+  "wendkeepVersion": "0.68.0",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.agents/skills/wk-verify/.wendkeep-meta.json
+++ b/.agents/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.67.2",
+  "wendkeepVersion": "0.68.0",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.agents/skills/wk-workflow/.wendkeep-meta.json
+++ b/.agents/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.67.2",
+  "wendkeepVersion": "0.68.0",
   "sourceHash": "ee0cb172a5b5bbd2ebb5c7e4039ba1a9081992f0461da98d508a5cba67ab23db"
 }

--- a/.claude/skills/example-skill/.wendkeep-meta.json
+++ b/.claude/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.67.2",
+  "wendkeepVersion": "0.68.0",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.claude/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.claude/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.67.2",
+  "wendkeepVersion": "0.68.0",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.claude/skills/wk-debugging/.wendkeep-meta.json
+++ b/.claude/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.67.2",
+  "wendkeepVersion": "0.68.0",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.claude/skills/wk-planning/.wendkeep-meta.json
+++ b/.claude/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.67.2",
+  "wendkeepVersion": "0.68.0",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.claude/skills/wk-tdd/.wendkeep-meta.json
+++ b/.claude/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.67.2",
+  "wendkeepVersion": "0.68.0",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.claude/skills/wk-verify/.wendkeep-meta.json
+++ b/.claude/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.67.2",
+  "wendkeepVersion": "0.68.0",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.claude/skills/wk-workflow/.wendkeep-meta.json
+++ b/.claude/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.67.2",
+  "wendkeepVersion": "0.68.0",
   "sourceHash": "ee0cb172a5b5bbd2ebb5c7e4039ba1a9081992f0461da98d508a5cba67ab23db"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- wendkeep:skills:start -->
-<!-- wendkeep-version: 0.67.2; skills-sha256: d170f56e18f94318178d4062b722c40275d07c10e76021f95d16f441d498328d -->
+<!-- wendkeep-version: 0.68.0; skills-sha256: d170f56e18f94318178d4062b722c40275d07c10e76021f95d16f441d498328d -->
 ## wendkeep — Keep Core & operating profiles
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. **Keep Core is always active**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.68.0] — 2026-08-02
+
+### Added
+
+- **Curadoria de memória agora tem um assistente interativo para pessoas.** O novo
+  `memory curate --vault <vault>` agrupa conflitos por nomes amigáveis, exibe somente previews
+  sanitizados e guia promoção, rejeição, pulo ou saída com confirmação negativa por padrão. O
+  trabalho restante pode ser retomado em outra execução; ambientes não-TTY recebem o fallback
+  seguro `memory candidates --active` e nenhuma escrita implícita.
+
+### Changed
+
+- **O `doctor` apresenta integridade e conflitos de memória em formato humano.** A saída principal
+  usa seções e categorias amigáveis e recomenda primeiro o assistente guiado, enquanto o hook de
+  health preserva seu contrato JSON para automações. O diagnóstico continua somente leitura e
+  `memory repair` continua estritamente estrutural, sem escolher vencedores semânticos.
+
 ## [0.67.3] — 2026-08-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.67.3] — 2026-08-02
+
+### Fixed
+
+- **Conflitos semânticos agora levam a uma curadoria humana executável.** O doctor diferencia
+  candidates em conflito de corrupção estrutural, explica que `memory repair` não escolhe um
+  vencedor e mostra `memory candidates --active --vault <vault>` com o Vault resolvido, seguido
+  pelos modelos explícitos para promover ou rejeitar a decisão.
+- **A inspeção de candidates deixa de exigir leitura direta do sidecar.** O novo comando read-only
+  `memory candidates [--active]` devolve somente `candidate_id`, `reason`, `status`, `memory_key` e
+  `event_ids`, sem valores ou conteúdo, em ordem determinística e sem alterar o bundle de memória.
+
 ## [0.67.2] — 2026-08-02
 
 ### Fixed

--- a/README.en.md
+++ b/README.en.md
@@ -369,8 +369,10 @@ backup/audit; divergent mirrors fail closed. A demonstrably superseded
 ambiguity uses `memory reconcile <session> --by-session <successor>
 --reason <reason>` as a dry run and requires `--apply`; the decision is backed up and audited
 without rewriting ledger, CORE, or notes. Run `status --gate` again afterwards. Conflicts require
-explicit, durable curation: `memory promote <id> --event <event-id>` selects one event from the
-candidate, while `memory reject <id>` keeps the current value. The decision is idempotent, and a
+explicit, durable curation: `memory candidates --active --vault <vault>` lists only safe IDs and
+metadata in read-only mode — it does not expose memory values or content. After human review,
+`memory promote <id> --event <event-id>` selects one event from the candidate, while
+`memory reject <id>` keeps the current value. `memory repair` does not choose a winner. The decision is idempotent, and a
 new promotion accepts a later Stop from the same session/activation without recreating a conflict.
 A promotion written by 0.66.1 remains historical: if the next Stop forms a new candidate, update
 to 0.66.3 and run `memory repair`. During replay, a transient candidate is re-evaluated against the

--- a/README.en.md
+++ b/README.en.md
@@ -369,8 +369,11 @@ backup/audit; divergent mirrors fail closed. A demonstrably superseded
 ambiguity uses `memory reconcile <session> --by-session <successor>
 --reason <reason>` as a dry run and requires `--apply`; the decision is backed up and audited
 without rewriting ledger, CORE, or notes. Run `status --gate` again afterwards. Conflicts require
-explicit, durable curation: `memory candidates --active --vault <vault>` lists only safe IDs and
-metadata in read-only mode — it does not expose memory values or content. After human review,
+explicit, durable curation. Start with `memory curate --vault <vault>`: the menu groups conflicts
+under friendly names, shows sanitized previews, and confirms every write with default `no`. Skip
+or quit and run it again to resume. In a non-TTY environment, use
+`memory candidates --active --vault <vault>` to list only safe IDs and metadata in read-only mode —
+it does not expose memory values or content. After human review,
 `memory promote <id> --event <event-id>` selects one event from the candidate, while
 `memory reject <id>` keeps the current value. `memory repair` does not choose a winner. The decision is idempotent, and a
 new promotion accepts a later Stop from the same session/activation without recreating a conflict.
@@ -381,7 +384,10 @@ superseded. Repair migrates the checkpoint and mirror only when it proves the ex
 replay, attempt identity, and absence of a real conflict; it creates a backup and audit without
 appending or rewriting events. Ambiguity stays queued for explicit curation. Do not publish or
 install 0.66.2; use 0.66.3 or later. Decisions survive repair/replay;
-`blocked_by_core` cannot override CORE. Doctor only diagnoses. When status/doctor reports projected
+`blocked_by_core` cannot override CORE. Doctor only diagnoses, now with human-readable output and
+the guided next action; its health hook preserves JSON for automation. A missing Vault or unsafe
+boundary/registry also yields blocked memory, a safe command with the resolved path, and structured
+JSON—never a false “intact bundle” or a stack trace. When status/doctor reports projected
 acknowledgement pending on 0.66.4 or later, first run the targeted dry run
 `memory recover-attempt <session> --vault <vault>`, then authorize `--apply`; it changes only
 registry/checkpoint. See syntax, preconditions, and fail-closed behavior in

--- a/README.md
+++ b/README.md
@@ -366,8 +366,10 @@ a fronteira física correta; espelhos divergentes falham fechados. Uma
 ambiguidade comprovadamente substituída usa `memory reconcile <sessão>
 --by-session <sucessora> --reason <motivo>` como dry-run e exige `--apply`; a decisão faz backup e
 auditoria sem reescrever ledger, CORE ou notas. Depois rode `status --gate` novamente. Conflitos
-exigem curadoria explícita e durável: `memory promote <id> --event <event-id>` escolhe um dos
-eventos do candidate; `memory reject <id>` mantém o valor atual. A decisão é idempotente, e uma
+exigem curadoria explícita e durável: `memory candidates --active --vault <cofre>` lista, em modo
+read-only, apenas IDs e metadados seguros — nunca valores ou conteúdo da memória. Depois da revisão
+humana, `memory promote <id> --event <event-id>` escolhe um dos eventos do candidate;
+`memory reject <id>` mantém o valor atual. `memory repair` não escolhe vencedor. A decisão é idempotente, e uma
 promoção nova aceita um Stop posterior da mesma sessão/activation sem recriar conflito. Uma
 promoção gravada pela 0.66.1 permanece histórica: se o próximo Stop formar novo candidate,
 atualize para a 0.66.3 e rode `memory repair`. Durante o replay, um candidate transitório é

--- a/README.md
+++ b/README.md
@@ -366,9 +366,12 @@ a fronteira física correta; espelhos divergentes falham fechados. Uma
 ambiguidade comprovadamente substituída usa `memory reconcile <sessão>
 --by-session <sucessora> --reason <motivo>` como dry-run e exige `--apply`; a decisão faz backup e
 auditoria sem reescrever ledger, CORE ou notas. Depois rode `status --gate` novamente. Conflitos
-exigem curadoria explícita e durável: `memory candidates --active --vault <cofre>` lista, em modo
-read-only, apenas IDs e metadados seguros — nunca valores ou conteúdo da memória. Depois da revisão
-humana, `memory promote <id> --event <event-id>` escolhe um dos eventos do candidate;
+exigem curadoria explícita e durável. Comece por `memory curate --vault <cofre>`: o menu agrupa os
+conflitos com nomes amigáveis, mostra previews sanitizados e confirma cada escrita com padrão
+negativo. Pular ou sair permite retomar depois. Em terminal não interativo, use
+`memory candidates --active --vault <cofre>` para listar, em modo read-only, apenas IDs e metadados
+seguros — nunca valores ou conteúdo da memória. Depois da revisão humana,
+`memory promote <id> --event <event-id>` escolhe um dos eventos do candidate;
 `memory reject <id>` mantém o valor atual. `memory repair` não escolhe vencedor. A decisão é idempotente, e uma
 promoção nova aceita um Stop posterior da mesma sessão/activation sem recriar conflito. Uma
 promoção gravada pela 0.66.1 permanece histórica: se o próximo Stop formar novo candidate,
@@ -381,7 +384,10 @@ Não publique nem instale a 0.66.2; use a 0.66.3 ou mais recente. Decisões sobr
 `blocked_by_core` não pode sobrescrever CORE.
 Desde a 0.66.4, quando status/doctor indicar acknowledgement projetado pendente, use o dry-run
 dirigido `memory recover-attempt <sessão> --vault <cofre>` e só então autorize `--apply`; ele
-altera apenas registry/checkpoint. O doctor apenas diagnostica. Veja sintaxe, pré-condições e
+altera apenas registry/checkpoint. O doctor apenas diagnostica, agora em saída de formato humano
+com a ação guiada recomendada; seu hook de health preserva o JSON para automações. Vault ausente ou
+boundary/registry inseguro também resulta em memória bloqueada, comando seguro com caminho resolvido
+e JSON estruturado, nunca em um falso “bundle íntegro” ou stack trace. Veja sintaxe, pré-condições e
 falhas fechadas em [memória e curadoria](docs/pt-BR/commands/memory.md).
 
 As notas de sessão usam um único snapshot vivo `## Agentes, tokens e custos`. Os hooks do agente principal e dos subagents recompõem o bloco atomicamente, incluindo custo, dimensões de tokens, reasoning e effort por modelo/origem. No Codex, prompts de subagents registram o rollout para observabilidade sem avançar a sequência do agente principal; `SubagentStop` lê o filho em `agent_transcript_path` e só persiste o sinal quando seu `parent_thread_id` corresponde a um root validado da sessão. O Stop principal usa o mapeamento causal de `turn_id` do registry antes da ordem local do transcript. Para recuperar marcadores ausentes com a conversa aberta, `hook session-backfill` é dry-run por padrão e nunca grava um turno Codex sem `task_complete`.

--- a/docs/en/commands/maintenance-and-diagnostics.md
+++ b/docs/en/commands/maintenance-and-diagnostics.md
@@ -57,6 +57,7 @@ npx --no-install wendkeep --version
 npx --no-install wendkeep sync-defs --check --vault .MyApp-vault --project .
 npx --no-install wendkeep doctor --vault .MyApp-vault
 npx --no-install wendkeep memory status --gate --vault .MyApp-vault
+npx --no-install wendkeep memory candidates --active --vault .MyApp-vault
 npx --no-install wendkeep cost rebuild --session <id> --json --vault .MyApp-vault
 npx --no-install wendkeep cost rebuild --session <id> --json --vault .MyApp-vault --apply
 ```
@@ -74,11 +75,17 @@ dry-run path before any write.
 
 - `no vault`: run from the bound root or pass `--vault`.
 - `defs stale`: confirm the version and run `sync-defs --reseed`.
-- Legacy vault: this is a non-blocking warning; plan `memory migrate --apply` separately.
+- Legacy vault: this is a non-blocking warning; doctor shows
+  `npx --no-install wendkeep memory migrate --apply --vault <vault>` with the resolved Vault, but
+  migration remains opt-in and must be planned separately.
 - `degraded` plus an intact outbox: warning; preserve the outbox and allow idempotent replay.
 - `ambiguous`, lost publication, or a mismatched checkpoint: blocking; preserve registry, ledger,
   outbox, and SHARED so `last_memory_attempt` can be correlated before repair.
 - Corrupt bundle: preserve evidence and run `memory status --gate` before `memory repair`.
+- An active semantic conflict requires a human decision: `memory repair` does not choose a winner.
+  List safe IDs with `memory candidates --active --vault <vault>`, review the evidence, and then use
+  `memory promote <candidate-id> --event <event-id> --vault <vault>` to select an event or
+  `memory reject <candidate-id> --vault <vault>` to keep the current operational value.
 - `legacy`/`degraded`/`stale`/`manifest-unproven` observability: run
   `npx --no-install wendkeep cost rebuild --session <id> --json --vault <vault>`, review diagnostics,
   and only then authorize the second variant with `--apply`.

--- a/docs/en/commands/maintenance-and-diagnostics.md
+++ b/docs/en/commands/maintenance-and-diagnostics.md
@@ -24,6 +24,7 @@ Run from the project root or provide `--project` and `--vault` explicitly.
 
 ```bash
 npx --no-install wendkeep doctor [--vault <vault>]
+npx --no-install wendkeep memory curate --vault <vault>
 npx --no-install wendkeep sync-defs [--check|--reseed] --vault <vault> --project <root>
 npx --no-install wendkeep theme sync --vault <vault>
 npx --no-install wendkeep --version
@@ -33,6 +34,12 @@ npx --no-install wendkeep --help
 ## Options and exit codes
 
 - `doctor` is read-only; exit `0` accepts recoverable warnings, while non-zero means failure.
+- `doctor` uses human-readable output with `[integrity]` and `[memory]` sections, friendly
+  categories, and a copyable next action. The `vault-health.mjs` hook remains the JSON surface for
+  automation; neither surface applies curation.
+- Even with a missing Vault, unsafe physical boundary, or unsafe registry, `doctor` marks memory as
+  blocked and shows `memory status --gate` with the resolved path; the hook preserves structured
+  JSON instead of replacing the result with stderr or a stack trace.
 - In v2, `doctor`/`memory status --gate` correlate `last_memory_attempt` (mode, disposition, event
   IDs, and checkpoint) with outbox, ledger, and SHARED; they do not infer health from revision alone.
 - `revision: 0` after a valid migration, with no v2 attempt, is healthy. A `degraded` attempt whose
@@ -57,6 +64,7 @@ npx --no-install wendkeep --version
 npx --no-install wendkeep sync-defs --check --vault .MyApp-vault --project .
 npx --no-install wendkeep doctor --vault .MyApp-vault
 npx --no-install wendkeep memory status --gate --vault .MyApp-vault
+npx --no-install wendkeep memory curate --vault .MyApp-vault
 npx --no-install wendkeep memory candidates --active --vault .MyApp-vault
 npx --no-install wendkeep cost rebuild --session <id> --json --vault .MyApp-vault
 npx --no-install wendkeep cost rebuild --session <id> --json --vault .MyApp-vault --apply
@@ -83,7 +91,9 @@ dry-run path before any write.
   outbox, and SHARED so `last_memory_attempt` can be correlated before repair.
 - Corrupt bundle: preserve evidence and run `memory status --gate` before `memory repair`.
 - An active semantic conflict requires a human decision: `memory repair` does not choose a winner.
-  List safe IDs with `memory candidates --active --vault <vault>`, review the evidence, and then use
+  Start with the guided menu `memory curate --vault <vault>`. For advanced inspection or a
+  non-interactive terminal, list safe IDs with `memory candidates --active --vault <vault>`, review
+  the evidence, and then use
   `memory promote <candidate-id> --event <event-id> --vault <vault>` to select an event or
   `memory reject <candidate-id> --vault <vault>` to keep the current operational value.
 - `legacy`/`degraded`/`stale`/`manifest-unproven` observability: run

--- a/docs/en/commands/memory.md
+++ b/docs/en/commands/memory.md
@@ -24,12 +24,13 @@ Pass the vault explicitly in automation. Preserve backups and evidence before re
 
 ```bash
 npx wendkeep memory status [--gate] --vault <vault>
+npx wendkeep memory curate --vault <vault>
 npx wendkeep memory candidates [--active] --vault <vault>
 npx wendkeep memory repair --vault <vault>
 npx wendkeep memory recover-attempt <session> [--apply] --vault <vault>
 npx wendkeep memory reconcile <ambiguous-session> --by-session <successor-session> --reason <reason> [--apply] --vault <vault>
-npx wendkeep memory promote <candidate> [--event <event-id>] --vault <vault>
-npx wendkeep memory reject <candidate> --vault <vault>
+npx wendkeep memory promote <candidate-id> [--event <event-id>] --vault <vault>
+npx wendkeep memory reject <candidate-id> --vault <vault>
 npx wendkeep validate-memory [CORE-path]
 npx wendkeep validate-memory --vault <v2-vault>
 ```
@@ -37,6 +38,14 @@ npx wendkeep validate-memory --vault <v2-vault>
 ## Options and exit codes
 
 - `memory status` is read-only; `--gate` exits `1` only for blocking state.
+- `memory curate` is the recommended human path: in an interactive terminal it groups each
+  conflict under a friendly name, shows sanitized previews only, and offers numbered choices,
+  `P` to skip, `R` to reject, `D` for technical details, and `Q` to quit. Every promotion or
+  rejection asks for confirmation with default `no`: Enter or `N` does not write. Skip or quit
+  leaves the remaining work pending; running the command again resumes the active conflicts.
+- The assistant accepts only `--vault`: there is no `--yes`, `--apply`, or batch mode. In a
+  non-TTY environment it exits `2` without changing bytes and recommends the advanced fallback
+  `memory candidates --active`.
 - `memory candidates` is read-only and prints deterministic JSON containing only `candidate_id`,
   `reason`, `status`, `memory_key`, and `event_ids`; it does not expose memory values or content and
   does not create a lock or mutate the bundle. `--active` omits terminal candidates (`resolved`,
@@ -89,8 +98,9 @@ npx wendkeep validate-memory --vault <v2-vault>
   the lease they acquired.
 - `promote`/`reject` append an auditable, idempotent decision to the ledger. Replay and repair
   preserve that decision and do not recreate the resolved candidate. For a `conflict` candidate,
-  `promote` requires an `--event <event-id>` that belongs to the candidate; date or random ID
-  never picks an implicit winner. `reject` preserves the current operational value. A
+  use `memory promote <candidate-id> --event <event-id>` with an event that belongs to the
+  candidate; date or random ID never picks an implicit winner. `reject` preserves the current
+  operational value. A
   `blocked_by_core` candidate can only be rejected: promotion first requires canonical CORE
   curation. If the selected event still belongs to the matching latest `projected` attempt,
   promotion also refreshes its checkpoint and mirror causally; JSON reports
@@ -113,6 +123,7 @@ npx wendkeep validate-memory --vault <v2-vault>
 
 ```bash
 npx wendkeep memory status --gate --vault .MyApp-vault
+npx wendkeep memory curate --vault .MyApp-vault
 npx wendkeep memory candidates --active --vault .MyApp-vault
 npx wendkeep memory recover-attempt session-123 --vault .MyApp-vault
 npx wendkeep memory recover-attempt session-123 --apply --vault .MyApp-vault

--- a/docs/en/commands/memory.md
+++ b/docs/en/commands/memory.md
@@ -24,6 +24,7 @@ Pass the vault explicitly in automation. Preserve backups and evidence before re
 
 ```bash
 npx wendkeep memory status [--gate] --vault <vault>
+npx wendkeep memory candidates [--active] --vault <vault>
 npx wendkeep memory repair --vault <vault>
 npx wendkeep memory recover-attempt <session> [--apply] --vault <vault>
 npx wendkeep memory reconcile <ambiguous-session> --by-session <successor-session> --reason <reason> [--apply] --vault <vault>
@@ -36,6 +37,13 @@ npx wendkeep validate-memory --vault <v2-vault>
 ## Options and exit codes
 
 - `memory status` is read-only; `--gate` exits `1` only for blocking state.
+- `memory candidates` is read-only and prints deterministic JSON containing only `candidate_id`,
+  `reason`, `status`, `memory_key`, and `event_ids`; it does not expose memory values or content and
+  does not create a lock or mutate the bundle. `--active` omits terminal candidates (`resolved`,
+  `rejected`, and `superseded`). A missing status is normalized to `active`.
+- For `memory candidates`, exit `0` means a valid inventory (including empty or conflicted), exit
+  `1` means an invalid sidecar/unsafe topology, and exit `2` means a missing `--vault`, unknown or
+  duplicate option, extra argument, or an invalid value passed to `--active`.
 - `Stop` writes events to the outbox before acknowledging `last_memory_attempt: enqueued`, then the
   projector runs outside the registry lock. Retrying the same attempt reuses its frozen event IDs
   and can project them at most once.
@@ -105,6 +113,7 @@ npx wendkeep validate-memory --vault <v2-vault>
 
 ```bash
 npx wendkeep memory status --gate --vault .MyApp-vault
+npx wendkeep memory candidates --active --vault .MyApp-vault
 npx wendkeep memory recover-attempt session-123 --vault .MyApp-vault
 npx wendkeep memory recover-attempt session-123 --apply --vault .MyApp-vault
 npx wendkeep memory reconcile old --by-session current --reason "delivery continued" --vault .MyApp-vault
@@ -120,6 +129,9 @@ Status prints schema, revision, cursor, hash, events, outbox, candidates, confli
 state of the last attempt. CORE stays hand-curated and canonical; SHARED stays a verifiable
 operational projection. After successful projection, an attempt checkpoint may be a valid prefix
 of a global projection that has already advanced with concurrent events.
+
+`memory candidates` returns `status: "ok"` and the sanitized candidate list in stable order; with
+`--active`, the list contains only decisions still open for human curation.
 
 ## Common errors and diagnosis
 

--- a/docs/pt-BR/commands/maintenance-and-diagnostics.md
+++ b/docs/pt-BR/commands/maintenance-and-diagnostics.md
@@ -57,6 +57,7 @@ npx --no-install wendkeep --version
 npx --no-install wendkeep sync-defs --check --vault .MeuApp-vault --project .
 npx --no-install wendkeep doctor --vault .MeuApp-vault
 npx --no-install wendkeep memory status --gate --vault .MeuApp-vault
+npx --no-install wendkeep memory candidates --active --vault .MeuApp-vault
 npx --no-install wendkeep cost rebuild --session <id> --json --vault .MeuApp-vault
 npx --no-install wendkeep cost rebuild --session <id> --json --vault .MeuApp-vault --apply
 ```
@@ -74,11 +75,17 @@ ou sem manifest comprovado e oferece um caminho dry-run antes de qualquer escrit
 
 - `no vault`: execute da raiz vinculada ou passe `--vault`.
 - `defs stale`: confirme a versão e rode `sync-defs --reseed`.
-- Vault legado: é warning não bloqueante; planeje `memory migrate --apply` separadamente.
+- Vault legado: é warning não bloqueante; o doctor mostra
+  `npx --no-install wendkeep memory migrate --apply --vault <cofre>` com o Vault resolvido, mas a
+  migração continua sendo opt-in e deve ser planejada separadamente.
 - `degraded` + outbox íntegra: warning; preserve a outbox e permita replay idempotente.
 - `ambiguous`, publicação perdida ou checkpoint divergente: bloqueante; preserve registry, ledger,
   outbox e SHARED para correlacionar `last_memory_attempt` antes de reparar.
 - Bundle corrompido: preserve a evidência e use `memory status --gate` antes de `memory repair`.
+- Conflito semântico ativo exige decisão humana: `memory repair` não escolhe vencedor. Liste os IDs
+  seguros com `memory candidates --active --vault <cofre>`, revise a evidência e então use
+  `memory promote <candidate-id> --event <event-id> --vault <cofre>` para selecionar um evento ou
+  `memory reject <candidate-id> --vault <cofre>` para manter o valor operacional atual.
 - Observabilidade `legacy`/`degraded`/`stale`/`manifest-unproven`: rode
   `npx --no-install wendkeep cost rebuild --session <id> --json --vault <cofre>`, revise diagnostics
   e só então autorize a segunda variante com `--apply`.

--- a/docs/pt-BR/commands/maintenance-and-diagnostics.md
+++ b/docs/pt-BR/commands/maintenance-and-diagnostics.md
@@ -24,6 +24,7 @@ Execute na raiz do projeto ou informe `--project`/`--vault` explicitamente.
 
 ```bash
 npx --no-install wendkeep doctor [--vault <cofre>]
+npx --no-install wendkeep memory curate --vault <cofre>
 npx --no-install wendkeep sync-defs [--check|--reseed] --vault <cofre> --project <raiz>
 npx --no-install wendkeep theme sync --vault <cofre>
 npx --no-install wendkeep --version
@@ -33,6 +34,12 @@ npx --no-install wendkeep --help
 ## Opções e códigos de saída
 
 - `doctor` é read-only; exit `0` aceita warnings recuperáveis e exit não zero indica falha.
+- O `doctor` usa saída em formato humano, com blocos `[integridade]` e `[memória]`, categorias
+  amigáveis e uma próxima ação copiável. O hook `vault-health.mjs` continua sendo a superfície JSON
+  para automações; nenhum dos dois aplica curadoria.
+- Mesmo com Vault ausente, boundary física insegura ou registry inseguro, o `doctor` marca a memória
+  como bloqueada e mostra `memory status --gate` com o caminho resolvido; o hook preserva JSON
+  estruturado em vez de substituir o resultado por stderr ou stack trace.
 - Em v2, `doctor`/`memory status --gate` correlacionam `last_memory_attempt` (mode, disposition,
   event IDs e checkpoint) com outbox, ledger e SHARED; não inferem saúde só pela revision atual.
 - `revision: 0` após migração válida, sem attempt v2, é saudável. Attempt `degraded` cujos eventos
@@ -57,6 +64,7 @@ npx --no-install wendkeep --version
 npx --no-install wendkeep sync-defs --check --vault .MeuApp-vault --project .
 npx --no-install wendkeep doctor --vault .MeuApp-vault
 npx --no-install wendkeep memory status --gate --vault .MeuApp-vault
+npx --no-install wendkeep memory curate --vault .MeuApp-vault
 npx --no-install wendkeep memory candidates --active --vault .MeuApp-vault
 npx --no-install wendkeep cost rebuild --session <id> --json --vault .MeuApp-vault
 npx --no-install wendkeep cost rebuild --session <id> --json --vault .MeuApp-vault --apply
@@ -82,8 +90,9 @@ ou sem manifest comprovado e oferece um caminho dry-run antes de qualquer escrit
 - `ambiguous`, publicação perdida ou checkpoint divergente: bloqueante; preserve registry, ledger,
   outbox e SHARED para correlacionar `last_memory_attempt` antes de reparar.
 - Bundle corrompido: preserve a evidência e use `memory status --gate` antes de `memory repair`.
-- Conflito semântico ativo exige decisão humana: `memory repair` não escolhe vencedor. Liste os IDs
-  seguros com `memory candidates --active --vault <cofre>`, revise a evidência e então use
+- Conflito semântico ativo exige decisão humana: `memory repair` não escolhe vencedor. Comece pelo
+  menu guiado `memory curate --vault <cofre>`. Para inspeção avançada ou terminal não interativo,
+  liste os IDs seguros com `memory candidates --active --vault <cofre>`, revise a evidência e use
   `memory promote <candidate-id> --event <event-id> --vault <cofre>` para selecionar um evento ou
   `memory reject <candidate-id> --vault <cofre>` para manter o valor operacional atual.
 - Observabilidade `legacy`/`degraded`/`stale`/`manifest-unproven`: rode

--- a/docs/pt-BR/commands/memory.md
+++ b/docs/pt-BR/commands/memory.md
@@ -24,6 +24,7 @@ Informe o vault explicitamente em automações. Preserve backups e evidências a
 
 ```bash
 npx wendkeep memory status [--gate] --vault <cofre>
+npx wendkeep memory candidates [--active] --vault <cofre>
 npx wendkeep memory repair --vault <cofre>
 npx wendkeep memory recover-attempt <sessão> [--apply] --vault <cofre>
 npx wendkeep memory reconcile <sessão-ambígua> --by-session <sessão-sucessora> --reason <motivo> [--apply] --vault <cofre>
@@ -36,6 +37,13 @@ npx wendkeep validate-memory --vault <cofre-v2>
 ## Opções e códigos de saída
 
 - `memory status` é read-only; `--gate` retorna exit `1` apenas para estado bloqueante.
+- `memory candidates` é read-only e imprime JSON determinístico com somente `candidate_id`,
+  `reason`, `status`, `memory_key` e `event_ids`; não expõe valores nem conteúdo da memória e não
+  cria lock nem altera o bundle. `--active` omite candidates terminais (`resolved`, `rejected` e
+  `superseded`). Status ausente é normalizado para `active`.
+- Em `memory candidates`, exit `0` indica inventário válido (inclusive vazio ou com conflitos),
+  exit `1` indica sidecar inválido/topologia insegura e exit `2` indica `--vault` ausente, opção
+  desconhecida/duplicada, argumento extra ou valor indevido em `--active`.
 - O `Stop` grava os eventos na outbox antes de reconhecer `last_memory_attempt: enqueued`; depois o
   projector roda fora do lock do registry. Retry do mesmo attempt reutiliza os event IDs congelados
   e pode projetá-los no máximo uma vez.
@@ -103,6 +111,7 @@ npx wendkeep validate-memory --vault <cofre-v2>
 
 ```bash
 npx wendkeep memory status --gate --vault .MeuApp-vault
+npx wendkeep memory candidates --active --vault .MeuApp-vault
 npx wendkeep memory recover-attempt sessao-123 --vault .MeuApp-vault
 npx wendkeep memory recover-attempt sessao-123 --apply --vault .MeuApp-vault
 npx wendkeep memory reconcile antiga --by-session atual --reason "entrega continuada" --vault .MeuApp-vault
@@ -118,6 +127,9 @@ O status imprime schema, revision, cursor, hash, eventos, outbox, candidates, co
 causal do último attempt. CORE permanece canônico e curado à mão; SHARED permanece projeção
 operacional verificável. Depois de uma projeção bem-sucedida, o checkpoint do attempt pode ser um
 prefixo válido de uma projeção global que já avançou com eventos concorrentes.
+
+`memory candidates` retorna `status: "ok"` e a lista sanitizada de candidates em ordem estável;
+com `--active`, a lista contém somente decisões ainda abertas para curadoria humana.
 
 ## Erros comuns e diagnóstico
 

--- a/docs/pt-BR/commands/memory.md
+++ b/docs/pt-BR/commands/memory.md
@@ -24,12 +24,13 @@ Informe o vault explicitamente em automações. Preserve backups e evidências a
 
 ```bash
 npx wendkeep memory status [--gate] --vault <cofre>
+npx wendkeep memory curate --vault <cofre>
 npx wendkeep memory candidates [--active] --vault <cofre>
 npx wendkeep memory repair --vault <cofre>
 npx wendkeep memory recover-attempt <sessão> [--apply] --vault <cofre>
 npx wendkeep memory reconcile <sessão-ambígua> --by-session <sessão-sucessora> --reason <motivo> [--apply] --vault <cofre>
-npx wendkeep memory promote <candidate> [--event <event-id>] --vault <cofre>
-npx wendkeep memory reject <candidate> --vault <cofre>
+npx wendkeep memory promote <candidate-id> [--event <event-id>] --vault <cofre>
+npx wendkeep memory reject <candidate-id> --vault <cofre>
 npx wendkeep validate-memory [caminho-do-CORE]
 npx wendkeep validate-memory --vault <cofre-v2>
 ```
@@ -37,6 +38,14 @@ npx wendkeep validate-memory --vault <cofre-v2>
 ## Opções e códigos de saída
 
 - `memory status` é read-only; `--gate` retorna exit `1` apenas para estado bloqueante.
+- `memory curate` é o caminho recomendado para pessoas: em um terminal interativo, agrupa cada
+  conflito por nome amigável, mostra somente previews sanitizados e oferece escolhas numeradas,
+  `P` para pular, `R` para rejeitar, `D` para detalhes técnicos e `Q` para sair. Cada promoção ou
+  rejeição pede confirmação com padrão negativo: Enter ou `N` não grava. Pular ou sair deixa o
+  restante pendente; uma nova execução retoma os conflitos ainda ativos.
+- O assistente aceita somente `--vault`: não há `--yes`, `--apply` ou modo em lote. Em ambiente
+  não-TTY/terminal não interativo, ele retorna exit `2` sem alterar bytes e orienta usar o fallback
+  avançado `memory candidates --active`.
 - `memory candidates` é read-only e imprime JSON determinístico com somente `candidate_id`,
   `reason`, `status`, `memory_key` e `event_ids`; não expõe valores nem conteúdo da memória e não
   cria lock nem altera o bundle. `--active` omite candidates terminais (`resolved`, `rejected` e
@@ -87,8 +96,9 @@ npx wendkeep validate-memory --vault <cofre-v2>
   symlink, reparse point ou hardlink falham fechados sem tocar bytes externos. Locks publicam owner
   e lease atomicamente, não colhem PID vivo apenas por idade e só liberam a lease adquirida.
 - `promote`/`reject` acrescentam uma decisão auditável e idempotente ao ledger. Replay e repair
-  preservam a decisão e não recriam o candidate resolvido. Para candidate `conflict`, `promote`
-  exige `--event <event-id>` pertencente ao candidate; não há vencedor implícito por data ou ID.
+  preservam a decisão e não recriam o candidate resolvido. Para candidate `conflict`, use
+  `memory promote <candidate-id> --event <event-id>` com um evento pertencente ao candidate; não há
+  vencedor implícito por data ou ID.
   `reject` preserva o valor operacional atual. Candidate `blocked_by_core` só pode ser rejeitado:
   promover exige antes alterar CORE pela curadoria canônica. Se o evento escolhido ainda pertence
   ao último attempt `projected` correspondente, a promoção também atualiza causalmente checkpoint
@@ -111,6 +121,7 @@ npx wendkeep validate-memory --vault <cofre-v2>
 
 ```bash
 npx wendkeep memory status --gate --vault .MeuApp-vault
+npx wendkeep memory curate --vault .MeuApp-vault
 npx wendkeep memory candidates --active --vault .MeuApp-vault
 npx wendkeep memory recover-attempt sessao-123 --vault .MeuApp-vault
 npx wendkeep memory recover-attempt sessao-123 --apply --vault .MeuApp-vault

--- a/hooks/vault-health.mjs
+++ b/hooks/vault-health.mjs
@@ -112,12 +112,28 @@ const memoryMigrateCommand = (vaultBase) => (
 const memoryCandidatesCommand = (vaultBase) => (
   `${WENDKEEP_COMMAND} memory candidates --active --vault ${quoteCommandArgument(vaultBase)}`
 );
-const memoryPromoteCommand = (vaultBase) => (
-  `${WENDKEEP_COMMAND} memory promote <candidate-id> --event <event-id> --vault ${quoteCommandArgument(vaultBase)}`
+const memoryCurateCommand = (vaultBase) => (
+  `${WENDKEEP_COMMAND} memory curate --vault ${quoteCommandArgument(vaultBase)}`
 );
-const memoryRejectCommand = (vaultBase) => (
-  `${WENDKEEP_COMMAND} memory reject <candidate-id> --vault ${quoteCommandArgument(vaultBase)}`
-);
+
+const MEMORY_KEY_PURPOSES = new Map([
+  ['handoff.latest', 'próximo handoff'],
+  ['quality.latest-sensors', 'sensores de qualidade'],
+  ['quality.latest-verdict', 'veredito de qualidade'],
+  ['git.local-head', 'commit local conhecido'],
+]);
+
+function groupConflictPurposes(conflicts) {
+  const counts = new Map();
+  for (const conflict of conflicts) {
+    const key = String(conflict?.memory_key || '').trim();
+    const label = MEMORY_KEY_PURPOSES.get(key) || (key ? `outras memórias (${key})` : 'outras memórias');
+    counts.set(label, (counts.get(label) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([label, count]) => `${label}: ${count}`);
+}
 
 function readJsonLines(vaultBase, path, label) {
   let checked;
@@ -218,11 +234,11 @@ function memoryMetrics() {
   };
 }
 
-function blockedMemoryBoundary(error) {
+function blockedMemoryBoundary(error, vaultBase) {
   return {
     ok: false,
     status: 'blocked',
-    failures: [`Boundary física da memória insegura: ${error?.message || error}`],
+    failures: [`Boundary física da memória insegura: ${error?.message || error}. Inspecione com: ${memoryStatusCommand(vaultBase)}.`],
     warnings: [],
     metrics: memoryMetrics(),
   };
@@ -393,17 +409,17 @@ export function checkMemoryBundle(vaultBase, { registry } = {}) {
     return {
       ok: false,
       status: 'blocked',
-      failures: [`Vault not found: ${vaultBase}`],
+      failures: [`Vault not found: ${vaultBase}. Inspecione com: ${memoryStatusCommand(vaultBase)}.`],
       warnings: [],
       metrics: memoryMetrics(),
     };
   }
   try { preflightMemoryBundle(vaultBase); }
-  catch (error) { return blockedMemoryBoundary(error); }
+  catch (error) { return blockedMemoryBoundary(error, vaultBase); }
   const brain = join(vaultBase, '.brain');
   let mode;
   try { mode = detectMemoryMode(vaultBase); }
-  catch (error) { return blockedMemoryBoundary(error); }
+  catch (error) { return blockedMemoryBoundary(error, vaultBase); }
   if (mode.mode === 'legacy') {
     return {
       ok: true,
@@ -463,7 +479,7 @@ export function checkMemoryBundle(vaultBase, { registry } = {}) {
   let effectiveRegistry = registry;
   if (!effectiveRegistry) {
     try { effectiveRegistry = readSessionRegistry(vaultBase); }
-    catch (error) { failures.push(`SESSION_REGISTRY.json inseguro ou ilegível: ${error?.message || error}.`); }
+    catch (error) { failures.push(`SESSION_REGISTRY.json inseguro ou ilegível: ${error?.message || error}. Inspecione com: ${memoryStatusCommand(vaultBase)}.`); }
   }
   const lifecycle = checkMemoryAttempts(effectiveRegistry || { version: 2, sessions: {} }, {
     vaultBase,
@@ -478,12 +494,11 @@ export function checkMemoryBundle(vaultBase, { registry } = {}) {
   const activeConflicts = unresolved.filter((item) => item?.reason === 'conflict');
   const ordinaryCandidates = unresolved.filter((item) => item?.reason !== 'conflict');
   if (activeConflicts.length) {
-    const keys = [...new Set(activeConflicts.map((item) => item.memory_key || item.candidate_id))]
-      .sort((left, right) => String(left).localeCompare(String(right)));
     const label = activeConflicts.length === 1
       ? '1 conflito ativo'
       : `${activeConflicts.length} conflitos ativos`;
-    failures.push(`${label} em chave operacional (${keys.join(', ')}). Conflito semântico exige curadoria humana; memory repair não escolhe vencedor. Liste IDs seguros com: ${memoryCandidatesCommand(vaultBase)}. Depois da revisão, use ${memoryPromoteCommand(vaultBase)} ou ${memoryRejectCommand(vaultBase)}.`);
+    const purposes = groupConflictPurposes(activeConflicts).join('; ');
+    failures.push(`${label} (${purposes}). Existem versões concorrentes e nenhum dado foi escolhido automaticamente. Conflito semântico exige curadoria humana; memory repair não escolhe vencedor. Próximo passo: ${memoryCurateCommand(vaultBase)}. Inventário avançado: ${memoryCandidatesCommand(vaultBase)}.`);
   }
   if (outbox.count) warnings.push(`${outbox.count} evento(s) pendente(s) na outbox; execute o projector quando seguro.`);
   if (ordinaryCandidates.length) warnings.push(`${ordinaryCandidates.length} candidate(s) aguardando curadoria humana.`);
@@ -562,8 +577,49 @@ function checkSession({ vaultBase, sessionRel, control, registry }) {
 }
 
 export function runVaultHealth({ vaultBase, session = '' }) {
-  const control = readControl(vaultBase);
-  const registry = readSessionRegistry(vaultBase);
+  const memoryMarkers = [
+    join(vaultBase, '.brain', 'SHARED_MEMORY.md'),
+    join(vaultBase, '.brain', 'MEMORY_EVENTS.jsonl'),
+    join(vaultBase, '.brain', 'MEMORY_CANDIDATES.jsonl'),
+    join(vaultBase, '.brain', 'memory-outbox'),
+  ];
+  const memory = !existsSync(vaultBase) || memoryMarkers.some((path) => existsSync(path))
+    ? checkMemoryBundle(vaultBase)
+    : {
+      ok: true,
+      status: 'legacy',
+      failures: [],
+      warnings: [`Bundle de memória v2 ausente (vault legado); inspecione com: ${memoryStatusCommand(vaultBase)}.`],
+      metrics: {},
+    };
+
+  let control = {};
+  let registry = { version: 2, sessions: {} };
+  const contextErrors = [];
+  try { control = readControl(vaultBase); }
+  catch (error) { contextErrors.push(error?.message || String(error)); }
+  try { registry = readSessionRegistry(vaultBase); }
+  catch (error) { contextErrors.push(error?.message || String(error)); }
+
+  if (contextErrors.length) {
+    const failures = [
+      `Validação de sessão e artefatos indisponível com segurança: ${contextErrors.join('; ')}. Inspecione com: ${memoryStatusCommand(vaultBase)}.`,
+      ...memory.failures.map((item) => `Memória: ${item}`),
+    ];
+    return {
+      ok: false,
+      session,
+      failures,
+      warnings: memory.warnings.map((item) => `Memória: ${item}`),
+      metrics: {
+        registrySessions: 0,
+        derivedNotes: 0,
+        memory: memory.metrics,
+      },
+      memoryStatus: memory.status,
+    };
+  }
+
   const sessionRel = session || control.session_file || control.last_session_file || '';
   const failures = [];
   const warnings = [];
@@ -596,20 +652,8 @@ export function runVaultHealth({ vaultBase, session = '' }) {
     return total + (existsSync(dir) ? listMarkdownFiles(dir).length : 0);
   }, 0);
 
-  const memoryMarkers = [
-    join(vaultBase, '.brain', 'SHARED_MEMORY.md'),
-    join(vaultBase, '.brain', 'MEMORY_EVENTS.jsonl'),
-    join(vaultBase, '.brain', 'MEMORY_CANDIDATES.jsonl'),
-    join(vaultBase, '.brain', 'memory-outbox'),
-  ];
-  let memory = { status: 'legacy', metrics: {} };
-  if (memoryMarkers.some((path) => existsSync(path))) {
-    memory = checkMemoryBundle(vaultBase, { registry });
-    failures.push(...memory.failures.map((item) => `Memória: ${item}`));
-    warnings.push(...memory.warnings.map((item) => `Memória: ${item}`));
-  } else {
-    warnings.push(`Bundle de memória v2 ausente (vault legado); inspecione com: ${memoryStatusCommand(vaultBase)}.`);
-  }
+  failures.push(...memory.failures.map((item) => `Memória: ${item}`));
+  warnings.push(...memory.warnings.map((item) => `Memória: ${item}`));
 
   return {
     ok: failures.length === 0,

--- a/hooks/vault-health.mjs
+++ b/hooks/vault-health.mjs
@@ -106,6 +106,18 @@ const memoryStatusCommand = (vaultBase) => (
 const memoryRepairCommand = (vaultBase) => (
   `${WENDKEEP_COMMAND} memory repair --vault ${quoteCommandArgument(vaultBase)}`
 );
+const memoryMigrateCommand = (vaultBase) => (
+  `${WENDKEEP_COMMAND} memory migrate --apply --vault ${quoteCommandArgument(vaultBase)}`
+);
+const memoryCandidatesCommand = (vaultBase) => (
+  `${WENDKEEP_COMMAND} memory candidates --active --vault ${quoteCommandArgument(vaultBase)}`
+);
+const memoryPromoteCommand = (vaultBase) => (
+  `${WENDKEEP_COMMAND} memory promote <candidate-id> --event <event-id> --vault ${quoteCommandArgument(vaultBase)}`
+);
+const memoryRejectCommand = (vaultBase) => (
+  `${WENDKEEP_COMMAND} memory reject <candidate-id> --vault ${quoteCommandArgument(vaultBase)}`
+);
 
 function readJsonLines(vaultBase, path, label) {
   let checked;
@@ -397,7 +409,7 @@ export function checkMemoryBundle(vaultBase, { registry } = {}) {
       ok: true,
       status: 'legacy',
       failures: [],
-      warnings: [LEGACY_MEMORY_WARNING],
+      warnings: [`${LEGACY_MEMORY_WARNING} Comando com Vault resolvido: ${memoryMigrateCommand(vaultBase)}.`],
       metrics: memoryMetrics(),
     };
   }
@@ -466,7 +478,12 @@ export function checkMemoryBundle(vaultBase, { registry } = {}) {
   const activeConflicts = unresolved.filter((item) => item?.reason === 'conflict');
   const ordinaryCandidates = unresolved.filter((item) => item?.reason !== 'conflict');
   if (activeConflicts.length) {
-    failures.push(`${activeConflicts.length} conflito ativo em chave operacional (${activeConflicts.map((item) => item.memory_key || item.candidate_id).join(', ')}). Inspecione com: ${memoryStatusCommand(vaultBase)}.`);
+    const keys = [...new Set(activeConflicts.map((item) => item.memory_key || item.candidate_id))]
+      .sort((left, right) => String(left).localeCompare(String(right)));
+    const label = activeConflicts.length === 1
+      ? '1 conflito ativo'
+      : `${activeConflicts.length} conflitos ativos`;
+    failures.push(`${label} em chave operacional (${keys.join(', ')}). Conflito semântico exige curadoria humana; memory repair não escolhe vencedor. Liste IDs seguros com: ${memoryCandidatesCommand(vaultBase)}. Depois da revisão, use ${memoryPromoteCommand(vaultBase)} ou ${memoryRejectCommand(vaultBase)}.`);
   }
   if (outbox.count) warnings.push(`${outbox.count} evento(s) pendente(s) na outbox; execute o projector quando seguro.`);
   if (ordinaryCandidates.length) warnings.push(`${ordinaryCandidates.length} candidate(s) aguardando curadoria humana.`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.67.3",
+  "version": "0.68.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.67.3",
+      "version": "0.68.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.67.2",
+  "version": "0.67.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.67.2",
+      "version": "0.67.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "acorn": "^8.18.0",
-        "wendkeep": "^0.67.1"
+        "wendkeep": "^0.68.0"
       },
       "engines": {
         "node": ">=18"
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/wendkeep": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/wendkeep/-/wendkeep-0.67.1.tgz",
-      "integrity": "sha512-0OxWC2FvR1d5W+ll7Q1gEaVAPKjIFRYQvMdiZwyIUx44tgLLD2yDQ2Ztnrc8uPac7MhyI29ZfVBjiY9psS3mQA==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/wendkeep/-/wendkeep-0.68.0.tgz",
+      "integrity": "sha512-83sYM5nEW6TPKW+OC4Wm8vfMdxRtiLeheuY6ifGm4O+SqAFjkCm8TQTTlP7Am0iBSq+lCAfA+9njooVAJscntg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
   },
   "devDependencies": {
     "acorn": "^8.18.0",
-    "wendkeep": "^0.67.1"
+    "wendkeep": "^0.68.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.67.3",
+  "version": "0.68.0",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.67.2",
+  "version": "0.67.3",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -99,7 +99,9 @@ Usage:
                            in session notes from the linked derived notes — the body used to lag
                            behind the closing block. Dry-run by default · --apply · --json.
   wendkeep lesson add "t" "l"   Record a project-local lesson (injected at SessionStart).
-  wendkeep memory <sub>          Shared memory v2: status | candidates [--active] | migrate [--apply] | repair |
+  wendkeep memory curate         Guide one semantic conflict at a time in an interactive terminal.
+                           Every promote/reject requires confirmation; --vault P.
+  wendkeep memory <sub>          Shared memory v2: status | candidates [--active] | curate | migrate [--apply] | repair |
                            recover-attempt <session> [--apply] |
                            reconcile <session> --by-session <session> --reason <text> [--apply] |
                            promote <candidate> [--event <event-id>] | reject <candidate>. --vault P.
@@ -230,8 +232,13 @@ async function main(argv) {
       break;
     }
     case 'memory': {
-      const { runMemory } = await import('../../../src/memory.mjs');
-      runMemory(rest);
+      if (rest[0] === 'curate') {
+        const { runMemoryCurateCli } = await import('../../../src/memory-curate.mjs');
+        process.exitCode = await runMemoryCurateCli(rest.slice(1));
+      } else {
+        const { runMemory } = await import('../../../src/memory.mjs');
+        runMemory(rest);
+      }
       break;
     }
     case 'sync-defs': {

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -99,7 +99,7 @@ Usage:
                            in session notes from the linked derived notes — the body used to lag
                            behind the closing block. Dry-run by default · --apply · --json.
   wendkeep lesson add "t" "l"   Record a project-local lesson (injected at SessionStart).
-  wendkeep memory <sub>          Shared memory v2: status | migrate [--apply] | repair |
+  wendkeep memory <sub>          Shared memory v2: status | candidates [--active] | migrate [--apply] | repair |
                            recover-attempt <session> [--apply] |
                            reconcile <session> --by-session <session> --reason <text> [--apply] |
                            promote <candidate> [--event <event-id>] | reject <candidate>. --vault P.

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -1,27 +1,64 @@
 // `wendkeep doctor` — vault/session integrity (hooks/vault-health.mjs) PLUS the a2
 // harness integrity check (hooks/harness-doctor.mjs). Exits 1 on any error.
-import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 import { checkHarness, checkVaultLinks, checkSessionActivity, checkStackedFrontmatter, renderStackedFrontmatterLines, checkUnpricedModels, renderUnpricedModelLines, checkStaleDerivedSections, renderStaleDerivedSectionLines, checkSessionObservability, renderSessionObservabilityLines } from '../hooks/harness-doctor.mjs';
+import { runVaultHealth } from '../hooks/vault-health.mjs';
 import { checkSyncDefs } from './sync-defs.mjs';
 import { resolveProjectVault } from './project-vault.mjs';
 
-export function runDoctor(argv) {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const hookFile = join(here, '..', 'hooks', 'vault-health.mjs');
+const healthStatusLabel = (status) => ({
+  healthy: 'saudável', warning: 'atenção', blocked: 'bloqueada', legacy: 'legado',
+}[status] || status || 'desconhecido');
 
+const metricValue = (value) => value === null || value === undefined || value === '' ? 'n/a' : value;
+
+export function renderVaultHealthLines(result) {
+  const memoryFailures = [];
+  const memoryWarnings = [];
+  const integrityFailures = [];
+  const integrityWarnings = [];
+  for (const failure of result.failures || []) {
+    const match = String(failure).match(/^Memória:\s*(.*)$/s);
+    (match ? memoryFailures : integrityFailures).push(match ? match[1] : failure);
+  }
+  for (const warning of result.warnings || []) {
+    const match = String(warning).match(/^Memória:\s*(.*)$/s);
+    (match ? memoryWarnings : integrityWarnings).push(match ? match[1] : warning);
+  }
+
+  const lines = [
+    `[integridade] ${integrityFailures.length ? 'bloqueada' : integrityWarnings.length ? 'atenção' : 'saudável'} — ${integrityFailures.length} falha(s), ${integrityWarnings.length} aviso(s)`,
+  ];
+  for (const failure of integrityFailures) lines.push(`  ✗ ${failure}`);
+  for (const warning of integrityWarnings) lines.push(`  ! ${warning}`);
+  if (!integrityFailures.length && !integrityWarnings.length) lines.push('  ✓ sessão e artefatos íntegros');
+  lines.push(`  sessão: ${result.session || 'nenhuma'} · registros: ${metricValue(result.metrics?.registrySessions)} · notas derivadas: ${metricValue(result.metrics?.derivedNotes)}`);
+
+  const memory = result.metrics?.memory || {};
+  lines.push(
+    `[memória] ${healthStatusLabel(result.memoryStatus)} — schema: ${metricValue(memory.schemaVersion)} · revisão: ${metricValue(memory.revision)} · cursor: ${metricValue(memory.eventCursor)} · hash: ${metricValue(memory.stateHash)}`,
+  );
+  lines.push(`  ledger: ${metricValue(memory.ledgerEvents)} evento(s) · outbox: ${metricValue(memory.pendingOutbox)} · candidates: ${metricValue(memory.candidates)} · conflitos: ${metricValue(memory.activeConflicts)}`);
+  for (const failure of memoryFailures) lines.push(`  ✗ ${failure}`);
+  for (const warning of memoryWarnings) lines.push(`  ! ${warning}`);
+  if (result.memoryStatus === 'healthy' && !memoryFailures.length && !memoryWarnings.length) {
+    lines.push('  ✓ bundle de memória íntegro');
+  }
+  return lines;
+}
+
+export function runDoctor(argv) {
   let vault;
   let project;
-  const passthrough = [];
+  let session = '';
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
     if (a === '--vault') vault = argv[++i];
     else if (a.startsWith('--vault=')) vault = a.slice(8);
     else if (a === '--project') project = argv[++i];
     else if (a.startsWith('--project=')) project = a.slice(10);
-    else passthrough.push(a);
+    else if (a === '--session') session = argv[++i] || '';
+    else if (a.startsWith('--session=')) session = a.slice(10);
   }
 
   const projectRoot = resolve(project || process.cwd());
@@ -42,12 +79,22 @@ export function runDoctor(argv) {
     process.stdout.write('  ! migração pendente: rode `wendkeep init --project . --vault "<vault>" --yes` para criar .wendkeep.json\n');
   }
 
-  // 1. Session/vault integrity (existing check).
-  let healthStatus = 0;
-  if (existsSync(hookFile)) {
-    const r = spawnSync(process.execPath, [hookFile, ...passthrough, '--vault', vaultBase], { stdio: 'inherit' });
-    healthStatus = r.status ?? 0;
+  // 1. Session/vault integrity. The standalone hook remains JSON; doctor renders it for humans.
+  let health;
+  try {
+    health = runVaultHealth({ vaultBase, session });
+  } catch (error) {
+    health = {
+      ok: false,
+      session,
+      failures: [`Vault health falhou: ${error?.message || error}`],
+      warnings: [],
+      metrics: { memory: {} },
+      memoryStatus: 'blocked',
+    };
   }
+  process.stdout.write(`${renderVaultHealthLines(health).join('\n')}\n`);
+  const healthStatus = health.ok ? 0 : 1;
 
   // 2. Harness integrity (Wave B).
   const { errors, warnings } = checkHarness(vaultBase, projectRoot);

--- a/src/memory-curate.mjs
+++ b/src/memory-curate.mjs
@@ -1,0 +1,328 @@
+import { existsSync } from 'node:fs';
+import { createInterface } from 'node:readline/promises';
+
+import { getLocale } from '../hooks/locale.mjs';
+import {
+  decideMemoryCandidate,
+  listMemoryCandidatesForCuration,
+} from './memory.mjs';
+
+const TEXT = {
+  'pt-BR': {
+    title: 'Curadoria guiada de memória',
+    intro: (count) => `${count} conflito(s) aguardam uma decisão humana. Nada será escolhido automaticamente.`,
+    categories: 'Categorias pendentes:',
+    progress: (index, total, label) => `Conflito ${index} de ${total} — ${label}`,
+    source: 'origem',
+    sourceKinds: {
+      session: 'sessão capturada', turn: 'turno capturado',
+      activation: 'ativação capturada', unknown: 'não identificada',
+    },
+    observed: 'registrado em',
+    newer: 'mais recente',
+    actions: '[1-N] Manter uma versão · [P] Pular · [R] Encerrar sem vencedor · [D] Detalhes · [Q] Sair',
+    choose: '> ',
+    confirmPromote: (number) => `Manter a versão ${number}? Essa decisão será gravada agora. [s/N] `,
+    confirmReject: 'Encerrar este conflito sem escolher uma versão? Essa decisão será gravada agora. [s/N] ',
+    invalid: 'Opção inválida. Escolha um número exibido, P, R, D ou Q.',
+    declined: 'Decisão não confirmada; nenhum byte foi alterado.',
+    promoted: 'Versão promovida e decisão auditada.',
+    rejected: 'Conflito encerrado sem promover uma versão.',
+    details: 'Detalhes técnicos',
+    paused: (decisions, skipped) => `Sessão encerrada: ${decisions} decisão(ões) gravada(s), ${skipped} conflito(s) pulado(s).`,
+    complete: (decisions) => `Curadoria concluída: ${decisions} decisão(ões) gravada(s); nenhum conflito semântico ativo restante.`,
+    blocked: 'O estado da memória mudou ou está ocupado. Nada mais foi aplicado; execute memory curate novamente.',
+    noConflicts: 'Nenhum conflito semântico ativo precisa de curadoria.',
+  },
+  en: {
+    title: 'Guided memory curation',
+    intro: (count) => `${count} conflict(s) require a human decision. Nothing will be selected automatically.`,
+    categories: 'Pending categories:',
+    progress: (index, total, label) => `Conflict ${index} of ${total} — ${label}`,
+    source: 'source',
+    sourceKinds: {
+      session: 'captured session', turn: 'captured turn',
+      activation: 'captured activation', unknown: 'unidentified',
+    },
+    observed: 'recorded at',
+    newer: 'newest timestamp',
+    actions: '[1-N] Keep one version · [P] Skip · [R] Close without a winner · [D] Details · [Q] Quit',
+    choose: '> ',
+    confirmPromote: (number) => `Keep version ${number}? This decision will be written now. [y/N] `,
+    confirmReject: 'Close this conflict without choosing a version? This decision will be written now. [y/N] ',
+    invalid: 'Invalid option. Choose a displayed number, P, R, D, or Q.',
+    declined: 'Decision not confirmed; no bytes were changed.',
+    promoted: 'Version promoted and decision audited.',
+    rejected: 'Conflict closed without promoting a version.',
+    details: 'Technical details',
+    paused: (decisions, skipped) => `Session ended: ${decisions} decision(s) written, ${skipped} conflict(s) skipped.`,
+    complete: (decisions) => `Curation complete: ${decisions} decision(s) written; no active semantic conflicts remain.`,
+    blocked: 'Memory state changed or is busy. Nothing else was applied; run memory curate again.',
+    noConflicts: 'No active semantic conflict requires curation.',
+  },
+};
+
+const KEY_TEXT = {
+  'handoff.latest': {
+    'pt-BR': ['Próximo handoff', 'Resumo que será apresentado à próxima sessão.'],
+    en: ['Next handoff', 'Summary that will be presented to the next session.'],
+  },
+  'quality.latest-sensors': {
+    'pt-BR': ['Sensores de qualidade', 'Conjunto de testes e sensores considerado mais recente.'],
+    en: ['Quality sensors', 'Test and sensor set considered the latest.'],
+  },
+  'quality.latest-verdict': {
+    'pt-BR': ['Veredito de qualidade', 'Resultado de verificação apresentado como vigente.'],
+    en: ['Quality verdict', 'Verification result presented as current.'],
+  },
+  'git.local-head': {
+    'pt-BR': ['Commit local conhecido', 'Commit que o WendKeep considera o último estado local.'],
+    en: ['Known local commit', 'Commit WendKeep considers the latest local state.'],
+  },
+};
+
+function localeId(value) {
+  return value === 'en' ? 'en' : 'pt-BR';
+}
+
+function keyText(memoryKey, locale) {
+  return KEY_TEXT[memoryKey]?.[locale]
+    || (locale === 'en'
+      ? [memoryKey, 'Operational memory value with competing versions.']
+      : [memoryKey, 'Valor operacional com versões concorrentes.']);
+}
+
+function isAffirmative(answer) {
+  return ['s', 'sim', 'y', 'yes'].includes(String(answer || '').trim().toLowerCase());
+}
+
+function groupLines(candidates, locale) {
+  const counts = new Map();
+  for (const candidate of candidates) {
+    counts.set(candidate.memory_key, (counts.get(candidate.memory_key) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, count]) => `  • ${keyText(key, locale)[0]}: ${count}`);
+}
+
+function newestEventId(events) {
+  return [...events]
+    .filter((event) => !Number.isNaN(Date.parse(event.observed_at || '')))
+    .sort((left, right) => Date.parse(right.observed_at) - Date.parse(left.observed_at))[0]?.event_id;
+}
+
+export function renderMemoryConflict(candidate, {
+  locale = 'pt-BR', index = 1, total = 1, details = false,
+} = {}) {
+  const id = localeId(locale);
+  const text = TEXT[id];
+  const [label, description] = keyText(candidate.memory_key, id);
+  const newest = newestEventId(candidate.events);
+  const lines = ['', text.progress(index, total, label), description, ''];
+  candidate.events.forEach((event, eventIndex) => {
+    const recent = event.event_id === newest ? ` — ${text.newer}` : '';
+    const source = text.sourceKinds[event.source] || text.sourceKinds.unknown;
+    lines.push(`[${eventIndex + 1}] ${text.source}: ${source}${recent}`);
+    if (event.observed_at) lines.push(`    ${text.observed}: ${event.observed_at}`);
+    lines.push(`    ${event.preview}`);
+  });
+  if (details) {
+    lines.push('', `${text.details}:`, `  candidate: ${candidate.candidate_id}`);
+    candidate.events.forEach((event) => lines.push(`  event: ${event.event_id}`));
+  }
+  lines.push('', text.actions);
+  return `${lines.join('\n')}\n`;
+}
+
+export async function runGuidedMemoryCuration(vault, {
+  ask,
+  write,
+  loadCandidates = listMemoryCandidatesForCuration,
+  decide = decideMemoryCandidate,
+  locale = 'pt-BR',
+} = {}) {
+  if (typeof ask !== 'function' || typeof write !== 'function') {
+    throw new TypeError('runGuidedMemoryCuration requer ask e write.');
+  }
+  const id = localeId(locale);
+  const text = TEXT[id];
+  let decisions = 0;
+  let skipped = 0;
+  const skippedIds = new Set();
+  const decidedIds = new Set();
+  let first = true;
+  let sessionTotal = 0;
+
+  while (true) {
+    let loaded;
+    try {
+      loaded = loadCandidates(vault);
+      if (!Array.isArray(loaded)) throw new TypeError('candidate inventory must be an array');
+    } catch {
+      write(`${text.blocked}\n`);
+      return { status: 'blocked', decisions, skipped };
+    }
+    const candidates = loaded.filter((candidate) => !skippedIds.has(candidate.candidate_id));
+    if (first) {
+      sessionTotal = loaded.length;
+      write(`${text.title}\n${text.intro(loaded.length)}\n`);
+      if (loaded.length) write(`${text.categories}\n${groupLines(loaded, id).join('\n')}\n`);
+      first = false;
+    }
+    if (!loaded.length) {
+      write(`${decisions ? text.complete(decisions) : text.noConflicts}\n`);
+      return { status: 'complete', decisions, skipped };
+    }
+    if (!candidates.length) {
+      write(`${text.paused(decisions, skipped)}\n`);
+      return { status: 'paused', decisions, skipped };
+    }
+
+    const candidate = candidates[0];
+    if (decidedIds.has(candidate.candidate_id)) {
+      write(`${text.blocked}\n`);
+      return { status: 'blocked', decisions, skipped };
+    }
+    const completed = decisions + skipped;
+    const progressTotal = Math.max(sessionTotal, completed + candidates.length);
+    const progressIndex = completed + 1;
+    write(renderMemoryConflict(candidate, {
+      locale: id, index: progressIndex, total: progressTotal,
+    }));
+    const answer = String(await ask(text.choose)).trim().toLowerCase();
+
+    if (answer === 'q') {
+      write(`${text.paused(decisions, skipped)}\n`);
+      return { status: 'quit', decisions, skipped };
+    }
+    if (answer === 'p') {
+      skippedIds.add(candidate.candidate_id);
+      skipped += 1;
+      continue;
+    }
+    if (answer === 'd') {
+      write(renderMemoryConflict(candidate, {
+        locale: id, index: progressIndex, total: progressTotal, details: true,
+      }));
+      continue;
+    }
+
+    let decision;
+    let confirmation;
+    if (answer === 'r') {
+      decision = { action: 'reject', candidateId: candidate.candidate_id };
+      confirmation = await ask(text.confirmReject);
+    } else if (/^\d+$/.test(answer)) {
+      const eventIndex = Number(answer) - 1;
+      const selected = candidate.events[eventIndex];
+      if (!selected) {
+        write(`${text.invalid}\n`);
+        continue;
+      }
+      decision = {
+        action: 'promote', candidateId: candidate.candidate_id, eventId: selected.event_id,
+      };
+      confirmation = await ask(text.confirmPromote(eventIndex + 1));
+    } else {
+      write(`${text.invalid}\n`);
+      continue;
+    }
+
+    if (!isAffirmative(confirmation)) {
+      write(`${text.declined}\n`);
+      continue;
+    }
+
+    let result;
+    try {
+      result = decide(vault, decision);
+    } catch {
+      write(`${text.blocked}\n`);
+      return { status: 'blocked', decisions, skipped };
+    }
+    if (!result || !['promoted', 'rejected'].includes(result.status)) {
+      write(`${text.blocked}\n`);
+      return { status: 'blocked', decisions, skipped };
+    }
+    decisions += 1;
+    decidedIds.add(candidate.candidate_id);
+    write(`${result.status === 'promoted' ? text.promoted : text.rejected}\n`);
+  }
+}
+
+function usageError(message) {
+  const error = new Error(message);
+  error.code = 'WENDKEEP_MEMORY_CURATE_USAGE';
+  return error;
+}
+
+export function parseMemoryCurateArgs(argv) {
+  let vault = '';
+  let seenVault = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) throw usageError(`argumento posicional inesperado: ${token}.`);
+    const equalAt = token.indexOf('=');
+    const name = equalAt >= 0 ? token.slice(0, equalAt) : token;
+    if (name !== '--vault') throw usageError(`opção desconhecida: ${name}.`);
+    if (seenVault) throw usageError('--vault duplicado.');
+    const value = equalAt >= 0 ? token.slice(equalAt + 1) : argv[index + 1];
+    if (!value || !value.trim() || value.startsWith('--')) {
+      throw usageError('--vault requer valor não vazio que não comece com --.');
+    }
+    vault = value;
+    seenVault = true;
+    if (equalAt < 0) index += 1;
+  }
+  return { vault };
+}
+
+export async function runMemoryCurateCli(argv, {
+  input = process.stdin,
+  output = process.stdout,
+  error = process.stderr,
+  env = process.env,
+} = {}) {
+  let args;
+  try {
+    args = parseMemoryCurateArgs(argv);
+  } catch {
+    error.write(
+      'wendkeep memory curate: não foi possível abrir a curadoria com segurança. '
+      + 'Inspecione o estado com memory candidates --active e tente novamente.\n',
+    );
+    return 2;
+  }
+  const vault = args.vault || env.OBSIDIAN_VAULT_PATH;
+  if (!vault) {
+    error.write('wendkeep memory curate: passe --vault <path>.\n');
+    return 2;
+  }
+  if (!existsSync(vault)) {
+    error.write(`wendkeep memory curate: not found: ${vault}\n`);
+    return 2;
+  }
+  if (!input?.isTTY || !output?.isTTY) {
+    error.write(
+      `wendkeep memory curate requer terminal interativo (TTY). Inspecione sem alterar com: `
+      + `npx --no-install wendkeep memory candidates --active --vault "${vault}"\n`,
+    );
+    return 2;
+  }
+
+  const rl = createInterface({ input, output });
+  try {
+    const result = await runGuidedMemoryCuration(vault, {
+      locale: getLocale(vault).id,
+      ask: (question) => rl.question(question),
+      write: (value) => output.write(String(value)),
+    });
+    return result.status === 'blocked' ? 1 : 0;
+  } catch (cause) {
+    error.write(`wendkeep memory curate: ${cause.message}\n`);
+    return 1;
+  } finally {
+    rl.close();
+  }
+}

--- a/src/memory.mjs
+++ b/src/memory.mjs
@@ -237,6 +237,48 @@ function readCandidates(vault) {
     .split('\n').filter(Boolean).map((line) => JSON.parse(line));
 }
 
+const TERMINAL_CANDIDATE_STATUSES = new Set(['resolved', 'rejected', 'superseded']);
+
+function lexicalCompare(left, right) {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function sanitizedCandidate(candidate, index) {
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+    throw new Error(`MEMORY_CANDIDATES.jsonl: candidate ${index + 1} inválido.`);
+  }
+  const required = ['candidate_id', 'reason', 'memory_key'];
+  const missing = required.filter((field) => typeof candidate[field] !== 'string' || !candidate[field]);
+  if (missing.length) {
+    throw new Error(`MEMORY_CANDIDATES.jsonl: candidate ${index + 1} sem ${missing.join(', ')}.`);
+  }
+  if (candidate.status !== undefined && (typeof candidate.status !== 'string' || !candidate.status)) {
+    throw new Error(`MEMORY_CANDIDATES.jsonl: candidate ${index + 1} possui status inválido.`);
+  }
+  const eventIds = candidate.event_ids ?? [];
+  if (!Array.isArray(eventIds) || eventIds.some((eventId) => typeof eventId !== 'string' || !eventId)) {
+    throw new Error(`MEMORY_CANDIDATES.jsonl: candidate ${index + 1} possui event_ids inválidos.`);
+  }
+  return {
+    candidate_id: candidate.candidate_id,
+    reason: candidate.reason,
+    status: candidate.status || 'active',
+    memory_key: candidate.memory_key,
+    event_ids: [...eventIds].sort(lexicalCompare),
+  };
+}
+
+export function listMemoryCandidates(vault, { activeOnly = false } = {}) {
+  const candidates = readCandidates(vault)
+    .map(sanitizedCandidate)
+    .filter((candidate) => !activeOnly || !TERMINAL_CANDIDATE_STATUSES.has(candidate.status))
+    .sort((left, right) => lexicalCompare(left.memory_key, right.memory_key)
+      || lexicalCompare(left.candidate_id, right.candidate_id));
+  return { status: 'ok', candidates };
+}
+
 function priorCandidateDecision(vault, candidateId) {
   return readMemoryLedger(vault).events.find(
     (event) => event.candidate_decision?.candidate_id === candidateId,
@@ -1897,10 +1939,49 @@ function parseRecoverAttemptArgs(argv) {
   };
 }
 
+function parseCandidatesArgs(argv) {
+  const seen = new Set();
+  let activeOnly = false;
+  let vault = '';
+
+  for (let index = 1; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) {
+      throw memoryUsageError(`memory candidates recebeu argumento posicional extra: ${token}.`);
+    }
+
+    const equalAt = token.indexOf('=');
+    const name = equalAt >= 0 ? token.slice(0, equalAt) : token;
+    if (name !== '--active' && name !== '--vault') {
+      throw memoryUsageError(`memory candidates recebeu opção desconhecida: ${name}.`);
+    }
+    if (seen.has(name)) {
+      throw memoryUsageError(`memory candidates recebeu opção duplicada: ${name}.`);
+    }
+    seen.add(name);
+
+    if (name === '--active') {
+      if (equalAt >= 0) throw memoryUsageError('--active não aceita valor.');
+      activeOnly = true;
+      continue;
+    }
+
+    const value = equalAt >= 0 ? token.slice(equalAt + 1) : argv[index + 1];
+    if (!value || !value.trim() || value.startsWith('--')) {
+      throw memoryUsageError('--vault requer valor não vazio que não comece com --.');
+    }
+    vault = value;
+    if (equalAt < 0) index += 1;
+  }
+
+  return { activeOnly, vault };
+}
+
 export function runMemory(argv) {
   const [sub, positional] = argv;
   let reconcileArgs = null;
   let recoverAttemptArgs = null;
+  let candidatesArgs = null;
   if (sub === 'reconcile') {
     try {
       reconcileArgs = parseReconcileArgs(argv);
@@ -1919,14 +2000,26 @@ export function runMemory(argv) {
       return;
     }
   }
+  if (sub === 'candidates') {
+    try {
+      candidatesArgs = parseCandidatesArgs(argv);
+    } catch (error) {
+      process.stderr.write(`wendkeep memory: ${error.message}\n`);
+      process.exitCode = error.code === 'WENDKEEP_MEMORY_USAGE' ? 2 : 1;
+      return;
+    }
+  }
   const vault = (
-    recoverAttemptArgs?.vault || reconcileArgs?.vault || option(argv, '--vault')
+    recoverAttemptArgs?.vault || reconcileArgs?.vault || candidatesArgs?.vault || option(argv, '--vault')
   ) || process.env.OBSIDIAN_VAULT_PATH;
   if (!vault) { process.stderr.write('wendkeep memory: passe --vault <path>.\n'); process.exitCode = 2; return; }
   if (!existsSync(vault)) { process.stderr.write(`wendkeep memory: not found: ${vault}\n`); process.exitCode = 2; return; }
   try {
     let result;
     if (sub === 'status') result = memoryStatus(vault);
+    else if (sub === 'candidates') {
+      result = listMemoryCandidates(vault, { activeOnly: candidatesArgs.activeOnly });
+    }
     else if (sub === 'migrate') result = migrateMemory(vault, { apply: argv.includes('--apply') });
     else if (sub === 'repair') result = repairMemory(vault);
     else if (sub === 'reconcile') {
@@ -1950,7 +2043,7 @@ export function runMemory(argv) {
         action: sub, candidateId: positional, ...(eventId ? { eventId } : {}),
       });
     }
-    else { process.stderr.write('wendkeep memory: use status | migrate [--apply] | repair | recover-attempt <session> [--apply] | reconcile <session> --by-session <session> --reason <text> [--apply] | promote <candidate> [--event <event-id>] | reject <candidate>.\n'); process.exitCode = 2; return; }
+    else { process.stderr.write('wendkeep memory: use status | candidates [--active] | migrate [--apply] | repair | recover-attempt <session> [--apply] | reconcile <session> --by-session <session> --reason <text> [--apply] | promote <candidate> [--event <event-id>] | reject <candidate>.\n'); process.exitCode = 2; return; }
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     if (sub === 'status' && argv.includes('--gate')) process.exitCode = result.status === 'blocked' ? 1 : 0;
     else if (sub === 'reconcile' && reconcileArgs.apply) process.exitCode = result.health?.status === 'blocked' ? 1 : 0;

--- a/src/memory.mjs
+++ b/src/memory.mjs
@@ -279,6 +279,62 @@ export function listMemoryCandidates(vault, { activeOnly = false } = {}) {
   return { status: 'ok', candidates };
 }
 
+const CURATION_PREVIEW_CHARS = 160;
+
+function curationPreview(value) {
+  const normalized = sanitizeMemoryText(value).replace(/\s+/g, ' ').trim();
+  const visible = normalized || '(sem conteúdo)';
+  return visible.length <= CURATION_PREVIEW_CHARS
+    ? visible
+    : `${visible.slice(0, CURATION_PREVIEW_CHARS - 1).trimEnd()}…`;
+}
+
+function sanitizedCurationEvent(candidate, eventId, candidateIndex) {
+  const events = Array.isArray(candidate.events) ? candidate.events : [];
+  const event = events.find((item) => item?.event_id === eventId);
+  if (!event || typeof event !== 'object' || Array.isArray(event)) {
+    throw new Error(
+      `MEMORY_CANDIDATES.jsonl: candidate ${candidateIndex + 1} sem evento elegível.`,
+    );
+  }
+  const source = event.canonical_session_id
+    ? 'session'
+    : event.source_turn_id
+      ? 'turn'
+      : event.activation_id
+        ? 'activation'
+        : 'unknown';
+  return {
+    event_id: eventId,
+    observed_at: sanitizeMemoryText(event.observed_at || event.effective_at || ''),
+    source: sanitizeMemoryText(source),
+    preview: curationPreview(event.value),
+  };
+}
+
+export function listMemoryCandidatesForCuration(vault) {
+  return readCandidates(vault)
+    .map((candidate, index) => ({ candidate, index, safe: sanitizedCandidate(candidate, index) }))
+    .filter(({ safe }) => safe.reason === 'conflict'
+      && !TERMINAL_CANDIDATE_STATUSES.has(safe.status))
+    .map(({ candidate, index, safe }) => {
+      if (!safe.event_ids.length) {
+        throw new Error(
+          `MEMORY_CANDIDATES.jsonl: candidate ${index + 1} sem eventos elegíveis.`,
+        );
+      }
+      return {
+        candidate_id: safe.candidate_id,
+        reason: safe.reason,
+        status: safe.status,
+        memory_key: safe.memory_key,
+        events: safe.event_ids.map((eventId) => sanitizedCurationEvent(candidate, eventId, index)),
+      };
+    })
+    .sort((left, right) => lexicalCompare(left.memory_key, right.memory_key)
+      || lexicalCompare(left.candidate_id, right.candidate_id));
+}
+
 function priorCandidateDecision(vault, candidateId) {
   return readMemoryLedger(vault).events.find(
     (event) => event.candidate_decision?.candidate_id === candidateId,

--- a/tests/docs-bilingual.test.mjs
+++ b/tests/docs-bilingual.test.mjs
@@ -447,3 +447,40 @@ test('[req:OBS-11] [req:OBS-12] DOC-13: READMEs resumem observabilidade e delega
     assert.match(contract.text, contract.doctor, `${locale}: resumo de doctor/frescor`);
   }
 });
+
+test('[req:MEM-CUR-4] [req:DIAG-8] DOC-14: inventário e orientação de conflitos são públicos e bilíngues', () => {
+  const help = spawnSync(process.execPath, [join(ROOT, 'bin', 'wendkeep.mjs'), '--help'], {
+    cwd: ROOT, encoding: 'utf8',
+  });
+  assert.equal(help.status, 0, help.stderr);
+  assert.match(help.stdout, /memory <sub>[\s\S]*candidates \[--active\]/i);
+
+  const cases = {
+    pt: {
+      memory: readFileSync(join(GUIDE_DIR.pt, 'memory.md'), 'utf8'),
+      doctor: readFileSync(join(GUIDE_DIR.pt, 'maintenance-and-diagnostics.md'), 'utf8'),
+      readme: readFileSync(join(ROOT, 'README.md'), 'utf8'),
+      repairBoundary: /memory repair[\s\S]*não escolhe vencedor/i,
+      noValues: /não (?:expõe|inclui)[^\n]*(?:valores|conteúdo)/i,
+    },
+    en: {
+      memory: readFileSync(join(GUIDE_DIR.en, 'memory.md'), 'utf8'),
+      doctor: readFileSync(join(GUIDE_DIR.en, 'maintenance-and-diagnostics.md'), 'utf8'),
+      readme: readFileSync(join(ROOT, 'README.en.md'), 'utf8'),
+      repairBoundary: /memory repair[\s\S]*(?:does not|never) choose[^\n]*winner/i,
+      noValues: /does not (?:expose|include)[^\n]*(?:values|content)/i,
+    },
+  };
+  for (const [locale, docs] of Object.entries(cases)) {
+    for (const text of [docs.memory, docs.doctor, docs.readme]) {
+      assert.match(text, /memory candidates --active/i, `${locale}: superfície candidates ausente`);
+    }
+    for (const field of ['candidate_id', 'reason', 'status', 'memory_key', 'event_ids']) {
+      assert.match(docs.memory, new RegExp(field), `${locale}: campo seguro ausente ${field}`);
+    }
+    assert.match(docs.memory, docs.noValues, `${locale}: limite de privacidade ausente`);
+    assert.match(docs.doctor, docs.repairBoundary, `${locale}: fronteira repair/curadoria ausente`);
+    assert.match(docs.doctor, /memory promote <candidate-id> --event <event-id>/i);
+    assert.match(docs.doctor, /memory reject <candidate-id>/i);
+  }
+});

--- a/tests/docs-bilingual.test.mjs
+++ b/tests/docs-bilingual.test.mjs
@@ -61,7 +61,8 @@ const GUIDE_FOR_FAMILY = new Map([
   ['wendkeep note new', 'notes-and-knowledge.md'], ['wendkeep note relink', 'notes-and-knowledge.md'],
   ['wendkeep note repair-frontmatter', 'notes-and-knowledge.md'],
   ['wendkeep note repair-sections', 'notes-and-knowledge.md'], ['wendkeep lesson add', 'notes-and-knowledge.md'],
-  ['wendkeep memory', 'memory.md'], ['wendkeep validate-memory', 'memory.md'],
+  ['wendkeep memory', 'memory.md'], ['wendkeep memory curate', 'memory.md'],
+  ['wendkeep validate-memory', 'memory.md'],
   ['wendkeep sync-defs', 'maintenance-and-diagnostics.md'], ['wendkeep --version', 'maintenance-and-diagnostics.md'],
   ['wendkeep --help', 'maintenance-and-diagnostics.md'],
 ]);
@@ -448,12 +449,13 @@ test('[req:OBS-11] [req:OBS-12] DOC-13: READMEs resumem observabilidade e delega
   }
 });
 
-test('[req:MEM-CUR-4] [req:DIAG-8] DOC-14: inventário e orientação de conflitos são públicos e bilíngues', () => {
+test('[req:MEM-CUR-4] [req:MEM-CUR-5] [req:MEM-CUR-6] [req:DIAG-8] [req:DIAG-11] DOC-14: curadoria guiada e doctor humano são públicos e bilíngues', () => {
   const help = spawnSync(process.execPath, [join(ROOT, 'bin', 'wendkeep.mjs'), '--help'], {
     cwd: ROOT, encoding: 'utf8',
   });
   assert.equal(help.status, 0, help.stderr);
   assert.match(help.stdout, /memory <sub>[\s\S]*candidates \[--active\]/i);
+  assert.match(help.stdout, /memory curate/i);
 
   const cases = {
     pt: {
@@ -462,6 +464,11 @@ test('[req:MEM-CUR-4] [req:DIAG-8] DOC-14: inventário e orientação de conflit
       readme: readFileSync(join(ROOT, 'README.md'), 'utf8'),
       repairBoundary: /memory repair[\s\S]*não escolhe vencedor/i,
       noValues: /não (?:expõe|inclui)[^\n]*(?:valores|conteúdo)/i,
+      confirmation: /confirmação[\s\S]*(?:padrão|default)[^\n]*(?:não|negativ)/i,
+      resume: /(?:pular|sair)[\s\S]*(?:retom|restant)/i,
+      humanDoctor: /doctor[\s\S]*(?:formato|saída)[^\n]*human/i,
+      ttyFallback: /(?:não-TTY|sem TTY|terminal não interativo)[\s\S]*memory candidates --active/i,
+      exceptionalHealth: /Vault ausente[\s\S]*(?:boundary|registry)[\s\S]*JSON\s+estruturado/i,
     },
     en: {
       memory: readFileSync(join(GUIDE_DIR.en, 'memory.md'), 'utf8'),
@@ -469,18 +476,30 @@ test('[req:MEM-CUR-4] [req:DIAG-8] DOC-14: inventário e orientação de conflit
       readme: readFileSync(join(ROOT, 'README.en.md'), 'utf8'),
       repairBoundary: /memory repair[\s\S]*(?:does not|never) choose[^\n]*winner/i,
       noValues: /does not (?:expose|include)[^\n]*(?:values|content)/i,
+      confirmation: /confirmation[\s\S]*default[^\n]*no/i,
+      resume: /(?:skip|quit)[\s\S]*resum/i,
+      humanDoctor: /doctor[\s\S]*human[^\n]*(?:format|output)/i,
+      ttyFallback: /non-TTY[\s\S]*memory candidates --active/i,
+      exceptionalHealth: /missing Vault[\s\S]*(?:boundary|registry)[\s\S]*structured\s+JSON/i,
     },
   };
   for (const [locale, docs] of Object.entries(cases)) {
     for (const text of [docs.memory, docs.doctor, docs.readme]) {
       assert.match(text, /memory candidates --active/i, `${locale}: superfície candidates ausente`);
+      assert.match(text, /memory curate/i, `${locale}: assistente de curadoria ausente`);
     }
     for (const field of ['candidate_id', 'reason', 'status', 'memory_key', 'event_ids']) {
       assert.match(docs.memory, new RegExp(field), `${locale}: campo seguro ausente ${field}`);
     }
     assert.match(docs.memory, docs.noValues, `${locale}: limite de privacidade ausente`);
+    assert.match(docs.memory, docs.confirmation, `${locale}: confirmação default-no ausente`);
+    assert.match(docs.memory, docs.resume, `${locale}: retomada após pular/sair ausente`);
+    assert.match(docs.memory, docs.ttyFallback, `${locale}: fallback não-TTY ausente`);
     assert.match(docs.doctor, docs.repairBoundary, `${locale}: fronteira repair/curadoria ausente`);
-    assert.match(docs.doctor, /memory promote <candidate-id> --event <event-id>/i);
-    assert.match(docs.doctor, /memory reject <candidate-id>/i);
+    assert.match(docs.doctor, docs.humanDoctor, `${locale}: saída humana do doctor ausente`);
+    assert.match(docs.doctor, docs.exceptionalHealth, `${locale}: exceções não preservam o contrato do doctor/hook`);
+    assert.match(docs.readme, docs.exceptionalHealth, `${locale}: README omite o contrato excepcional do doctor/hook`);
+    assert.match(docs.memory, /memory promote <candidate-id> --event <event-id>/i);
+    assert.match(docs.memory, /memory reject <candidate-id>/i);
   }
 });

--- a/tests/doctor-memory-guidance.test.mjs
+++ b/tests/doctor-memory-guidance.test.mjs
@@ -1,0 +1,298 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  linkSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { reduceMemoryEvents } from '../hooks/memory-store.mjs';
+import { renderSharedMemory } from '../hooks/memory-schema.mjs';
+import { runVaultHealth } from '../hooks/vault-health.mjs';
+import { renderVaultHealthLines } from '../src/doctor.mjs';
+import { renderCoreSkeleton } from '../src/validate-core.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const BIN = join(ROOT, 'bin', 'wendkeep.mjs');
+const HEALTH_HOOK = join(ROOT, 'hooks', 'vault-health.mjs');
+const PROJECT_ID = 'doctor-guidance-project';
+
+function memoryEvent() {
+  return {
+    v: 1,
+    project_id: PROJECT_ID,
+    event_id: 'mem-doctor-guidance',
+    memory_key: 'handoff.latest',
+    operation: 'assert',
+    value: 'safe-current-value',
+    authority: 'verified',
+    canonical_session_id: 'doctor-guidance-session',
+    activation_id: 'doctor-guidance-activation',
+    activation_epoch: 1,
+    turn_sequence: 1,
+    source_turn_id: 'doctor-guidance-turn',
+    observed_at: '2026-08-02T12:00:00.000Z',
+    evidence: ['tests/doctor-memory-guidance.test.mjs'],
+  };
+}
+
+function fixture() {
+  const project = mkdtempSync(join(tmpdir(), 'wk-doctor-guidance-'));
+  const vault = join(project, '.doctor-guidance-vault');
+  const brain = join(vault, '.brain');
+  mkdirSync(brain, { recursive: true });
+  writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'doctor-guidance' }));
+  writeFileSync(join(project, '.wendkeep.json'), JSON.stringify({ vault: '.doctor-guidance-vault' }));
+  writeFileSync(join(brain, 'PROJECT.json'), `${JSON.stringify({ schemaVersion: 1, projectId: PROJECT_ID })}\n`);
+  writeFileSync(join(brain, 'CORE.md'), renderCoreSkeleton());
+  writeFileSync(join(brain, 'SESSION_REGISTRY.json'), `${JSON.stringify({ version: 2, sessions: {} })}\n`);
+
+  const event = memoryEvent();
+  const reduced = reduceMemoryEvents([event]);
+  writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), `${JSON.stringify(event)}\n`);
+  writeFileSync(join(brain, 'SHARED_MEMORY.md'), renderSharedMemory({
+    revision: reduced.revision,
+    eventCursor: reduced.eventCursor,
+    stateHash: reduced.stateHash,
+    events: reduced.activeEvents,
+    updatedAt: '2026-08-02T12:00:00.000Z',
+    reviewAfter: '2026-08-09T12:00:00.000Z',
+  }));
+  writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), [
+    {
+      candidate_id: 'private-candidate-a', reason: 'conflict', status: 'active',
+      memory_key: 'handoff.latest', values: ['private-value-a', 'private-value-b'],
+      events: [{ event_id: 'private-event-a', value: 'private-full-event-a' }],
+    },
+    {
+      candidate_id: 'private-candidate-b', reason: 'conflict', status: 'active',
+      memory_key: 'handoff.latest', values: ['private-value-c', 'private-value-d'],
+      events: [{ event_id: 'private-event-b', value: 'private-full-event-b' }],
+    },
+    {
+      candidate_id: 'private-candidate-c', reason: 'conflict', status: 'active',
+      memory_key: 'quality.latest-sensors', values: ['private-value-e', 'private-value-f'],
+      events: [{ event_id: 'private-event-c', value: 'private-full-event-c' }],
+    },
+  ].map((item) => JSON.stringify(item)).join('\n') + '\n');
+  return { project, vault };
+}
+
+function byteSnapshot(root) {
+  const entries = [];
+  const walk = (dir, rel = '') => {
+    for (const name of readdirSync(dir).sort()) {
+      const path = join(dir, name);
+      const itemRel = rel ? `${rel}/${name}` : name;
+      if (statSync(path).isDirectory()) walk(path, itemRel);
+      else entries.push([itemRel, readFileSync(path, 'utf8')]);
+    }
+  };
+  walk(root);
+  return entries;
+}
+
+function createAlias(t, source, target, type = 'hardlink') {
+  try {
+    if (type === 'hardlink') linkSync(source, target);
+    else symlinkSync(source, target, process.platform === 'win32' ? 'junction' : 'dir');
+    return true;
+  } catch (error) {
+    if (['EPERM', 'EACCES', 'ENOTSUP', 'EXDEV'].includes(error?.code)) {
+      t.skip(`${type}s unavailable on this filesystem: ${error.code}`);
+      return false;
+    }
+    throw error;
+  }
+}
+
+function assertExceptionalHealthSurfaces({ project, vault }) {
+  const before = byteSnapshot(project);
+  const expectedCommand = `npx --no-install wendkeep memory status --gate --vault "${vault}"`;
+  const direct = spawnSync(process.execPath, [HEALTH_HOOK, '--vault', vault], {
+    cwd: project,
+    encoding: 'utf8',
+  });
+  assert.equal(direct.status, 1, direct.stderr || direct.stdout);
+  assert.equal(direct.stderr, '', 'standalone hook must not replace JSON with stderr/stack traces');
+  const json = JSON.parse(direct.stdout);
+  const inProcess = runVaultHealth({ vaultBase: vault });
+  assert.deepEqual(json, inProcess, 'standalone JSON and in-process exceptional health are identical');
+  assert.equal(json.ok, false);
+  assert.equal(json.memoryStatus, 'blocked');
+  const memoryFailures = json.failures.filter((failure) => failure.startsWith('Memória:'));
+  assert.ok(memoryFailures.length > 0, 'exception is classified as a memory failure');
+  assert.ok(memoryFailures.some((failure) => failure.includes(expectedCommand)));
+  assert.ok(memoryFailures.every((failure) => (
+    /npx --no-install wendkeep memory (?:status --gate|migrate --apply|repair|curate) --vault /.test(failure)
+      && failure.includes(`--vault "${vault}"`)
+  )), 'every memory failure includes a safe command with the resolved Vault');
+
+  const doctor = spawnSync(process.execPath, [BIN, 'doctor', '--project', project, '--vault', vault], {
+    cwd: project,
+    encoding: 'utf8',
+  });
+  assert.equal(doctor.status, 1, doctor.stderr || doctor.stdout);
+  assert.match(doctor.stdout, /\[memória\] bloqueada/i);
+  assert.ok(doctor.stdout.includes(expectedCommand));
+  assert.doesNotMatch(doctor.stdout, /bundle de memória íntegro/i);
+  assert.doesNotMatch(doctor.stdout, /"failures"|"warnings"|"metrics"|"memoryStatus"/);
+  assert.deepEqual(byteSnapshot(project), before, 'exceptional diagnostics remain byte-for-byte read-only');
+}
+
+test('[req:DIAG-8] [req:DIAG-11] missing Vault keeps doctor human and hook JSON actionable', () => {
+  const project = mkdtempSync(join(tmpdir(), 'wk-doctor-missing-vault-'));
+  const vault = join(project, '.missing-vault');
+  try {
+    writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'doctor-missing-vault' }));
+    assertExceptionalHealthSurfaces({ project, vault });
+  } finally { rmSync(project, { recursive: true, force: true }); }
+});
+
+test('[req:DIAG-8] [req:DIAG-11] unsafe .brain junction keeps doctor human and hook JSON actionable', (t) => {
+  const source = fixture();
+  const project = mkdtempSync(join(tmpdir(), 'wk-doctor-junction-'));
+  const vault = join(project, '.junction-vault');
+  try {
+    mkdirSync(vault, { recursive: true });
+    writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'doctor-junction' }));
+    if (!createAlias(t, join(source.vault, '.brain'), join(vault, '.brain'), 'junction')) return;
+    assertExceptionalHealthSurfaces({ project, vault });
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+    rmSync(source.project, { recursive: true, force: true });
+  }
+});
+
+test('[req:DIAG-8] [req:DIAG-11] unsafe registry hardlink keeps doctor human and hook JSON actionable', (t) => {
+  const { project, vault } = fixture();
+  const outside = mkdtempSync(join(tmpdir(), 'wk-doctor-registry-outside-'));
+  try {
+    const source = join(outside, 'SESSION_REGISTRY.json');
+    const target = join(vault, '.brain', 'SESSION_REGISTRY.json');
+    writeFileSync(source, '{"private":"registry-content"}\n');
+    rmSync(target);
+    if (!createAlias(t, source, target)) return;
+    assertExceptionalHealthSurfaces({ project, vault });
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test('[req:DIAG-8] [req:DIAG-11] doctor renders grouped memory conflicts humanly and remains read-only', () => {
+  const { project, vault } = fixture();
+  try {
+    const before = byteSnapshot(project);
+    const result = spawnSync(process.execPath, [BIN, 'doctor', '--project', project, '--vault', vault], {
+      cwd: project,
+      encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stdout, /\[integridade\]/i);
+    assert.match(result.stdout, /\[memória\]/i);
+    assert.match(result.stdout, /próximo handoff:\s*2/i);
+    assert.match(result.stdout, /sensores de qualidade:\s*1/i);
+    assert.ok(result.stdout.includes(`npx --no-install wendkeep memory curate --vault "${vault}"`));
+    assert.doesNotMatch(result.stdout, /"failures"|"warnings"|"metrics"|"memoryStatus"/);
+    assert.doesNotMatch(result.stdout, /private-candidate|private-event|private-value|private-full-event/);
+    assert.deepEqual(byteSnapshot(project), before, 'doctor must remain byte-for-byte read-only');
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
+test('[req:DIAG-11] direct vault-health hook preserves structured JSON', () => {
+  const { project, vault } = fixture();
+  try {
+    const before = byteSnapshot(project);
+    const result = spawnSync(process.execPath, [HEALTH_HOOK, '--vault', vault], {
+      cwd: project,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 1, result.stderr || result.stdout);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, false);
+    assert.ok(Array.isArray(payload.failures));
+    assert.ok(Array.isArray(payload.warnings));
+    assert.equal(payload.metrics.memory.activeConflicts, 3);
+    assert.deepEqual(byteSnapshot(project), before, 'standalone JSON hook must remain byte-for-byte read-only');
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
+test('[req:DIAG-8] human renderer explicitly names healthy integrity and memory', () => {
+  const human = renderVaultHealthLines({
+    ok: true,
+    session: 'healthy-session.md',
+    failures: [],
+    warnings: [],
+    metrics: {
+      registrySessions: 1,
+      derivedNotes: 0,
+      memory: {
+        schemaVersion: 2,
+        revision: 7,
+        eventCursor: 'mem-safe',
+        stateHash: 'hash-safe',
+        ledgerEvents: 7,
+        pendingOutbox: 0,
+        candidates: 0,
+        activeConflicts: 0,
+      },
+    },
+    memoryStatus: 'healthy',
+  }).join('\n');
+  assert.match(human, /\[integridade\] saudável/i);
+  assert.match(human, /\[memória\] saudável/i);
+  assert.match(human, /sessão e artefatos íntegros/i);
+  assert.match(human, /bundle de memória íntegro/i);
+});
+
+test('[req:DIAG-11] human renderer and JSON hook agree on ok, failures, warnings and metrics', () => {
+  const { project, vault } = fixture();
+  try {
+    const direct = spawnSync(process.execPath, [HEALTH_HOOK, '--vault', vault], {
+      cwd: project,
+      encoding: 'utf8',
+    });
+    assert.equal(direct.status, 1, direct.stderr || direct.stdout);
+    const json = JSON.parse(direct.stdout);
+    const inProcess = runVaultHealth({ vaultBase: vault });
+    assert.deepEqual(json, inProcess, 'standalone JSON and in-process health are identical');
+
+    const human = renderVaultHealthLines(inProcess).join('\n');
+    assert.equal(inProcess.ok, inProcess.failures.length === 0);
+    for (const failure of inProcess.failures) {
+      assert.ok(human.includes(failure.replace(/^Memória:\s*/, '')), `missing failure: ${failure}`);
+    }
+    for (const warning of inProcess.warnings) {
+      assert.ok(human.includes(warning.replace(/^Memória:\s*/, '')), `missing warning: ${warning}`);
+    }
+    const integrityFailures = inProcess.failures.filter((item) => !item.startsWith('Memória:')).length;
+    const integrityWarnings = inProcess.warnings.filter((item) => !item.startsWith('Memória:')).length;
+    assert.match(human, new RegExp(`\\[integridade\\].*${integrityFailures} falha\\(s\\), ${integrityWarnings} aviso\\(s\\)`));
+    for (const value of [
+      inProcess.metrics.registrySessions,
+      inProcess.metrics.derivedNotes,
+      inProcess.metrics.memory.schemaVersion,
+      inProcess.metrics.memory.revision,
+      inProcess.metrics.memory.eventCursor,
+      inProcess.metrics.memory.stateHash,
+      inProcess.metrics.memory.ledgerEvents,
+      inProcess.metrics.memory.pendingOutbox,
+      inProcess.metrics.memory.candidates,
+      inProcess.metrics.memory.activeConflicts,
+    ]) {
+      assert.ok(human.includes(String(value)), `missing metric value: ${value}`);
+    }
+    assert.match(human, /\[memória\] bloqueada/i);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+});

--- a/tests/memory-cli.test.mjs
+++ b/tests/memory-cli.test.mjs
@@ -886,6 +886,226 @@ test('[req:MEM-CUR-2] promoção de conflito exige event_id pertencente ao candi
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
 
+test('[req:MEM-CUR-4] CLI candidates --active lista somente metadados sanitizados sem mutação', () => {
+  const vault = fixture();
+  const brain = join(vault, '.brain');
+  const candidatesPath = join(brain, 'MEMORY_CANDIDATES.jsonl');
+  try {
+    const candidates = [
+      {
+        candidate_id: 'memcand-handoff',
+        reason: 'conflict',
+        memory_key: 'handoff.latest',
+        event_ids: ['mem-z', 'mem-a'],
+        values: ['private-winner', 'private-loser'],
+        events: [{ event_id: 'mem-z', value: 'private-event' }],
+        provenance: { source: 'private-source' },
+      },
+      {
+        candidate_id: 'memcand-git',
+        reason: 'conflict',
+        status: 'active',
+        memory_key: 'git.local-head',
+        event_ids: ['mem-git'],
+        proposed_value: 'private-proposal',
+      },
+      {
+        candidate_id: 'memcand-resolved',
+        reason: 'conflict',
+        status: 'resolved',
+        memory_key: 'next.ui',
+        event_ids: ['mem-resolved'],
+        core_value: 'private-core',
+      },
+      {
+        candidate_id: 'memcand-rejected',
+        reason: 'conflict',
+        status: 'rejected',
+        memory_key: 'queue.rejected',
+        event_ids: ['mem-rejected'],
+        value: 'private-rejected',
+      },
+      {
+        candidate_id: 'memcand-superseded',
+        reason: 'conflict',
+        status: 'superseded',
+        memory_key: 'queue.superseded',
+        event_ids: ['mem-superseded'],
+        value: 'private-superseded',
+      },
+    ];
+    writeFileSync(candidatesPath, `${candidates.map((item) => JSON.stringify(item)).join('\n')}\n`);
+    const snapshot = readdirSync(brain).sort().map((name) => [name, readFileSync(join(brain, name))]);
+
+    const result = spawnSync(process.execPath, [
+      BIN, 'memory', 'candidates', '--active', '--vault', vault,
+    ], { encoding: 'utf8' });
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.status, 'ok');
+    assert.deepEqual(payload.candidates, [
+      {
+        candidate_id: 'memcand-git',
+        reason: 'conflict',
+        status: 'active',
+        memory_key: 'git.local-head',
+        event_ids: ['mem-git'],
+      },
+      {
+        candidate_id: 'memcand-handoff',
+        reason: 'conflict',
+        status: 'active',
+        memory_key: 'handoff.latest',
+        event_ids: ['mem-a', 'mem-z'],
+      },
+    ]);
+    for (const candidate of payload.candidates) {
+      assert.deepEqual(
+        Object.keys(candidate).sort(),
+        ['candidate_id', 'event_ids', 'memory_key', 'reason', 'status'],
+      );
+    }
+    assert.doesNotMatch(
+      result.stdout,
+      /private-winner|private-loser|private-event|private-source|private-proposal|private-core|private-rejected|private-superseded/,
+    );
+
+    const allResult = spawnSync(process.execPath, [
+      BIN, 'memory', 'candidates', '--vault', vault,
+    ], { encoding: 'utf8' });
+    assert.equal(allResult.status, 0, allResult.stderr);
+    assert.deepEqual(
+      JSON.parse(allResult.stdout).candidates.map((candidate) => [candidate.candidate_id, candidate.status]),
+      [
+        ['memcand-git', 'active'],
+        ['memcand-handoff', 'active'],
+        ['memcand-resolved', 'resolved'],
+        ['memcand-rejected', 'rejected'],
+        ['memcand-superseded', 'superseded'],
+      ],
+    );
+    assert.doesNotMatch(
+      allResult.stdout,
+      /private-winner|private-loser|private-event|private-source|private-proposal|private-core|private-rejected|private-superseded/,
+    );
+    assert.deepEqual(
+      readdirSync(brain).sort().map((name) => [name, readFileSync(join(brain, name))]),
+      snapshot,
+    );
+    assert.equal(existsSync(join(brain, 'MEMORY.lock')), false);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-CUR-4] CLI candidates rejeita opções e posicionais não declarados sem tocar o bundle', () => {
+  const vault = fixture();
+  const brain = join(vault, '.brain');
+  try {
+    const snapshot = readdirSync(brain).sort().map((name) => [name, readFileSync(join(brain, name))]);
+    const invalidArgs = [
+      ['--active=false'],
+      ['--active', 'extra'],
+      ['--active', '--active'],
+      ['--unknown'],
+    ];
+
+    for (const args of invalidArgs) {
+      const result = spawnSync(process.execPath, [
+        BIN, 'memory', 'candidates', ...args, '--vault', vault,
+      ], { encoding: 'utf8' });
+      assert.equal(result.status, 2, `${args.join(' ')}\n${result.stderr}`);
+      assert.equal(result.stdout, '');
+      assert.match(result.stderr, /opção|argumento|duplicad|valor/i);
+    }
+
+    assert.deepEqual(
+      readdirSync(brain).sort().map((name) => [name, readFileSync(join(brain, name))]),
+      snapshot,
+    );
+    assert.equal(existsSync(join(brain, 'MEMORY.lock')), false);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-CUR-4] CLI candidates usa ordem lexical explícita independente de locale', () => {
+  const vault = fixture();
+  const candidatesPath = join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl');
+  try {
+    const candidates = [
+      { candidate_id: 'memcand-accent', reason: 'conflict', memory_key: 'á.key', event_ids: ['mem-3'] },
+      { candidate_id: 'memcand-lower', reason: 'conflict', memory_key: 'a.key', event_ids: ['mem-2'] },
+      { candidate_id: 'memcand-upper', reason: 'conflict', memory_key: 'Z.key', event_ids: ['mem-1'] },
+    ];
+    writeFileSync(candidatesPath, `${candidates.map((item) => JSON.stringify(item)).join('\n')}\n`);
+
+    const result = spawnSync(process.execPath, [
+      BIN, 'memory', 'candidates', '--vault', vault,
+    ], { encoding: 'utf8' });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(
+      JSON.parse(result.stdout).candidates.map((item) => item.candidate_id),
+      ['memcand-upper', 'memcand-lower', 'memcand-accent'],
+    );
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-CUR-4] CLI candidates falha fechado para metadata inválida sem ecoar conteúdo', () => {
+  const vault = fixture();
+  const brain = join(vault, '.brain');
+  const candidatesPath = join(brain, 'MEMORY_CANDIDATES.jsonl');
+  try {
+    writeFileSync(candidatesPath, `${JSON.stringify({
+      reason: 'conflict',
+      memory_key: 'handoff.latest',
+      event_ids: ['mem-private'],
+      value: 'private-invalid-value',
+    })}\n`);
+    const snapshot = readdirSync(brain).sort().map((name) => [name, readFileSync(join(brain, name))]);
+
+    const result = spawnSync(process.execPath, [
+      BIN, 'memory', 'candidates', '--active', '--vault', vault,
+    ], { encoding: 'utf8' });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /candidate|inválid|invalid/i);
+    assert.doesNotMatch(result.stderr, /private-invalid-value|mem-private/);
+    assert.deepEqual(
+      readdirSync(brain).sort().map((name) => [name, readFileSync(join(brain, name))]),
+      snapshot,
+    );
+    assert.equal(existsSync(join(brain, 'MEMORY.lock')), false);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('[req:MEM-CUR-4] CLI candidates rejeita sidecar por hardlink antes da leitura', (t) => {
+  const vault = fixture();
+  const outside = mkdtempSync(join(tmpdir(), 'wk-memory-candidates-hardlink-outside-'));
+  const brain = join(vault, '.brain');
+  const candidatesPath = join(brain, 'MEMORY_CANDIDATES.jsonl');
+  const outsidePath = join(outside, 'candidates.jsonl');
+  try {
+    const outsideBytes = `${JSON.stringify({
+      candidate_id: 'memcand-outside', reason: 'conflict', memory_key: 'outside.key', event_ids: ['mem-outside'],
+    })}\n`;
+    writeFileSync(outsidePath, outsideBytes);
+    if (!createAlias(t, outsidePath, candidatesPath)) return;
+
+    const result = spawnSync(process.execPath, [
+      BIN, 'memory', 'candidates', '--active', '--vault', vault,
+    ], { encoding: 'utf8' });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /hardlink|nlink|Vault/i);
+    assert.equal(readFileSync(outsidePath, 'utf8'), outsideBytes);
+    assert.equal(existsSync(join(brain, 'MEMORY.lock')), false);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
 test('[req:MEM-CUR-2] CLI promote encaminha --event e falha fechado sem a escolha', () => {
   const vault = fixture();
   try {

--- a/tests/memory-curate.test.mjs
+++ b/tests/memory-curate.test.mjs
@@ -1,0 +1,485 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, watch, writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { spawn, spawnSync } from 'node:child_process';
+
+import { canonicalMemoryJson, prepareMemoryProjection } from '../hooks/memory-store.mjs';
+import { listMemoryCandidatesForCuration } from '../src/memory.mjs';
+import { renderCoreSkeleton } from '../src/validate-core.mjs';
+import {
+  parseMemoryCurateArgs,
+  runGuidedMemoryCuration,
+  runMemoryCurateCli,
+} from '../src/memory-curate.mjs';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const BIN = join(ROOT, 'bin', 'wendkeep.mjs');
+
+function fixture(candidates) {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-memory-curate-'));
+  const brain = join(vault, '.brain');
+  mkdirSync(brain, { recursive: true });
+  writeFileSync(
+    join(brain, 'MEMORY_CANDIDATES.jsonl'),
+    `${candidates.map((candidate) => JSON.stringify(candidate)).join('\n')}\n`,
+  );
+  return vault;
+}
+
+function durableFixture() {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-memory-curate-durable-'));
+  const brain = join(vault, '.brain');
+  mkdirSync(brain, { recursive: true });
+  writeFileSync(join(brain, 'PROJECT.json'), '{"schemaVersion":1,"projectId":"project-a"}\n');
+  writeFileSync(join(brain, 'CORE.md'), renderCoreSkeleton());
+  const event = (eventId, memoryKey, value, session, turn) => ({
+    v: 1,
+    project_id: 'project-a',
+    event_id: eventId,
+    memory_key: memoryKey,
+    operation: 'assert',
+    value,
+    authority: 'reported',
+    canonical_session_id: session,
+    activation_id: `activation-${session}`,
+    activation_epoch: 1,
+    turn_sequence: turn,
+    source_turn_id: `turn-${eventId}`,
+    observed_at: `2026-08-02T1${turn}:00:00.000Z`,
+    evidence: [`turn:${turn}`],
+  });
+  const events = [
+    event('mem-handoff-a', 'handoff.latest', 'handoff A', 'session-a', 1),
+    event('mem-handoff-b', 'handoff.latest', 'handoff B', 'session-b', 2),
+    event('mem-verdict-a', 'quality.latest-verdict', 'verdict A', 'session-c', 3),
+    event('mem-verdict-b', 'quality.latest-verdict', 'verdict B', 'session-d', 4),
+  ];
+  const projection = prepareMemoryProjection(vault, events);
+  writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), `${events.map(canonicalMemoryJson).join('\n')}\n`);
+  writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), projection.candidatesContent);
+  writeFileSync(join(brain, 'SHARED_MEMORY.md'), projection.sharedContent);
+  return vault;
+}
+
+test('[req:MEM-CUR-5] curation view exposes two interpretable choices without raw memory', () => {
+  const vault = fixture([
+    {
+      candidate_id: 'memcand-guided',
+      reason: 'conflict',
+      status: 'active',
+      memory_key: 'handoff.latest',
+      event_ids: ['mem-b', 'mem-a'],
+      values: ['raw-a', 'raw-b'],
+      events: [
+        {
+          event_id: 'mem-b',
+          value: `TOKEN=super-private-token ${'x'.repeat(220)}`,
+          observed_at: '2026-08-02T17:00:00.000Z',
+          canonical_session_id: 'session-b',
+        },
+        {
+          event_id: 'mem-a',
+          value: 'handoff for private@company.dev\nfrom\tC:\\Users\\private\\transcript.jsonl',
+          observed_at: '2026-08-02T16:00:00.000Z',
+          source_turn_id: 'turn-a',
+        },
+      ],
+    },
+    {
+      candidate_id: 'memcand-done',
+      reason: 'conflict',
+      status: 'resolved',
+      memory_key: 'handoff.latest',
+      event_ids: ['mem-done'],
+      events: [{ event_id: 'mem-done', value: 'must-not-render' }],
+    },
+    {
+      candidate_id: 'memcand-core',
+      reason: 'blocked_by_core',
+      status: 'blocked_by_core',
+      memory_key: 'release.push',
+      event_ids: ['mem-core'],
+      events: [{ event_id: 'mem-core', value: 'must-not-render-either' }],
+    },
+  ]);
+
+  try {
+    const candidates = listMemoryCandidatesForCuration(vault);
+    assert.equal(candidates.length, 1);
+    const [candidate] = candidates;
+    assert.deepEqual(
+      Object.keys(candidate).sort(),
+      ['candidate_id', 'events', 'memory_key', 'reason', 'status'],
+    );
+    assert.deepEqual(candidate.events.map((event) => event.event_id), ['mem-a', 'mem-b']);
+    assert.deepEqual(candidate.events.map((event) => event.source), ['turn', 'session']);
+    assert.deepEqual(
+      Object.keys(candidate.events[0]).sort(),
+      ['event_id', 'observed_at', 'preview', 'source'],
+    );
+    assert.match(candidate.events[0].preview, /REDACTED_EMAIL|REDACTED_LOCAL_PATH/);
+    assert.doesNotMatch(candidate.events[0].preview, /[\r\n\t]/);
+    assert.match(candidate.events[1].preview, /TOKEN=\[REDACTED_SECRET\]/);
+    assert.ok(candidate.events[1].preview.length <= 161);
+    assert.match(candidate.events[1].preview, /…$/);
+
+    const rendered = JSON.stringify(candidates);
+    assert.doesNotMatch(
+      rendered,
+      /super-private-token|private@company\.dev|C:\\\\Users\\\\private|raw-a|raw-b|must-not-render/,
+    );
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+function guidedCandidate(id = 'c1', key = 'handoff.latest') {
+  return {
+    candidate_id: id,
+    reason: 'conflict',
+    status: 'active',
+    memory_key: key,
+    events: [
+      {
+        event_id: `${id}-e1`, observed_at: '2026-08-02T16:00:00.000Z',
+        source: 'session', preview: 'first safe preview',
+      },
+      {
+        event_id: `${id}-e2`, observed_at: '2026-08-02T17:00:00.000Z',
+        source: 'session', preview: 'second safe preview',
+      },
+    ],
+  };
+}
+
+async function drive(answers, initial = [guidedCandidate()], { decisionError, decisionResult } = {}) {
+  const queue = [...answers];
+  const writes = [];
+  const applied = [];
+  let candidates = [...initial];
+  let loads = 0;
+  const result = await runGuidedMemoryCuration('C:\\safe-vault', {
+    locale: 'pt-BR',
+    ask: async () => queue.shift() ?? 'q',
+    write: (text) => writes.push(String(text)),
+    loadCandidates: () => {
+      loads += 1;
+      return candidates;
+    },
+    decide: (_vault, decision) => {
+      applied.push(decision);
+      if (decisionError) throw decisionError;
+      if (decisionResult) return decisionResult;
+      candidates = candidates.filter((candidate) => candidate.candidate_id !== decision.candidateId);
+      return { status: decision.action === 'promote' ? 'promoted' : 'rejected' };
+    },
+  });
+  return { result, writes: writes.join(''), applied, loads };
+}
+
+test('[req:MEM-CUR-6] default-no never mutates and affirmative promotion selects the numbered event', async () => {
+  const declined = await drive(['1', '', 'q']);
+  assert.equal(declined.result.decisions, 0);
+  assert.deepEqual(declined.applied, []);
+
+  const confirmed = await drive(['2', 's']);
+  assert.equal(confirmed.result.decisions, 1);
+  assert.deepEqual(confirmed.applied, [{
+    action: 'promote', candidateId: 'c1', eventId: 'c1-e2',
+  }]);
+  assert.ok(confirmed.loads >= 2, 'reloads after a confirmed decision');
+});
+
+test('[req:MEM-CUR-5] [req:MEM-CUR-6] skip, reject, details and quit have explicit effects', async () => {
+  const skipped = await drive(['p']);
+  assert.equal(skipped.result.skipped, 1);
+  assert.deepEqual(skipped.applied, []);
+
+  const rejected = await drive(['r', 's']);
+  assert.deepEqual(rejected.applied, [{ action: 'reject', candidateId: 'c1' }]);
+
+  const detailed = await drive(['d', 'q']);
+  assert.match(detailed.writes, /c1/);
+  assert.match(detailed.writes, /c1-e1/);
+  assert.equal(detailed.result.decisions, 0);
+
+  const ordinary = await drive(['q']);
+  assert.match(ordinary.writes, /origem: sessão capturada/i);
+  assert.match(ordinary.writes, /first safe preview/);
+  assert.match(ordinary.writes, /second safe preview/);
+  assert.match(ordinary.writes, /\[1\][\s\S]*2026-08-02T16:00:00\.000Z/);
+  assert.match(ordinary.writes, /\[2\][\s\S]*2026-08-02T17:00:00\.000Z/);
+  assert.doesNotMatch(ordinary.writes, /\[(?:x|\*)\]|pré-selecionad|selecionad[ao]/i);
+  assert.doesNotMatch(ordinary.writes, /session-one|session-two|c1-e1|candidate: c1/);
+});
+
+test('[req:MEM-CUR-5] progress advances across skipped conflicts without restarting', async () => {
+  const guided = await drive(
+    ['p', 'q'],
+    [guidedCandidate('c1'), guidedCandidate('c2', 'quality.latest-verdict')],
+  );
+  assert.match(guided.writes, /Conflito 1 de 2[\s\S]*Conflito 2 de 2/);
+  assert.equal(guided.result.skipped, 1);
+});
+
+test('[req:MEM-CUR-5] pending conflicts are grouped and counted by human purpose', async () => {
+  const grouped = await drive(
+    ['q'],
+    [
+      guidedCandidate('c1', 'handoff.latest'),
+      guidedCandidate('c2', 'handoff.latest'),
+      guidedCandidate('c3', 'quality.latest-sensors'),
+    ],
+  );
+  assert.match(grouped.writes, /Categorias pendentes:[\s\S]*Próximo handoff: 2/);
+  assert.match(grouped.writes, /Categorias pendentes:[\s\S]*Sensores de qualidade: 1/);
+  assert.doesNotMatch(grouped.writes, /handoff\.latest|quality\.latest-sensors/);
+});
+
+test('[req:MEM-CUR-5] malformed conflicts fail closed without exposing technical IDs', async () => {
+  const vault = fixture([{
+    candidate_id: 'candidate-private-id', reason: 'conflict', status: 'active',
+    memory_key: 'handoff.latest', event_ids: [], events: [],
+  }]);
+  try {
+    assert.throws(
+      () => listMemoryCandidatesForCuration(vault),
+      (error) => {
+        assert.doesNotMatch(error.message, /candidate-private-id/);
+        return /sem eventos|inválid/i.test(error.message);
+      },
+    );
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+
+  const writes = [];
+  const result = await runGuidedMemoryCuration('C:\\safe-vault', {
+    locale: 'pt-BR',
+    ask: async () => assert.fail('estado inválido não deve abrir prompt'),
+    write: (text) => writes.push(String(text)),
+    loadCandidates: () => { throw new Error('evento technical-secret-id ausente'); },
+  });
+  assert.equal(result.status, 'blocked');
+  assert.doesNotMatch(writes.join(''), /technical-secret-id/);
+});
+
+test('[req:MEM-CUR-6] confirmed decisions are durable and a later run resumes remaining conflicts', async () => {
+  const vault = durableFixture();
+  try {
+    const firstAnswers = ['1', 's', 'q'];
+    const firstWrites = [];
+    const first = await runGuidedMemoryCuration(vault, {
+      locale: 'pt-BR',
+      ask: async () => firstAnswers.shift() ?? 'q',
+      write: (text) => firstWrites.push(String(text)),
+    });
+    assert.equal(first.decisions, 1);
+    assert.equal(first.status, 'quit');
+    assert.equal(listMemoryCandidatesForCuration(vault).length, 1);
+    const decisions = readFileSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl'), 'utf8')
+      .trim().split('\n').map(JSON.parse).filter((event) => event.candidate_decision);
+    assert.equal(decisions.length, 1, 'one confirmation appends exactly one audited decision');
+    assert.equal(decisions[0].candidate_decision.action, 'promote');
+    assert.equal(decisions[0].candidate_decision.selected_event_id, 'mem-handoff-a');
+
+    const secondWrites = [];
+    const second = await runGuidedMemoryCuration(vault, {
+      locale: 'pt-BR',
+      ask: async () => 'q',
+      write: (text) => secondWrites.push(String(text)),
+    });
+    assert.equal(second.status, 'quit');
+    assert.match(secondWrites.join(''), /1 conflito\(s\)/);
+    assert.doesNotMatch(secondWrites.join(''), /2 conflito\(s\)/);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-CUR-6] skipping a real candidate preserves the complete bundle byte for byte', async () => {
+  const vault = durableFixture();
+  try {
+    const brain = join(vault, '.brain');
+    const snapshot = () => readdirSync(brain).sort().map((name) => [
+      name, readFileSync(join(brain, name)),
+    ]);
+    const before = snapshot();
+    const answers = ['p', 'q'];
+    const result = await runGuidedMemoryCuration(vault, {
+      locale: 'pt-BR',
+      ask: async () => answers.shift() ?? 'q',
+      write: () => {},
+    });
+    assert.equal(result.status, 'quit');
+    assert.equal(result.skipped, 1);
+    assert.equal(result.decisions, 0);
+    assert.equal(listMemoryCandidatesForCuration(vault).length, 2);
+    assert.deepEqual(snapshot(), before);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-CUR-6] stale, incompatible and concurrent outcomes stop before another candidate', async () => {
+  for (const message of ['candidate stale', 'decisão incompatível']) {
+    const blocked = await drive(
+      ['1', 's'],
+      [guidedCandidate('c1'), guidedCandidate('c2', 'quality.latest-verdict')],
+      { decisionError: new Error(message) },
+    );
+    assert.equal(blocked.result.status, 'blocked');
+    assert.equal(blocked.applied.length, 1);
+    assert.doesNotMatch(blocked.writes, new RegExp(message, 'i'));
+    assert.match(blocked.writes, /execute memory curate novamente/i);
+  }
+
+  const changed = await drive(
+    ['1', 's'],
+    [guidedCandidate('c1'), guidedCandidate('c2', 'quality.latest-verdict')],
+    { decisionResult: { status: 'promoted' } },
+  );
+  assert.equal(changed.result.status, 'blocked');
+  assert.equal(changed.applied.length, 1);
+  assert.equal(changed.applied[0].candidateId, 'c1');
+  assert.match(changed.writes, /execute memory curate novamente/i);
+});
+
+test('[req:MEM-CUR-6] interactive prompts never hold MEMORY.lock while awaiting input', async () => {
+  const vault = durableFixture();
+  try {
+    const answers = ['1', 'n', 'q'];
+    let prompts = 0;
+    const result = await runGuidedMemoryCuration(vault, {
+      locale: 'pt-BR',
+      ask: async () => {
+        prompts += 1;
+        assert.equal(existsSync(join(vault, '.brain', 'MEMORY.lock')), false);
+        return answers.shift() ?? 'q';
+      },
+      write: () => {},
+    });
+    assert.equal(result.status, 'quit');
+    assert.equal(result.decisions, 0);
+    assert.equal(prompts, 3);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-CUR-6] busy decision stops before applying a choice to the next candidate', async () => {
+  const blocked = await drive(
+    ['1', 's'],
+    [guidedCandidate('c1'), guidedCandidate('c2', 'quality.latest-verdict')],
+    { decisionResult: { status: 'busy' } },
+  );
+  assert.equal(blocked.result.status, 'blocked');
+  assert.equal(blocked.applied.length, 1);
+  assert.equal(blocked.applied[0].candidateId, 'c1');
+  assert.match(blocked.writes, /execute memory curate novamente/i);
+  assert.doesNotMatch(blocked.writes, /second safe preview[\s\S]*second safe preview/);
+});
+
+test('[req:MEM-CUR-5] English vault gets English guidance without changing the choices', async () => {
+  const writes = [];
+  const result = await runGuidedMemoryCuration('C:\\safe-vault', {
+    locale: 'en',
+    ask: async () => 'q',
+    write: (text) => writes.push(String(text)),
+    loadCandidates: () => [guidedCandidate()],
+    decide: () => assert.fail('quit must not decide'),
+  });
+  const output = writes.join('');
+  assert.equal(result.status, 'quit');
+  assert.match(output, /Guided memory curation/);
+  assert.match(output, /Next handoff/);
+  assert.match(output, /first safe preview/);
+  assert.match(output, /second safe preview/);
+  assert.doesNotMatch(output, /Curadoria guiada|Próximo handoff/);
+});
+
+test('[req:MEM-CUR-6] parser has no batch or implicit-confirmation escape hatch', () => {
+  assert.deepEqual(parseMemoryCurateArgs(['--vault', 'C:\\vault']), { vault: 'C:\\vault' });
+  assert.deepEqual(parseMemoryCurateArgs(['--vault=C:\\vault']), { vault: 'C:\\vault' });
+  for (const args of [['--yes'], ['--apply'], ['candidate-id'], ['--vault', 'C:\\one', '--vault', 'C:\\two']]) {
+    assert.throws(() => parseMemoryCurateArgs(args), /desconhecida|inesperado|duplicado/i);
+  }
+});
+
+test('[req:MEM-CUR-5] [req:MEM-CUR-6] CLI refuses non-TTY without touching or transiently locking the bundle', async () => {
+  const vault = fixture([{
+    candidate_id: 'memcand-cli', reason: 'conflict', status: 'active',
+    memory_key: 'git.local-head', event_ids: ['e1', 'e2'],
+    events: [
+      { event_id: 'e1', value: 'one' },
+      { event_id: 'e2', value: 'two' },
+    ],
+  }]);
+  try {
+    const brain = join(vault, '.brain');
+    const before = readdirSync(brain).sort().map((name) => [name, readFileSync(join(brain, name))]);
+    const lockEvents = [];
+    const watcher = watch(brain, (_eventType, filename) => {
+      if (/MEMORY\.lock/i.test(String(filename || ''))) lockEvents.push(String(filename));
+    });
+    let result;
+    try {
+      result = await new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [BIN, 'memory', 'curate', '--vault', vault], {
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.setEncoding('utf8');
+        child.stderr.setEncoding('utf8');
+        child.stdout.on('data', (chunk) => { stdout += chunk; });
+        child.stderr.on('data', (chunk) => { stderr += chunk; });
+        child.once('error', reject);
+        child.once('close', (status, signal) => resolve({ status, signal, stdout, stderr }));
+      });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    } finally {
+      watcher.close();
+    }
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /TTY|terminal interativo/i);
+    assert.match(result.stderr, /memory candidates --active/i);
+    assert.deepEqual(
+      readdirSync(brain).sort().map((name) => [name, readFileSync(join(brain, name))]),
+      before,
+    );
+    assert.deepEqual(lockEvents, [], 'non-TTY path never creates even a transient MEMORY.lock');
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-CUR-5] either missing TTY side triggers the same read-only fallback', async () => {
+  const vault = fixture([]);
+  try {
+    for (const [inputTTY, outputTTY] of [[true, false], [false, true]]) {
+      const stderr = [];
+      const status = await runMemoryCurateCli(['--vault', vault], {
+        input: { isTTY: inputTTY },
+        output: { isTTY: outputTTY, write: () => {} },
+        error: { write: (text) => stderr.push(String(text)) },
+        env: {},
+      });
+      assert.equal(status, 2);
+      assert.match(stderr.join(''), /memory candidates --active/i);
+    }
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-CUR-5] top-level help advertises the guided command', () => {
+  const result = spawnSync(process.execPath, [BIN, '--help'], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /memory curate/i);
+});

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -68,13 +68,14 @@ test('extractReleaseNotes: throws when the version is absent', () => {
   assert.throws(() => extractReleaseNotes(FIXTURE, '9.9.9'), /9\.9\.9/);
 });
 
-test('[sensor:release-tests] 0.67.2 notes are extractable and match the package', () => {
-  const release = extractReleaseNotes(CHANGELOG, '0.67.2');
-  assert.equal(PACKAGE.version, '0.67.2');
+test('[sensor:release-tests] 0.67.3 notes are extractable and match the package', () => {
+  const release = extractReleaseNotes(CHANGELOG, '0.67.3');
+  assert.equal(PACKAGE.version, '0.67.3');
   assert.equal(release.date, '2026-08-02');
-  assert.match(release.notes, /npx --no-install wendkeep/i);
+  assert.match(release.notes, /memory candidates \[--active\]/i);
+  assert.match(release.notes, /memory repair/i);
   assert.match(release.notes, /--vault/i);
-  assert.match(release.notes, /--apply/i);
+  assert.match(release.notes, /candidate_id/i);
   assert.doesNotMatch(release.notes, /019f[0-9a-f-]+/i);
 });
 

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -68,14 +68,15 @@ test('extractReleaseNotes: throws when the version is absent', () => {
   assert.throws(() => extractReleaseNotes(FIXTURE, '9.9.9'), /9\.9\.9/);
 });
 
-test('[sensor:release-tests] 0.67.3 notes are extractable and match the package', () => {
-  const release = extractReleaseNotes(CHANGELOG, '0.67.3');
-  assert.equal(PACKAGE.version, '0.67.3');
+test('[sensor:release-tests] 0.68.0 notes are extractable and match the package', () => {
+  const release = extractReleaseNotes(CHANGELOG, '0.68.0');
+  assert.equal(PACKAGE.version, '0.68.0');
   assert.equal(release.date, '2026-08-02');
-  assert.match(release.notes, /memory candidates \[--active\]/i);
+  assert.match(release.notes, /memory curate --vault/i);
+  assert.match(release.notes, /memory candidates --active/i);
   assert.match(release.notes, /memory repair/i);
-  assert.match(release.notes, /--vault/i);
-  assert.match(release.notes, /candidate_id/i);
+  assert.match(release.notes, /doctor[\s\S]*formato humano/i);
+  assert.match(release.notes, /somente leitura/i);
   assert.doesNotMatch(release.notes, /019f[0-9a-f-]+/i);
 });
 

--- a/tests/sync-command.test.mjs
+++ b/tests/sync-command.test.mjs
@@ -177,7 +177,7 @@ test('[req:MEM-HYB-9] sync de SHARED legado com sidecars vazios conclui com doct
 
     const second = spawnWk(['sync', '--project', project, '--yes'], { cwd: project });
     assert.ok(second.status === 0 || second.status === 1, second.stderr || second.stdout);
-    assert.match(second.stdout, /"memoryStatus": "legacy"/);
+    assert.match(second.stdout, /\[memória\].*legado/i);
     assert.doesNotMatch(second.stdout, /schema_version deve ser 2|event_cursor .*n[aã]o existe no ledger/i);
     assert.equal(readFileSync(join(brain, 'SHARED_MEMORY.md'), 'utf8'), legacy);
 

--- a/tests/vault-health-memory.test.mjs
+++ b/tests/vault-health-memory.test.mjs
@@ -139,6 +139,31 @@ function createAlias(t, source, target, type = 'hardlink') {
   }
 }
 
+function assertEveryFailureHasSafeMemoryCommand(result, vault) {
+  assert.ok(result.failures.length > 0, 'expected at least one memory failure');
+  for (const failure of result.failures) {
+    assert.match(
+      failure,
+      /npx --no-install wendkeep memory (?:status --gate|migrate --apply|repair|curate) --vault /,
+    );
+    assert.ok(failure.includes(`--vault "${vault}"`), 'command uses the resolved Vault path');
+  }
+}
+
+test('[req:DIAG-8] missing Vault blocks with a safe resolved status command', () => {
+  const parent = mkdtempSync(join(tmpdir(), 'wk-health-memory-missing-'));
+  const vault = join(parent, 'vault-does-not-exist');
+  try {
+    const result = checkMemoryBundle(vault);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 'blocked');
+    assert.match(result.failures.join('\n'), /Vault not found/i);
+    assertEveryFailureHasSafeMemoryCommand(result, vault);
+    assert.equal(existsSync(vault), false, 'status check does not create the missing Vault');
+  } finally { rmSync(parent, { recursive: true, force: true }); }
+});
+
 test('[req:DIAG-8] doctor names a healthy bundle and reports schema/revision/cursor/hash', () => {
   const vault = createBundle();
   try {
@@ -171,6 +196,7 @@ test('[req:OP-10] memory health bloqueia .brain junction antes de diagnosticar c
     assert.equal(result.ok, false);
     assert.equal(result.status, 'blocked');
     assert.match(result.failures.join('\n'), /link simbólico|junction|reparse|Vault/i);
+    assertEveryFailureHasSafeMemoryCommand(result, vault);
     assert.deepEqual(byteSnapshot(sourceVault), before);
     assert.equal(lstatSync(brain).isSymbolicLink(), true);
   } finally {
@@ -203,12 +229,35 @@ test('[req:OP-10] memory health bloqueia hardlinks de candidates e outbox sem oc
         assert.equal(result.ok, false);
         assert.equal(result.status, 'blocked');
         assert.match(result.failures.join('\n'), /hardlink|nlink|Vault/i);
+        assertEveryFailureHasSafeMemoryCommand(result, vault);
         assert.deepEqual(readFileSync(source), before);
       } finally {
         rmSync(vault, { recursive: true, force: true });
         rmSync(outside, { recursive: true, force: true });
       }
     });
+  }
+});
+
+test('[req:DIAG-8] unsafe session registry blocks with a safe resolved status command', (t) => {
+  const vault = createBundle();
+  const outside = mkdtempSync(join(tmpdir(), 'wk-health-memory-registry-outside-'));
+  try {
+    const source = join(outside, 'SESSION_REGISTRY.json');
+    const target = join(vault, '.brain', 'SESSION_REGISTRY.json');
+    writeFileSync(source, '{"private":"registry-content"}\n');
+    if (!createAlias(t, source, target)) return;
+
+    const result = checkMemoryBundle(vault);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 'blocked');
+    assert.match(result.failures.join('\n'), /SESSION_REGISTRY\.json.*inseguro|hardlink|nlink/i);
+    assertEveryFailureHasSafeMemoryCommand(result, vault);
+    assert.doesNotMatch(result.failures.join('\n'), /registry-content/);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
   }
 });
 
@@ -665,9 +714,9 @@ test('[req:DIAG-8] active semantic conflicts explain safe human curation without
     assert.ok(failure);
     assert.match(failure, /conflito semântico.*curadoria humana/i);
     assert.match(failure, /memory repair.*não escolhe vencedor/i);
-    assert.match(failure, /memory promote <candidate-id> --event <event-id>/i);
-    assert.match(failure, /memory reject <candidate-id>/i);
-    assert.ok(failure.includes(`npx --no-install wendkeep memory candidates --active --vault "${vault}"`));
+    assert.ok(failure.includes(`npx --no-install wendkeep memory curate --vault "${vault}"`));
+    assert.match(failure, /próximo passo/i);
+    assert.match(failure, /outras memórias \(next\.ui\): 2/i);
     assert.equal((failure.match(/next\.ui/g) || []).length, 1, 'doctor deduplicates repeated keys');
     assert.doesNotMatch(
       failure,

--- a/tests/vault-health-memory.test.mjs
+++ b/tests/vault-health-memory.test.mjs
@@ -467,13 +467,13 @@ test('[req:MEM-STOP-5] [req:MEM-STOP-6] [sensor:memory-health] rejected stale at
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
 
-test('[req:MEM-HYB-9] legacy SHARED plus empty v2 artifacts remains a non-blocking compatibility state', () => {
+test('[req:DIAG-8] [req:MEM-HYB-9] legacy SHARED points to resolved migration and remains read-only', () => {
   const vault = mkdtempSync(join(tmpdir(), 'wk-health-legacy-'));
   const brain = join(vault, '.brain');
   mkdirSync(brain, { recursive: true });
   writeFileSync(join(brain, 'PROJECT.json'), `${JSON.stringify({ schemaVersion: 1, projectId: PROJECT_ID })}\n`);
   writeFileSync(join(brain, 'CORE.md'), renderCoreSkeleton());
-  writeFileSync(join(brain, 'SHARED_MEMORY.md'), '# SHARED legado\n\n## Estado\n- preservar sem migrar\n');
+  writeFileSync(join(brain, 'SHARED_MEMORY.md'), '# SHARED legado\n\n## Estado\n- private-legacy-content\n');
   writeFileSync(join(brain, 'MEMORY_EVENTS.jsonl'), '');
   writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), '');
   try {
@@ -482,7 +482,10 @@ test('[req:MEM-HYB-9] legacy SHARED plus empty v2 artifacts remains a non-blocki
     assert.equal(result.ok, true, result.failures.join('; '));
     assert.equal(result.status, 'legacy');
     assert.deepEqual(result.failures, []);
-    assert.match(result.warnings.join('\n'), /legado|migra/i);
+    const warning = result.warnings.join('\n');
+    assert.match(warning, /legado|migra/i);
+    assert.ok(warning.includes(`npx --no-install wendkeep memory migrate --apply --vault "${vault}"`));
+    assert.doesNotMatch(warning, /<vault>|<cofre>|private-legacy-content/i);
     assert.deepEqual(byteSnapshot(vault), before, 'compatibility diagnosis is read-only');
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
@@ -559,41 +562,63 @@ test('[req:DIAG-8] pending outbox and an ordinary candidate are warnings, not fa
     writeFileSync(join(outbox, 'mem-pending.json'), `${JSON.stringify(event('mem-pending'))}\n`);
     writeFileSync(join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl'), `${JSON.stringify({
       candidate_id: 'candidate-review', reason: 'reported', memory_key: 'next.ui', status: 'pending',
+      value: 'private-candidate-value',
+      events: [{ event_id: 'private-candidate-event', value: 'private-candidate-event-value' }],
     })}\n`);
 
+    const before = byteSnapshot(vault);
     const result = checkMemoryBundle(vault);
     assert.equal(result.ok, true, result.failures.join('; '));
     assert.equal(result.status, 'warning');
     assert.equal(result.metrics.pendingOutbox, 1);
     assert.equal(result.metrics.candidates, 1);
-    assert.match(result.warnings.join('\n'), /outbox/i);
-    assert.match(result.warnings.join('\n'), /candidate/i);
+    const warnings = result.warnings.join('\n');
+    assert.match(warnings, /outbox/i);
+    assert.match(warnings, /candidate/i);
+    assert.doesNotMatch(
+      warnings,
+      /<vault>|<cofre>|private-candidate-value|private-candidate-event|private-candidate-event-value/i,
+    );
+    assert.deepEqual(byteSnapshot(vault), before);
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
 
 test('[req:DIAG-8] corrupt/partial ledger is blocking and points to safe repair', () => {
   const vault = createBundle();
   try {
-    writeFileSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl'), `${JSON.stringify(event())}\n{"v":1`);
+    writeFileSync(
+      join(vault, '.brain', 'MEMORY_EVENTS.jsonl'),
+      `${JSON.stringify(event())}\n{"v":1,"value":"private-corrupt-payload"`,
+    );
+    const before = byteSnapshot(vault);
     const result = checkMemoryBundle(vault);
     assert.equal(result.ok, false);
     assert.equal(result.status, 'blocked');
-    assert.match(result.failures.join('\n'), /linha 2|partial|parcial/i);
-    assert.match(result.failures.join('\n'), /wendkeep memory repair/);
+    const failures = result.failures.join('\n');
+    assert.match(failures, /linha 2|partial|parcial/i);
+    assert.ok(failures.includes(`npx --no-install wendkeep memory repair --vault "${vault}"`));
+    assert.doesNotMatch(failures, /<vault>|<cofre>|private-corrupt-payload/i);
+    assert.deepEqual(byteSnapshot(vault), before);
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
 
 test('[req:DIAG-8] ledger/projection lag and hash divergence are blocking', () => {
   const vault = createBundle();
   try {
-    const second = event('mem-health-2', { memory_key: 'blocker.e2e', value: 'worker-down', turn_sequence: 2 });
+    const second = event('mem-health-2', {
+      memory_key: 'blocker.e2e', value: 'private-lag-payload', turn_sequence: 2,
+    });
     writeFileSync(join(vault, '.brain', 'MEMORY_EVENTS.jsonl'), `${JSON.stringify(event())}\n${JSON.stringify(second)}\n`);
+    const lagBefore = byteSnapshot(vault);
     const lag = checkMemoryBundle(vault);
     assert.equal(lag.ok, false);
-    assert.match(lag.failures.join('\n'), /proje[cç][aã]o|cursor|revision|hash/i);
+    const lagFailures = lag.failures.join('\n');
+    assert.match(lagFailures, /proje[cç][aã]o|cursor|revision|hash/i);
     assert.ok(lag.failures.some((failure) => (
       failure.includes(`npx --no-install wendkeep memory status --gate --vault "${vault}"`)
     )));
+    assert.doesNotMatch(lagFailures, /<vault>|<cofre>|private-lag-payload/i);
+    assert.deepEqual(byteSnapshot(vault), lagBefore);
 
     const sharedPath = join(vault, '.brain', 'SHARED_MEMORY.md');
     const reduced = reduceMemoryEvents([event(), second]);
@@ -605,26 +630,50 @@ test('[req:DIAG-8] ledger/projection lag and hash divergence are blocking', () =
       updatedAt: '2026-07-26T04:00:00Z',
       reviewAfter: '2026-08-02T04:00:00Z',
     }));
+    const hashBefore = byteSnapshot(vault);
     const hash = checkMemoryBundle(vault);
     assert.equal(hash.ok, false);
-    assert.match(hash.failures.join('\n'), /state_hash|hash/i);
+    const hashFailures = hash.failures.join('\n');
+    assert.match(hashFailures, /state_hash|hash/i);
+    assert.ok(hash.failures.some((failure) => (
+      failure.includes(`npx --no-install wendkeep memory status --gate --vault "${vault}"`)
+    )));
+    assert.doesNotMatch(hashFailures, /<vault>|<cofre>|private-lag-payload/i);
+    assert.deepEqual(byteSnapshot(vault), hashBefore);
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
 
-test('[req:DIAG-8] an unresolved conflict candidate for an active key is blocking', () => {
+test('[req:DIAG-8] active semantic conflicts explain safe human curation without leaking or mutating', () => {
   const vault = createBundle();
   try {
-    writeFileSync(join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl'), `${JSON.stringify({
-      candidate_id: 'conflict-next-ui', reason: 'conflict', memory_key: 'next.ui', status: 'active',
-      event_ids: ['mem-health-1', 'mem-competing'], values: ['review', 'discard'],
-    })}\n`);
+    writeFileSync(join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl'), [
+      {
+        candidate_id: 'conflict-next-ui', reason: 'conflict', memory_key: 'next.ui', status: 'active',
+        event_ids: ['mem-health-1', 'mem-competing'], values: ['private-review', 'private-discard'],
+        events: [{ event_id: 'private-full-event', value: 'private-event-payload' }],
+      },
+      {
+        candidate_id: 'conflict-next-ui-later', reason: 'conflict', memory_key: 'next.ui',
+        event_ids: ['mem-later', 'mem-competing'], values: ['private-later', 'private-discard'],
+      },
+    ].map((item) => JSON.stringify(item)).join('\n') + '\n');
+    const before = byteSnapshot(vault);
     const result = checkMemoryBundle(vault);
     assert.equal(result.ok, false);
-    assert.equal(result.metrics.activeConflicts, 1);
-    assert.match(result.failures.join('\n'), /conflito ativo/i);
-    assert.ok(result.failures.some((failure) => (
-      failure.includes(`npx --no-install wendkeep memory status --gate --vault "${vault}"`)
-    )));
+    assert.equal(result.metrics.activeConflicts, 2);
+    const failure = result.failures.find((item) => /conflitos? ativos?/i.test(item));
+    assert.ok(failure);
+    assert.match(failure, /conflito semântico.*curadoria humana/i);
+    assert.match(failure, /memory repair.*não escolhe vencedor/i);
+    assert.match(failure, /memory promote <candidate-id> --event <event-id>/i);
+    assert.match(failure, /memory reject <candidate-id>/i);
+    assert.ok(failure.includes(`npx --no-install wendkeep memory candidates --active --vault "${vault}"`));
+    assert.equal((failure.match(/next\.ui/g) || []).length, 1, 'doctor deduplicates repeated keys');
+    assert.doesNotMatch(
+      failure,
+      /<vault>|<cofre>|private-review|private-discard|private-later|private-full-event|private-event-payload/,
+    );
+    assert.deepEqual(byteSnapshot(vault), before);
     assert.equal(existsSync(join(vault, '.brain', 'MEMORY.lock')), false, 'doctor does not acquire a mutation lock');
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
Sincroniza o GitHub com o npm: `latest` já está em **0.68.0**, mas a `main` parou em `0.67.2`. Esta branch traz os dois releases pendentes.

## Commits

- `e87fe71` — **0.67.3**: doctor diferencia conflitos semânticos de corrupção estrutural; novo `memory candidates [--active]` read-only.
- `e1fd080` — **0.68.0**: `memory curate --vault <vault>` interativo (previews sanitizados, confirmação negativa por padrão, fallback seguro em não-TTY); `doctor` apresenta integridade e conflitos em formato humano preservando o contrato JSON do hook de health.
- `87e0166` — chore: bump da devDependency de dogfood para `^0.68.0`.

## ⚠️ Usar merge commit — não squash

`.github/workflows/auto-tag.yml` só lê a versão corrente do `package.json` em `main`, então o merge vai gerar automaticamente apenas a tag e a Release `v0.68.0`. A `v0.67.3` (já publicada no npm) precisa de tag manual ancorada em `e87fe71` — um squash apagaria esse commit e deixaria a versão sem âncora.

Após o merge:

```bash
git tag -a v0.67.3 -m v0.67.3 e87fe71 && git push origin v0.67.3
node scripts/print-release-notes.mjs 0.67.3 > /tmp/n.md && gh release create v0.67.3 --title v0.67.3 --notes-file /tmp/n.md
```

Notas de release de ambas as versões já extraem sem erro do CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
