### PR TITLE
fix: correct pnpm update guidance (0.68.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.68.6] — 2026-08-16
+
+### Fixed
+
+- **A orientação de atualização em monorepos pnpm agora resolve a versão publicada antes da
+  instalação.** README e guias bilíngues deixam de oferecer `X.Y.Z` como argumento copiável,
+  explicam o cooldown silencioso de `@latest` e orientam a regeneração segura do lock quando a
+  integridade do tarball divergir.
+
 ## [0.68.5] — 2026-08-14
 
 ### Fixed

--- a/README.en.md
+++ b/README.en.md
@@ -176,24 +176,37 @@ The install stays outside `sync` on purpose: a running process cannot replace it
 keep going — the code in memory would still be the old one.
 
 In a **pnpm** monorepo the install command differs (`npm` in a pnpm repo fails with
-`Cannot read properties of null (reading 'matches')`) and the version must be **exact**:
+`Cannot read properties of null (reading 'matches')`). Resolve the published version first and
+reuse exactly the value returned:
 
-```bash
-pnpm add -D -w wendkeep@X.Y.Z --config.minimumReleaseAge=0 && npx --no-install wendkeep sync --project . --yes
+```powershell
+$version = pnpm view wendkeep version
+pnpm add -D -w "wendkeep@$version" --config.minimumReleaseAge=0
+pnpm install --update-checksums --config.minimumReleaseAge=0
+pnpm exec wendkeep sync --project . --yes
 ```
 
 > **Do not ask pnpm for `wendkeep@latest`.** pnpm 11 ignores packages published in the last
 > 24h by default (`minimumReleaseAge`, a supply-chain guard) — and it does not complain: it
 > installs the previous version, exits 0, and the only hint is a quiet `(X.Y.Z is available)`
 > in the output. You end up on the old version thinking you upgraded. Check with
-> `npx wendkeep --version`.
+> `pnpm exec wendkeep --version`.
+>
+> Do not edit only the version or integrity in `pnpm-lock.yaml`. `pnpm add` and
+> `pnpm install --update-checksums` must recalculate the complete entry. If the lock is already
+> inconsistent and `ERR_PNPM_TARBALL_INTEGRITY` appears, prune the local store and repeat:
+>
+> ```powershell
+> pnpm store prune
+> pnpm install --update-checksums --config.minimumReleaseAge=0
+> ```
 >
 > After installing, record the exception in `pnpm-workspace.yaml` — **pnpm does not write
 > that line for you**:
 >
 > ```yaml
 > minimumReleaseAgeExclude:
->   - wendkeep@X.Y.Z
+>   - wendkeep@<the version returned by pnpm view>
 > ```
 >
 > Without it, CI's `pnpm install` fails with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` until

--- a/README.md
+++ b/README.md
@@ -173,24 +173,37 @@ O `install` fica de fora do `sync` de propósito: um processo não se auto-subst
 rodando — o código em execução continuaria sendo o antigo.
 
 Num monorepo **pnpm**, o comando de instalação é outro (`npm` num repositório pnpm falha com
-`Cannot read properties of null (reading 'matches')`) e a versão vai **exata**:
+`Cannot read properties of null (reading 'matches')`). Resolva a versão publicada primeiro e
+reutilize exatamente o valor retornado:
 
-```bash
-pnpm add -D -w wendkeep@X.Y.Z --config.minimumReleaseAge=0 && npx --no-install wendkeep sync --project . --yes
+```powershell
+$version = pnpm view wendkeep version
+pnpm add -D -w "wendkeep@$version" --config.minimumReleaseAge=0
+pnpm install --update-checksums --config.minimumReleaseAge=0
+pnpm exec wendkeep sync --project . --yes
 ```
 
 > **Não peça `wendkeep@latest` ao pnpm.** O pnpm 11 ignora por padrão pacote publicado nas
 > últimas 24h (`minimumReleaseAge`, proteção de supply-chain) — e não reclama: instala a
 > versão anterior, sai 0, e a única pista é um discreto `(X.Y.Z is available)` no meio da
 > saída. Você fica com a versão velha achando que atualizou. Confira com
-> `npx wendkeep --version`.
+> `pnpm exec wendkeep --version`.
+>
+> Não edite apenas a versão ou a integridade no `pnpm-lock.yaml`. O `pnpm add` e o
+> `pnpm install --update-checksums` devem recalcular a entrada inteira. Se o lock já estiver
+> inconsistente e aparecer `ERR_PNPM_TARBALL_INTEGRITY`, limpe o store local e repita a instalação:
+>
+> ```powershell
+> pnpm store prune
+> pnpm install --update-checksums --config.minimumReleaseAge=0
+> ```
 >
 > Depois de instalar, registre a exceção no `pnpm-workspace.yaml` — **o pnpm não escreve
 > essa linha por você**:
 >
 > ```yaml
 > minimumReleaseAgeExclude:
->   - wendkeep@X.Y.Z
+>   - wendkeep@<a versão retornada por pnpm view>
 > ```
 >
 > Sem ela, o `pnpm install` do CI falha com `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` até a

--- a/docs/en/commands/getting-started.md
+++ b/docs/en/commands/getting-started.md
@@ -60,13 +60,21 @@ npm install --save-dev wendkeep@latest
 npx wendkeep sync --yes
 ```
 
-With pnpm, pin a concrete version because minimum-release-age policies may keep `latest` silently
-behind:
+With pnpm, query the published version and reuse the returned value. Minimum-release-age policies
+may keep `latest` silently behind; in a monorepo, `-w` targets the workspace root:
 
-```bash
-pnpm add -D wendkeep@X.Y.Z --config.minimumReleaseAge=0
+```powershell
+$version = pnpm view wendkeep version
+pnpm add -D -w "wendkeep@$version" --config.minimumReleaseAge=0
+pnpm install --update-checksums --config.minimumReleaseAge=0
 pnpm exec wendkeep sync --yes
 ```
+
+Do not edit only the version or integrity in `pnpm-lock.yaml`. If
+`ERR_PNPM_TARBALL_INTEGRITY` appears after a manual edit, run `pnpm store prune` and repeat
+`pnpm install --update-checksums --config.minimumReleaseAge=0`. The
+`minimumReleaseAgeExclude` entry in `pnpm-workspace.yaml` is also manual and must use the
+version returned by `pnpm view`; pnpm does not write that line.
 
 ## Expected result
 

--- a/docs/pt-BR/commands/getting-started.md
+++ b/docs/pt-BR/commands/getting-started.md
@@ -60,13 +60,21 @@ npm install --save-dev wendkeep@latest
 npx wendkeep sync --yes
 ```
 
-Com pnpm, informe uma versão concreta porque políticas de idade mínima podem manter `latest`
-atrasado silenciosamente:
+Com pnpm, consulte a versão publicada e reutilize o valor retornado. Políticas de idade mínima
+podem manter `latest` atrasado silenciosamente; em um monorepo, `-w` aponta para o workspace raiz:
 
-```bash
-pnpm add -D wendkeep@X.Y.Z --config.minimumReleaseAge=0
+```powershell
+$version = pnpm view wendkeep version
+pnpm add -D -w "wendkeep@$version" --config.minimumReleaseAge=0
+pnpm install --update-checksums --config.minimumReleaseAge=0
 pnpm exec wendkeep sync --yes
 ```
+
+Não edite apenas a versão ou a integridade no `pnpm-lock.yaml`. Se aparecer
+`ERR_PNPM_TARBALL_INTEGRITY` depois de uma edição manual, rode `pnpm store prune` e repita
+`pnpm install --update-checksums --config.minimumReleaseAge=0`. A exceção
+`minimumReleaseAgeExclude` do `pnpm-workspace.yaml` também é manual e deve usar a versão
+retornada por `pnpm view`; o pnpm não escreve essa linha.
 
 ## Resultado esperado
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.68.5",
+  "version": "0.68.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.68.5",
+      "version": "0.68.6",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.68.5",
+  "version": "0.68.6",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [

--- a/tests/readme-packaging.test.mjs
+++ b/tests/readme-packaging.test.mjs
@@ -85,6 +85,28 @@ test('nenhum README manda instalar por pnpm com @latest', () => {
   }
 });
 
+test('a atualização por pnpm resolve e reinstala a versão publicada', () => {
+  const files = [
+    'README.md',
+    'README.en.md',
+    'docs/pt-BR/commands/getting-started.md',
+    'docs/en/commands/getting-started.md',
+  ];
+  for (const file of files) {
+    const text = readFileSync(join(ROOT, file), 'utf8');
+    assert.match(text, /pnpm view wendkeep version/, `${file} consulta a versão publicada`);
+    assert.match(text, /wendkeep@\$version/, `${file} reutiliza a versão consultada`);
+    assert.match(text, /pnpm add .*--config\.minimumReleaseAge=0/, `${file} desativa o cooldown só para a atualização`);
+    assert.match(text, /pnpm install --update-checksums --config\.minimumReleaseAge=0/, `${file} documenta a regeneração do lock`);
+    assert.match(text, /pnpm exec wendkeep sync/, `${file} executa o binário pelo pnpm`);
+    assert.doesNotMatch(
+      text,
+      /^pnpm add .*wendkeep@(?:latest|X\.Y\.Z).*$/m,
+      `${file} não pode deixar um argumento literal ou silenciosamente atrasado copiável`,
+    );
+  }
+});
+
 // O que realmente importa: o conteúdo do tarball, e o repo intacto depois.
 test('[req:OP-9] npm pack leva módulos de profile/FLOW, docs bilíngues e restaura o README', () => {
   const outDir = mkdtempSync(join(tmpdir(), 'wk-pack-'));

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -81,15 +81,14 @@ test('extractReleaseNotes: throws when the version is absent', () => {
   assert.throws(() => extractReleaseNotes(FIXTURE, '9.9.9'), /9\.9\.9/);
 });
 
-test('[sensor:release-tests] 0.68.5 notes are extractable and match the package', () => {
-  const release = extractReleaseNotes(CHANGELOG, '0.68.5');
-  assert.equal(PACKAGE.version, '0.68.5');
-  assert.equal(release.date, '2026-08-14');
-  assert.match(release.notes, /resultado durável/i);
-  assert.match(release.notes, /turn_aborted/i);
-  assert.match(release.notes, /append-only/i);
-  assert.match(release.notes, /publica no npm por OIDC/i);
-  assert.match(release.notes, /provenance/i);
+test('[sensor:release-tests] 0.68.6 notes are extractable and match the package', () => {
+  const release = extractReleaseNotes(CHANGELOG, '0.68.6');
+  assert.equal(PACKAGE.version, '0.68.6');
+  assert.equal(release.date, '2026-08-16');
+  assert.match(release.notes, /monorepos pnpm/i);
+  assert.match(release.notes, /X\.Y\.Z/);
+  assert.match(release.notes, /cooldown/i);
+  assert.match(release.notes, /integridade/i);
   assert.doesNotMatch(release.notes, /019f[0-9a-f-]+/i);
 });
 


### PR DESCRIPTION
## Summary

- resolve the published WendKeep version before a pnpm monorepo update
- document safe lockfile checksum regeneration and mirror the guidance in PT-BR and English
- prepare package metadata and changelog for `0.68.6`

## Why

pnpm's `minimumReleaseAge` can leave `@latest` silently behind the current published version,
while a literal `X.Y.Z` is not a safe copyable command. The guides now query the registry,
reuse the returned version, and regenerate the complete lock entry when tarball integrity
diverges.

## Validation

- No tests were run in this round, per user request.
- The working-tree scope was reviewed and `git diff --check` passed before commit.
- Earlier local WendKeep verification for this archived change was already completed before this
  release request.

## Release

After merge, the repository's `auto-tag-release` workflow will publish `0.68.6` to npm and
create/update tag `v0.68.6` and its GitHub Release from `CHANGELOG.md`.
