### PR TITLE
fix: classifica retry de lock por walk fresco, não por errno (0.68.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.68.1] — 2026-08-08
+
+### Fixed
+
+- **A contenção de locks do Vault deixa de expor `VAULT_PATH_UNSAFE` no Windows.** A revalidação de
+  uma falha transiente de resolução do lock público passa a decidir por um walk fresco do
+  componente, e não pelo `errno` reportado pela plataforma. O Windows devolve `UNKNOWN`, `EBADF` ou
+  `EPERM` onde o Linux devolve `ENOENT`, então a guarda de retry nunca disparava lá e promoções FLOW
+  concorrentes falhavam de forma intermitente com o código de fronteira física em vez do conflito de
+  promoção. Sufixo ausente ou diretório canônico estabilizado autorizam o retry; junction, symlink,
+  reparse point, componente redirecionado ou estado irresolvível persistente continuam falhando
+  fechado, e o orçamento de retry permanece único e limitado por aquisição.
+- **Falha de lock nos caminhos FLOW reporta o código do domínio.** `withFlowPromotionLock` e o store
+  de sessão passam a propagar `FLOW_VAULT_BOUNDARY` para a fronteira física, alinhando a superfície
+  de erro ao resto da saga de promoção.
+
 ## [0.68.0] — 2026-08-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.68.0",
+  "version": "0.68.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.68.0",
+      "version": "0.68.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.68.0",
+  "version": "0.68.1",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [

--- a/packages/harness/src/flow-store.mjs
+++ b/packages/harness/src/flow-store.mjs
@@ -84,10 +84,16 @@ function immutableJson(vaultBase, path, value) {
   return { created: true, path };
 }
 
+// Lock failures on the FLOW paths surface with the domain boundary code, like every other
+// Vault write in the promotion saga — not with the physical-boundary default.
 function underSessionLock(vaultBase, sessionId, fn) {
   const root = sessionRoot(vaultBase, sessionId);
-  mkdirVaultPath(vaultBase, root, { label: 'raiz runtime da sessão FLOW' });
-  const outcome = withVaultPathLock(vaultBase, join(root, '.state'), fn, { timeoutMs: 5000 });
+  mkdirVaultPath(vaultBase, root, {
+    label: 'raiz runtime da sessão FLOW', code: 'FLOW_VAULT_BOUNDARY',
+  });
+  const outcome = withVaultPathLock(vaultBase, join(root, '.state'), fn, {
+    timeoutMs: 5000, code: 'FLOW_VAULT_BOUNDARY',
+  });
   if (typeof outcome === 'symbol') {
     const error = new Error(`store FLOW ocupado para sessão ${sessionId}`);
     error.code = 'FLOW_STORE_BUSY';
@@ -107,10 +113,13 @@ export function withFlowPromotionLock(vaultBase, changeSlug, fn, {
 } = {}) {
   const slug = safeId(changeSlug, 'change_slug');
   const root = join(vaultBase, '.brain', 'runtime', 'flow-promotion-locks');
-  mkdirVaultPath(vaultBase, root, { label: 'raiz de locks de promoção FLOW' });
+  mkdirVaultPath(vaultBase, root, {
+    label: 'raiz de locks de promoção FLOW', code: 'FLOW_VAULT_BOUNDARY',
+  });
   const outcome = withVaultPathLock(vaultBase, join(root, slug), fn, {
     timeoutMs,
     staleMs: ownerGraceMs,
+    code: 'FLOW_VAULT_BOUNDARY',
   });
   if (outcome === VAULT_LOCK_BUSY) {
     const busy = new Error(`promoção FLOW ocupada para a change ${slug}`);

--- a/packages/vault/src/vault-path-safety.mjs
+++ b/packages/vault/src/vault-path-safety.mjs
@@ -335,17 +335,34 @@ function waitBriefly(ms) {
   Atomics.wait(signal, 0, 0, ms);
 }
 
-// A public lock may legitimately disappear while another owner releases it. Only ENOENT
-// observed by an operation explicitly scoped to that canonical lock receives bounded
-// backoff; private .pending paths and every unsafe topology fail closed.
-function retryablePublicLockError(lock, error, code, { allowRaw = true } = {}) {
+// A public lock may legitimately disappear while another owner releases it. Structural shape
+// only: which errno a concurrent removal produces is a platform detail — Windows reports
+// UNKNOWN, EBADF or EPERM where Linux reports ENOENT — so the code is merely the trigger to go
+// re-observe, never the answer. Private .pending paths are siblings, not descendants, of the
+// canonical lock and are excluded by the containment check.
+function publicLockRetryCandidate(lock, error, code, { allowRaw = true } = {}) {
   const failure = error?.[VAULT_PATH_FAILURE];
+  // A raw error carries no component to re-observe, so it stays on the narrow ENOENT path.
   if (!failure) return allowRaw && error?.code === 'ENOENT' && !error?.cause;
-  const causeCode = error?.cause?.code || failure.causeCode;
-  return causeCode === 'ENOENT'
-    && (error?.code === code || error?.code === 'VAULT_PATH_UNSAFE')
+  return (error?.code === code || error?.code === 'VAULT_PATH_UNSAFE')
     && ['component-realpath', 'component-missing'].includes(failure.kind)
     && containedBy(resolve(lock), resolve(failure.component));
+}
+
+// The decision itself. Only a fresh walk that settles as a missing suffix or the canonical
+// entry authorizes a retry; junction, symlink, reparse, a redirected component or a state that
+// is still unresolvable keeps failing closed, exactly as a first-time validation would.
+function publicLockComponentSettled(vaultBase, error, code) {
+  const component = error?.[VAULT_PATH_FAILURE]?.component;
+  if (typeof component !== 'string' || !component) return false;
+  try {
+    assertVaultPathSafe(vaultBase, component, {
+      label: 'revalidação do lock de escrita do Vault', code,
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function vaultLockRenameCollision(error, pending, lock) {
@@ -374,17 +391,22 @@ function vaultLockRetryDeadlineError() {
   return error;
 }
 
-function withPublicLockRetry(lock, code, retryState, operation, initialError = null) {
+function withPublicLockRetry(vaultBase, lock, code, retryState, operation, initialError = null) {
   let error = initialError;
   while (true) {
     if (error) {
-      if (!retryablePublicLockError(lock, error, code)
+      if (!publicLockRetryCandidate(lock, error, code)
         || retryState.remaining <= 0) throw error;
       const remainingMs = retryState.deadline - Date.now();
       if (remainingMs <= 0) throw vaultLockRetryDeadlineError();
       retryState.remaining -= 1;
       waitBriefly(Math.min(VAULT_LOCK_TOPOLOGY_RETRY_MS, remainingMs));
       if (Date.now() >= retryState.deadline) throw vaultLockRetryDeadlineError();
+      // Reclassify only after the backoff, and only while the deadline still allows a retry:
+      // "settled" means observed once the concurrent owner had a chance to finish releasing.
+      // A raw error carries no component and already passed the narrow ENOENT filter above.
+      if (error[VAULT_PATH_FAILURE]
+        && !publicLockComponentSettled(vaultBase, error, code)) throw error;
     }
     try {
       return operation();
@@ -395,9 +417,11 @@ function withPublicLockRetry(lock, code, retryState, operation, initialError = n
 }
 
 function inspectVaultLock(vaultBase, lock, code, retryState, initialError = null) {
-  return withPublicLockRetry(lock, code, retryState, () => assertVaultPathSafe(vaultBase, lock, {
-    expectedType: 'directory', label: 'lock de escrita do Vault', code,
-  }), initialError);
+  return withPublicLockRetry(vaultBase, lock, code, retryState, () => assertVaultPathSafe(
+    vaultBase, lock, {
+      expectedType: 'directory', label: 'lock de escrita do Vault', code,
+    },
+  ), initialError);
 }
 
 function processIsAlive(pid) {
@@ -447,7 +471,7 @@ function vaultLockOwner(vaultBase, lock, code, retryState = null) {
     }
   };
   return retryState
-    ? withPublicLockRetry(lock, code, retryState, inspect)
+    ? withPublicLockRetry(vaultBase, lock, code, retryState, inspect)
     : inspect();
 }
 
@@ -492,7 +516,7 @@ function releaseOwnedVaultLock(vaultBase, lock, {
   // The token-specific lease is the filesystem CAS. An old finally/reaper can only
   // remove the directory after successfully unlinking the lease it originally saw;
   // a replacement lock never contains that unguessable path.
-  const leaseRemoved = withPublicLockRetry(lock, code, retryState, () => unlinkVaultFile(
+  const leaseRemoved = withPublicLockRetry(vaultBase, lock, code, retryState, () => unlinkVaultFile(
     vaultBase, vaultLockLease(lock, token), {
       label: 'lease do lock de escrita do Vault', code,
     },
@@ -503,12 +527,12 @@ function releaseOwnedVaultLock(vaultBase, lock, {
   const current = currentState.owner;
   if (current?.pid !== pid || current?.token !== token) return false;
   const ownerPath = join(lock, VAULT_LOCK_OWNER_FILE);
-  if (!withPublicLockRetry(lock, code, retryState, () => unlinkVaultFile(
+  if (!withPublicLockRetry(vaultBase, lock, code, retryState, () => unlinkVaultFile(
     vaultBase, ownerPath, {
       label: 'owner do lock de escrita do Vault', code,
     },
   ))) return false;
-  return withPublicLockRetry(lock, code, retryState, () => removeVaultLockDirectory(
+  return withPublicLockRetry(vaultBase, lock, code, retryState, () => removeVaultLockDirectory(
     vaultBase, lock, {
       missingOk: false, label: 'lock de escrita do Vault', code,
     },
@@ -516,7 +540,7 @@ function releaseOwnedVaultLock(vaultBase, lock, {
 }
 
 function reapDeadVaultLock(vaultBase, lock, staleMs, code, retryState) {
-  const initial = withPublicLockRetry(lock, code, retryState, () => {
+  const initial = withPublicLockRetry(vaultBase, lock, code, retryState, () => {
     const checked = assertVaultPathSafe(vaultBase, lock, {
       expectedType: 'directory', label: 'lock de escrita do Vault', code,
     });
@@ -530,7 +554,7 @@ function reapDeadVaultLock(vaultBase, lock, staleMs, code, retryState) {
   if (!observed.lockExists) return true;
   if (observed.owner) {
     if (processIsAlive(observed.owner.pid)) return false;
-    const lease = withPublicLockRetry(lock, code, retryState, () => {
+    const lease = withPublicLockRetry(vaultBase, lock, code, retryState, () => {
       const current = assertVaultPathSafe(vaultBase, lock, {
         expectedType: 'directory', label: 'lock de escrita do Vault', code,
       });
@@ -548,7 +572,7 @@ function reapDeadVaultLock(vaultBase, lock, staleMs, code, retryState) {
     // Compatibility with owner-aware locks from 0.58.x, which predate token leases.
     // A dead PID plus byte-identical owner and directory identity is sufficient here;
     // a live legacy owner was returned above and is never reaped by age.
-    const legacy = withPublicLockRetry(lock, code, retryState, () => {
+    const legacy = withPublicLockRetry(vaultBase, lock, code, retryState, () => {
       const current = assertVaultPathSafe(vaultBase, lock, {
         expectedType: 'directory', label: 'lock legado de escrita do Vault', code,
       });
@@ -565,12 +589,12 @@ function reapDeadVaultLock(vaultBase, lock, staleMs, code, retryState) {
     if (currentStat.birthtimeMs !== before.birthtimeMs
       || currentStat.mtimeMs !== before.mtimeMs
       || currentOwner.raw !== observed.raw) return false;
-    if (!withPublicLockRetry(lock, code, retryState, () => unlinkVaultFile(
+    if (!withPublicLockRetry(vaultBase, lock, code, retryState, () => unlinkVaultFile(
       vaultBase, currentOwner.path, {
         label: 'owner legado morto do lock de escrita do Vault', code,
       },
     ))) return false;
-    return withPublicLockRetry(lock, code, retryState, () => removeVaultLockDirectory(
+    return withPublicLockRetry(vaultBase, lock, code, retryState, () => removeVaultLockDirectory(
       vaultBase, checked.target, {
         missingOk: false, label: 'lock legado de escrita do Vault', code,
       },
@@ -580,7 +604,7 @@ function reapDeadVaultLock(vaultBase, lock, staleMs, code, retryState) {
   // Locks are published by atomic directory rename only after owner + lease exist.
   // Thus an old empty/partial directory is legacy or crash residue, never an in-flight
   // live acquisition. Unknown children remain fail-closed.
-  const partial = withPublicLockRetry(lock, code, retryState, () => {
+  const partial = withPublicLockRetry(vaultBase, lock, code, retryState, () => {
     const current = assertVaultPathSafe(vaultBase, lock, {
       expectedType: 'directory', label: 'lock de escrita do Vault', code,
     });
@@ -604,12 +628,12 @@ function reapDeadVaultLock(vaultBase, lock, staleMs, code, retryState) {
     || currentStat.mtimeMs !== before.mtimeMs
     || currentOwner.raw !== observed.raw) return false;
   if (entries.includes(VAULT_LOCK_OWNER_FILE)
-    && !withPublicLockRetry(lock, code, retryState, () => unlinkVaultFile(
+    && !withPublicLockRetry(vaultBase, lock, code, retryState, () => unlinkVaultFile(
       vaultBase, currentOwner.path, {
         label: 'owner parcial do lock de escrita do Vault', code,
       },
     ))) return false;
-  return withPublicLockRetry(lock, code, retryState, () => removeVaultLockDirectory(
+  return withPublicLockRetry(vaultBase, lock, code, retryState, () => removeVaultLockDirectory(
     vaultBase, checked.target, {
       missingOk: false, label: 'lock de escrita do Vault', code,
     },
@@ -672,7 +696,8 @@ export function withVaultPathLock(vaultBase, path, fn, {
             });
             break;
           } catch (error) {
-            const retryableRenameRace = retryablePublicLockError(lock, error, code, {
+            // Shape check only; inspectVaultLock below re-observes through the full retry path.
+            const retryableRenameRace = publicLockRetryCandidate(lock, error, code, {
               allowRaw: false,
             });
             const nativeRenameCollision = vaultLockRenameCollision(error, pending, lock);

--- a/tests/fixtures/vault-lock-race-probe.mjs
+++ b/tests/fixtures/vault-lock-race-probe.mjs
@@ -78,8 +78,63 @@ async function ownerRead(code) {
   }
 }
 
+// Orçamento único: a operação falha de forma transiente e o walk fresco de reclassificação
+// sempre observa o componente estabilizado, então cada falha consome uma unidade do orçamento
+// até esgotá-lo. Chamadas ímpares são da operação; pares, da reclassificação.
 async function retryBudget() {
   const fx = fixture('wk-vault-lock-budget-');
+  deadOwner(fx, { lease: true });
+  const originalRealpath = fs.realpathSync.native;
+  const originalWait = Atomics.wait;
+  let injected = 0;
+  let waits = 0;
+  let calls = 0;
+  fs.realpathSync.native = function alternatingOwnerRealpath(path, ...args) {
+    if (resolve(path) === resolve(fx.owner)) {
+      calls += 1;
+      if (calls % 2 === 1) {
+        injected += 1;
+        const error = new Error('owner transitoriamente irresolvível');
+        error.code = 'ENOENT';
+        throw error;
+      }
+    }
+    return originalRealpath.call(this, path, ...args);
+  };
+  Atomics.wait = () => {
+    waits += 1;
+    return 'timed-out';
+  };
+  syncBuiltinESMExports();
+  const started = Date.now();
+  try {
+    const { withVaultPathLock } = await load('budget');
+    let errorCode = null;
+    let causeCode = null;
+    try {
+      withVaultPathLock(fx.vault, fx.target, () => 'não deve entrar', {
+        timeoutMs: 1000, staleMs: 0,
+      });
+    } catch (error) {
+      errorCode = error?.code || null;
+      causeCode = error?.cause?.code || null;
+    }
+    return {
+      injected, waits, errorCode, causeCode, elapsedMs: Date.now() - started,
+    };
+  } finally {
+    fs.realpathSync.native = originalRealpath;
+    Atomics.wait = originalWait;
+    syncBuiltinESMExports();
+    fs.rmSync(fx.vault, { recursive: true, force: true });
+  }
+}
+
+// Contraponto de retryBudget: quando o componente continua irresolvível no walk fresco, o estado
+// não estabilizou e a aquisição falha fechado já na primeira reclassificação, sem consumir o
+// orçamento inteiro.
+async function retryPersistent() {
+  const fx = fixture('wk-vault-lock-persistent-');
   deadOwner(fx, { lease: true });
   const originalRealpath = fs.realpathSync.native;
   const originalWait = Atomics.wait;
@@ -101,7 +156,7 @@ async function retryBudget() {
   syncBuiltinESMExports();
   const started = Date.now();
   try {
-    const { withVaultPathLock } = await load('budget');
+    const { withVaultPathLock } = await load('persistent');
     let errorCode = null;
     let causeCode = null;
     try {
@@ -156,6 +211,72 @@ async function releaseRace() {
     Atomics.wait = originalWait;
     syncBuiltinESMExports();
     fs.rmSync(fx.vault, { recursive: true, force: true });
+  }
+}
+
+// A remoção concorrente do lock público não reporta o mesmo errno em toda plataforma: o Windows
+// devolve UNKNOWN, EBADF ou EPERM onde o Linux devolve ENOENT. A reclassificação precisa derivar
+// de um walk fresco do componente, nunca do código de erro — e continuar recusando topologia
+// hostil observada nesse mesmo walk.
+async function acquirePlatformErrno(code, { hostileTopology = false } = {}) {
+  const fx = fixture(`wk-vault-lock-errno-${code.toLowerCase()}-`);
+  const outside = fs.mkdtempSync(join(tmpdir(), 'wk-vault-lock-errno-outside-'));
+  fs.mkdirSync(fx.lock, { recursive: true });
+  const originalRealpath = fs.realpathSync.native;
+  const originalWait = Atomics.wait;
+  let injected = 0;
+  let waits = 0;
+  let entered = false;
+  let linkSupported = true;
+  fs.realpathSync.native = function platformErrnoRealpath(path, ...args) {
+    if (resolve(String(path)) === resolve(fx.lock) && waits === 0) {
+      injected += 1;
+      const error = new Error(`resolução transiente ${code} simulada`);
+      error.code = code;
+      throw error;
+    }
+    return originalRealpath.call(this, path, ...args);
+  };
+  Atomics.wait = () => {
+    waits += 1;
+    // O owner concorrente libera o lock durante o backoff.
+    fs.rmSync(fx.lock, { recursive: true, force: true });
+    if (hostileTopology) {
+      // ...e o path reaparece como junction/symlink: o walk fresco deve recusar mesmo tendo
+      // sido disparado pelo mesmo errno transiente que autoriza o retry no caso benigno.
+      try {
+        fs.symlinkSync(outside, fx.lock, process.platform === 'win32' ? 'junction' : 'dir');
+      } catch (error) {
+        if (['EPERM', 'EACCES', 'ENOTSUP'].includes(error?.code)) linkSupported = false;
+        else throw error;
+      }
+    }
+    return 'timed-out';
+  };
+  syncBuiltinESMExports();
+  try {
+    const { withVaultPathLock } = await load(`errno-${code}-${hostileTopology ? 'hostile' : 'benign'}`);
+    let value = null;
+    let errorCode = null;
+    let message = '';
+    try {
+      value = withVaultPathLock(fx.vault, fx.target, () => {
+        entered = true;
+        return 'acquired';
+      }, { timeoutMs: 250, staleMs: 50 });
+    } catch (error) {
+      errorCode = error?.code || null;
+      message = error?.message || '';
+    }
+    return {
+      value, errorCode, message, entered, injected, waits, linkSupported,
+    };
+  } finally {
+    fs.realpathSync.native = originalRealpath;
+    Atomics.wait = originalWait;
+    syncBuiltinESMExports();
+    fs.rmSync(fx.vault, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
   }
 }
 
@@ -401,18 +522,28 @@ async function sharedRetryBudget() {
   let ownerInjected = 0;
   let waits = 0;
   let entered = false;
+  let publicCalls = 0;
+  let ownerCalls = 0;
+  // Cada checkpoint alterna falha da operação / walk fresco estabilizado, para que o orçamento
+  // seja de fato consumido e se possa observar que ele é único e compartilhado entre eles.
   fs.realpathSync.native = function sharedBudgetRealpath(path, ...args) {
     if (resolve(String(path)) === resolve(fx.lock) && publicInjected < 2) {
-      publicInjected += 1;
-      const error = new Error('lock público ENOENT transitório');
-      error.code = 'ENOENT';
-      throw error;
+      publicCalls += 1;
+      if (publicCalls % 2 === 1) {
+        publicInjected += 1;
+        const error = new Error('lock público ENOENT transitório');
+        error.code = 'ENOENT';
+        throw error;
+      }
     }
     if (resolve(String(path)) === resolve(fx.owner) && ownerInjected < 2) {
-      ownerInjected += 1;
-      const error = new Error('owner ENOENT transitório');
-      error.code = 'ENOENT';
-      throw error;
+      ownerCalls += 1;
+      if (ownerCalls % 2 === 1) {
+        ownerInjected += 1;
+        const error = new Error('owner ENOENT transitório');
+        error.code = 'ENOENT';
+        throw error;
+      }
     }
     return originalRealpath.call(this, path, ...args);
   };
@@ -494,7 +625,14 @@ try {
   if (scenario === 'owner-enoent') result = await ownerRead('ENOENT');
   else if (scenario === 'owner-eacces') result = await ownerRead('EACCES');
   else if (scenario === 'retry-budget') result = await retryBudget();
+  else if (scenario === 'retry-persistent') result = await retryPersistent();
   else if (scenario === 'release-enoent') result = await releaseRace();
+  else if (scenario === 'acquire-errno-unknown') result = await acquirePlatformErrno('UNKNOWN');
+  else if (scenario === 'acquire-errno-ebadf') result = await acquirePlatformErrno('EBADF');
+  else if (scenario === 'acquire-errno-eperm') result = await acquirePlatformErrno('EPERM');
+  else if (scenario === 'acquire-errno-hostile') {
+    result = await acquirePlatformErrno('EBADF', { hostileTopology: true });
+  }
   else if (scenario === 'rename-collision') result = await renameRace('NATIVE');
   else if (scenario === 'rename-eacces') result = await renameRace('EACCES');
   else if (scenario === 'rename-eperm-bad-dest') result = await renameRace('EPERM_BAD_DEST');

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -68,15 +68,16 @@ test('extractReleaseNotes: throws when the version is absent', () => {
   assert.throws(() => extractReleaseNotes(FIXTURE, '9.9.9'), /9\.9\.9/);
 });
 
-test('[sensor:release-tests] 0.68.0 notes are extractable and match the package', () => {
-  const release = extractReleaseNotes(CHANGELOG, '0.68.0');
-  assert.equal(PACKAGE.version, '0.68.0');
-  assert.equal(release.date, '2026-08-02');
-  assert.match(release.notes, /memory curate --vault/i);
-  assert.match(release.notes, /memory candidates --active/i);
-  assert.match(release.notes, /memory repair/i);
-  assert.match(release.notes, /doctor[\s\S]*formato humano/i);
-  assert.match(release.notes, /somente leitura/i);
+test('[sensor:release-tests] 0.68.1 notes are extractable and match the package', () => {
+  const release = extractReleaseNotes(CHANGELOG, '0.68.1');
+  assert.equal(PACKAGE.version, '0.68.1');
+  assert.equal(release.date, '2026-08-08');
+  assert.match(release.notes, /VAULT_PATH_UNSAFE/);
+  assert.match(release.notes, /walk fresco/i);
+  assert.match(release.notes, /UNKNOWN[\s\S]*EBADF[\s\S]*EPERM/);
+  assert.match(release.notes, /ENOENT/);
+  assert.match(release.notes, /FLOW_VAULT_BOUNDARY/);
+  assert.match(release.notes, /orçamento de retry permanece único/i);
   assert.doesNotMatch(release.notes, /019f[0-9a-f-]+/i);
 });
 

--- a/tests/vault-path-safety.test.mjs
+++ b/tests/vault-path-safety.test.mjs
@@ -228,10 +228,61 @@ test('[req:OP-7] retries de topologia compartilham orçamento global e terminam'
   assert.ok(result.elapsedMs < 500, `retry excedeu o limite: ${result.elapsedMs} ms`);
 });
 
+test('[req:OP-7] componente que não estabiliza falha fechado sem consumir o orçamento inteiro', () => {
+  const result = runVaultLockRaceProbe('retry-persistent', 2000);
+  // Contraponto do teste acima: lá o walk fresco estabiliza a cada rodada e o orçamento é gasto
+  // até o fim; aqui ele nunca estabiliza, então a aquisição desiste na primeira reclassificação.
+  assert.deepEqual({
+    injected: result.injected,
+    waits: result.waits,
+    errorCode: result.errorCode,
+    causeCode: result.causeCode,
+  }, {
+    injected: 2, waits: 1, errorCode: 'VAULT_PATH_UNSAFE', causeCode: 'ENOENT',
+  });
+  assert.ok(result.elapsedMs < 500, `retry excedeu o limite: ${result.elapsedMs} ms`);
+});
+
 test('[req:OP-7] release repete ENOENT transitório e não deixa lock público residual', () => {
   assert.deepEqual(runVaultLockRaceProbe('release-enoent'), {
     value: 'done', injected: 1, waits: 1, lockExists: false,
   });
+});
+
+test('[req:OP-7] liberação concorrente converge sob qualquer errno de plataforma, não só ENOENT', () => {
+  // O Windows reporta a remoção concorrente do lock como UNKNOWN, EBADF ou EPERM; o Linux, como
+  // ENOENT. Nenhum errno específico pode ser condição necessária para o retry.
+  for (const scenario of ['acquire-errno-unknown', 'acquire-errno-ebadf', 'acquire-errno-eperm']) {
+    const result = runVaultLockRaceProbe(scenario);
+    assert.deepEqual({
+      value: result.value,
+      errorCode: result.errorCode,
+      entered: result.entered,
+      injected: result.injected,
+      waits: result.waits,
+    }, {
+      value: 'acquired', errorCode: null, entered: true, injected: 1, waits: 1,
+    }, `${scenario} não convergiu: ${result.errorCode} ${result.message}`);
+  }
+});
+
+test('[req:OP-7] errno transitório não autoriza retry quando o walk fresco vê topologia hostil', (t) => {
+  const result = runVaultLockRaceProbe('acquire-errno-hostile');
+  if (!result.linkSupported) {
+    t.skip('links indisponíveis neste filesystem');
+    return;
+  }
+  // Mesmo errno, mesmo filtro estrutural e mesmo backoff do caso benigno acima — `waits: 1`
+  // prova que chegou até a reclassificação. O que diverge é só o estado visto no walk fresco,
+  // e a falha preserva o erro original em vez de trocar a superfície de erro do chamador.
+  assert.deepEqual({
+    value: result.value,
+    errorCode: result.errorCode,
+    entered: result.entered,
+    waits: result.waits,
+  }, {
+    value: null, errorCode: 'VAULT_PATH_UNSAFE', entered: false, waits: 1,
+  }, `topologia hostil não falhou fechado: ${result.message}`);
 });
 
 test('[req:OP-7] rename aceita colisão nativa, mas nunca converte EACCES em contenção', () => {

--- a/tests/vault-runtime-store.test.mjs
+++ b/tests/vault-runtime-store.test.mjs
@@ -452,7 +452,12 @@ test('[req:OP-7] lock de promoção rejeita raiz redirecionada antes de executar
 
     assert.throws(
       () => withFlowPromotionLock(vault, 'safe-slug', () => { called = true; }),
-      /Vault|link simbólico|junction|reparse|redirecion/i,
+      {
+        // Falha de fronteira no lock de promoção reporta o código do domínio, nunca o default
+        // físico: sem a propagação de `code`, isto seria VAULT_PATH_UNSAFE.
+        code: 'FLOW_VAULT_BOUNDARY',
+        message: /Vault|link simbólico|junction|reparse|redirecion/i,
+      },
     );
     assert.equal(called, false);
     assert.deepEqual(readdirSync(outside), ['sentinel.txt']);
@@ -493,12 +498,14 @@ test('[req:OP-7] store rejeita contract.json preexistente por hardlink', (t) => 
 });
 
 test('[req:OP-7] store valida fisicamente as raízes de sessão, FLOW e lock de estado', async (t) => {
+  // O código esperado separa as duas fronteiras: validação de raiz compartilhada reporta o
+  // default físico, enquanto a falha do lock do store de sessão reporta o código do domínio.
   const cases = [
-    ['session-root', (vault) => join(vault, '.brain', 'runtime', 'flows', 'session-1')],
-    ['flow-root', (vault) => join(vault, '.brain', 'runtime', 'flows', 'session-1', 'flow-1')],
-    ['state-lock', (vault) => join(vault, '.brain', 'runtime', 'flows', 'session-1', '.state.lock')],
+    ['session-root', (vault) => join(vault, '.brain', 'runtime', 'flows', 'session-1'), 'VAULT_PATH_UNSAFE'],
+    ['flow-root', (vault) => join(vault, '.brain', 'runtime', 'flows', 'session-1', 'flow-1'), 'VAULT_PATH_UNSAFE'],
+    ['state-lock', (vault) => join(vault, '.brain', 'runtime', 'flows', 'session-1', '.state.lock'), 'FLOW_VAULT_BOUNDARY'],
   ];
-  for (const [label, targetOf] of cases) {
+  for (const [label, targetOf, expectedCode] of cases) {
     await t.test(label, (subtest) => {
       const vault = mkdtempSync(join(tmpdir(), 'wk-flow-store-safe-layer-'));
       const outside = mkdtempSync(join(tmpdir(), 'wk-flow-store-layer-outside-'));
@@ -517,7 +524,10 @@ test('[req:OP-7] store valida fisicamente as raízes de sessão, FLOW e lock de 
         }
         assert.throws(
           () => createFlowContract(vault, contract('flow-1')),
-          /Vault|link simbólico|junction|reparse|redirecion/i,
+          {
+            code: expectedCode,
+            message: /Vault|link simbólico|junction|reparse|redirecion/i,
+          },
         );
         assert.deepEqual(readdirSync(outside), ['sentinel.txt']);
         assert.equal(readFileSync(join(outside, 'sentinel.txt'), 'utf8'), 'preservado\n');
@@ -554,7 +564,12 @@ test('[req:OP-7] lock de promoção rejeita owner preexistente por hardlink', (t
       () => withFlowPromotionLock(vault, 'safe-slug', () => { called = true; }, {
         timeoutMs: 50, ownerGraceMs: 0,
       }),
-      /hardlink|nlink|Vault/i,
+      {
+        // Esta falha nasce dentro de withVaultPathLock, na inspeção do owner — o caminho que
+        // aceitava o código de fronteira física default antes da propagação de `code`.
+        code: 'FLOW_VAULT_BOUNDARY',
+        message: /hardlink|nlink|Vault/i,
+      },
     );
     assert.equal(called, false);
     assert.equal(readFileSync(source, 'utf8'), original);


### PR DESCRIPTION
Corrige o flake intermitente do job `test (windows-latest, 22)`, observado duas vezes em CI separadas por nove dias e cinco releases ([run 30532122281](https://github.com/rogersialves/wendkeep/actions/runs/30532122281) em `main` 0.66.2, [run 31259465719](https://github.com/rogersialves/wendkeep/actions/runs/31259465719) no PR #38).

## Causa raiz

A guarda de retry transiente do lock público decidia comparando o errno da causa com `ENOENT`:

```js
const causeCode = error?.cause?.code || failure.causeCode;
return causeCode === 'ENOENT' && ...
```

No Windows, remover concorrentemente o diretório do lock faz `realpathSync.native` devolver `UNKNOWN`, `EBADF` ou `EPERM` — **nunca** `ENOENT`. A guarda era código morto naquela plataforma, o backoff nunca disparava, e o erro subia cru como `VAULT_PATH_UNSAFE`. O sintoma visível era o perdedor de uma promoção FLOW concorrente falhando com o código de fronteira física em vez de `FLOW_PROMOTION_CONFLICT`.

Repro dirigido com 8 processos, medindo a distribuição de causas em duas execuções independentes:

| Execução | UNKNOWN | EBADF | EPERM | ENOENT |
|---|---|---|---|---|
| baseline | 13 | 7 | 4 | **0** |
| controle | 6 | 8 | 2 | **0** |

OP-7 já exigia o comportamento correto — *"sem expor `VAULT_PATH_UNSAFE`"* — e já prescrevia a solução — *"somente um walk fresco estabilizado como sufixo ausente ou diretório canônico permite retry"*. A implementação nunca fez o walk; passava no Linux por coincidência de errno.

## O que muda

A classificação passa a ter dois estágios:

- **Filtro estrutural** (`publicLockRetryCandidate`) — forma do erro, sem I/O e sem errno.
- **Walk fresco** (`publicLockComponentSettled`) — decide, executado depois do backoff e dentro do deadline.

Nenhum errno foi adicionado a uma allowlist; eles deixaram de ser consultados. O errno virou apenas o gatilho para re-observar.

Junction, symlink, reparse point, componente redirecionado, tipo errado ou estado irresolvível persistente continuam falhando fechado. **O orçamento de retry permanece único e limitado por aquisição**, como o spec exige — reabastecê-lo foi testado e descartado por não alterar a distribuição de causas.

Secundário: `withFlowPromotionLock` e o store de sessão propagam `FLOW_VAULT_BOUNDARY`, alinhando a superfície de erro ao resto da saga de promoção.

## Prova

Repro dirigido, mesmos parâmetros de `withFlowPromotionLock`:

| | acquired | busy | `VAULT_PATH_UNSAFE` |
|---|---|---|---|
| antes | 286 | 10 | **24** |
| depois (3 rodadas) | 318–319 | 0–1 | **0** |

Verificação independente (autor ≠ verificador) rodou 8 mutações e aprovou. Um primeiro passe reprovou com gap real — um bullet novo do spec implementado sem teste que o discriminasse — corrigido antes da aprovação. Mutação confirma: removendo `code` dos call sites, 3 testes falham.

Suíte completa: 1388 testes, 1384 pass, 0 fail, 4 skipped.

## Fora de escopo

Resta um erro residual de 0,3% (`EPERM` no rename de publicação, quando o vencedor libera o lock antes da reinspeção). Causa raiz distinta, guarda deliberada e documentada no código, e corrigi-la afrouxa uma decisão de segurança em cenário ambíguo. Registrado como BUG-0014 no vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
