### PR TITLE
fix: allow manual OIDC release dispatch for 0.68.5

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - 'package.json'
       - 'CHANGELOG.md'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -21,6 +22,7 @@ permissions:
 
 jobs:
   tag-and-release:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -121,6 +121,15 @@ test('[sensor:release-tests] [req:CLI-PKG-3] publish precede a criação da tag 
   assert.doesNotMatch(AUTO_TAG_PUBLISH_GUARD, /npm publish[^\r\n]*--provenance/);
 });
 
+test('[sensor:release-tests] [req:CLI-PKG-3] dispatch manual só publica na main', () => {
+  const trigger = AUTO_TAG_WORKFLOW.match(/^on:\r?\n[\s\S]*?(?=^permissions:)/m)?.[0] || '';
+  assert.match(trigger, /^  workflow_dispatch:\s*$/m);
+  assert.match(
+    AUTO_TAG_WORKFLOW,
+    /^  tag-and-release:\r?\n    if:\s*github\.ref\s*==\s*['"]refs\/heads\/main['"]/m,
+  );
+});
+
 const releaseFacts = (overrides = {}) => ({
   name: 'wendkeep',
   version: '1.2.3',


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` to `auto-tag.yml` for recovery of the existing 0.68.5 commit.
- Restrict the release job to `github.ref == 'refs/heads/main'`.
- Add a regression test that discriminates both the manual trigger and the branch guard.

## Why

Commit `03d694d` already contains version 0.68.5 but includes `[skip ci]`, so the push trigger did not run. This PR adds the smallest safe recovery path without rewriting that commit, publishing locally, or introducing npm tokens.

## Validation

- `node --test --test-name-pattern "dispatch manual" tests/release-changelog.test.mjs`
- `npm test` — 1445 passed, 4 skipped, 0 failed
- `npm run check`
- `wendkeep verify --change npm-oidc-trusted-publishing`
- `wendkeep verify --deep --change npm-oidc-trusted-publishing`
- Independent `wk-verify` verdict recorded with fresh task/spec hashes

## Post-merge handoff

After merge, the maintainer should run `gh workflow run auto-tag.yml --ref main` and confirm npm 0.68.5, tag `v0.68.5`, the GitHub Release body, and npm provenance before closing the remaining change tasks. No self-merge is performed here.