### PR TITLE
feat: shared project memory handoff (0.69.0)

### DIFF
--- a/.agents/skills/example-skill/.wendkeep-meta.json
+++ b/.agents/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.68.0",
+  "wendkeepVersion": "0.69.0",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.agents/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.agents/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.68.0",
+  "wendkeepVersion": "0.69.0",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.agents/skills/wk-debugging/.wendkeep-meta.json
+++ b/.agents/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.68.0",
+  "wendkeepVersion": "0.69.0",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.agents/skills/wk-planning/.wendkeep-meta.json
+++ b/.agents/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.68.0",
+  "wendkeepVersion": "0.69.0",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.agents/skills/wk-tdd/.wendkeep-meta.json
+++ b/.agents/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.68.0",
+  "wendkeepVersion": "0.69.0",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.agents/skills/wk-verify/.wendkeep-meta.json
+++ b/.agents/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.68.0",
+  "wendkeepVersion": "0.69.0",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.agents/skills/wk-workflow/.wendkeep-meta.json
+++ b/.agents/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.68.0",
+  "wendkeepVersion": "0.69.0",
   "sourceHash": "ee0cb172a5b5bbd2ebb5c7e4039ba1a9081992f0461da98d508a5cba67ab23db"
 }

--- a/.claude/skills/example-skill/.wendkeep-meta.json
+++ b/.claude/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.68.0",
+  "wendkeepVersion": "0.69.0",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.claude/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.claude/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.68.0",
+  "wendkeepVersion": "0.69.0",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.claude/skills/wk-debugging/.wendkeep-meta.json
+++ b/.claude/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.68.0",
+  "wendkeepVersion": "0.69.0",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.claude/skills/wk-planning/.wendkeep-meta.json
+++ b/.claude/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.68.0",
+  "wendkeepVersion": "0.69.0",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.claude/skills/wk-tdd/.wendkeep-meta.json
+++ b/.claude/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.68.0",
+  "wendkeepVersion": "0.69.0",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.claude/skills/wk-verify/.wendkeep-meta.json
+++ b/.claude/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.68.0",
+  "wendkeepVersion": "0.69.0",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.claude/skills/wk-workflow/.wendkeep-meta.json
+++ b/.claude/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.68.0",
+  "wendkeepVersion": "0.69.0",
   "sourceHash": "ee0cb172a5b5bbd2ebb5c7e4039ba1a9081992f0461da98d508a5cba67ab23db"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- wendkeep:skills:start -->
-<!-- wendkeep-version: 0.68.0; skills-sha256: d170f56e18f94318178d4062b722c40275d07c10e76021f95d16f441d498328d -->
+<!-- wendkeep-version: 0.69.0; skills-sha256: d170f56e18f94318178d4062b722c40275d07c10e76021f95d16f441d498328d -->
 ## wendkeep — Keep Core & operating profiles
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. **Keep Core is always active**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.69.0] — 2026-08-16
+
+### Added
+
+- **A Shared Project Memory v2 preserva handoffs estruturados entre providers.** Stop publica
+  objetivo, entrega, restrições, decisões, próximas ações, bloqueios e riscos com `work_session_id`;
+  CORE continua manual com cap 40/alerta 35, e status/validate-memory diagnosticam cobertura
+  semântica sem expor valores privados.
+
 ## [0.68.6] — 2026-08-16
 
 ### Fixed

--- a/README.en.md
+++ b/README.en.md
@@ -357,7 +357,9 @@ Codex uses `session_id`/`turn_id` plus transcript order, with no artificial caus
 
 ### Injection and budgets
 
-`brain-inject` delivers the same revision/hash on `startup`, `/clear`, and `/compact` `SessionStart` events, always placing CORE and SHARED before change context. The full envelope is capped at 24 KiB; CORE reserves up to 4 KiB, SHARED up to 6 KiB, and each line is capped at 320 characters. Under pressure, lessons are removed first, then non-current changes. CORE and SHARED are never prefix-sliced: a missing, invalid, or over-budget layer becomes a visible, repairable `<wk_memory_error>`.
+`CORE.md` is the only manual layer: it accepts up to 40 lines, warns from 35, keeps a 4 KiB ceiling, and caps each line at 320 characters. `SHARED_MEMORY.md` is generated exclusively by the projector and ledger; never edit it to repair state. `brain-inject` delivers the same revision/hash on `startup`, `/clear`, and `/compact` `SessionStart` events, always placing CORE and SHARED before change context. The full envelope is capped at 24 KiB; SHARED reserves up to 6 KiB. Under pressure, lessons are removed first, then non-current changes. CORE and SHARED are never prefix-sliced: a missing, invalid, or over-budget layer becomes a visible, repairable `<wk_memory_error>`.
+
+`memory status --gate` and `validate-memory --vault` also check semantic coverage: they report a code, counts, and active/projected/missing keys. An empty v2 bundle is neutral; a missing projectable event, placeholders as the only content, or an unresolved decision link becomes an explicit degraded/blocking diagnosis without printing memory values.
 
 `DIGEST.md` is no longer the operational handoff: it remains the `/brain-recall` bridge and legacy-vault fallback. A vault without SHARED receives CORE+DIGEST with a deprecation warning; migrate during the compatibility window:
 

--- a/README.md
+++ b/README.md
@@ -354,7 +354,9 @@ Lifecycle resumido: cada `SessionStart` abre um epoch que atravessa vários `Sto
 
 ### Injeção e budgets
 
-`brain-inject` entrega a mesma revision/hash no `SessionStart` de `startup`, `/clear` e `/compact`, sempre com CORE e SHARED antes do contexto da change. O envelope total tem 24 KiB; CORE reserva até 4 KiB, SHARED até 6 KiB e cada linha até 320 caracteres. Sob pressão, lessons saem primeiro e depois changes não atuais. CORE e SHARED nunca sofrem corte de prefixo: uma camada ausente, inválida ou acima do budget vira um `<wk_memory_error>` visível e reparável.
+`CORE.md` é a única camada manual: aceita até 40 linhas, alerta a partir de 35, mantém o teto de 4 KiB e limita cada linha a 320 caracteres. `SHARED_MEMORY.md` é exclusivamente gerado pelo projector e pelo ledger; nunca o edite para corrigir o estado. `brain-inject` entrega a mesma revision/hash no `SessionStart` de `startup`, `/clear` e `/compact`, sempre com CORE e SHARED antes do contexto da change. O envelope total tem 24 KiB e SHARED reserva até 6 KiB. Sob pressão, lessons saem primeiro e depois changes não atuais. CORE e SHARED nunca sofrem corte de prefixo: uma camada ausente, inválida ou acima do budget vira um `<wk_memory_error>` visível e reparável.
+
+`memory status --gate` e `validate-memory --vault` também verificam a cobertura semântica: reportam um código, contagens e chaves ativas/projetadas/ausentes. Bundle v2 vazio é neutro; evento projetável ausente, placeholders como único conteúdo ou decisão sem link resolvido bloqueiam/degradam de forma explícita, sem imprimir valores da memória.
 
 `DIGEST.md` não é mais o handoff operacional: permanece como ponte para `/brain-recall` e fallback de vault legado. Um vault sem SHARED recebe CORE+DIGEST com aviso de depreciação; migre durante a janela de compatibilidade:
 

--- a/docs/en/commands/memory.md
+++ b/docs/en/commands/memory.md
@@ -7,6 +7,10 @@
 Inspect and curate CORE, SHARED, ledger, outbox, attempts, and candidates without confusing
 canonical authorship with generated operational state.
 
+`CORE.md` is the only manual, canonical layer: it accepts up to 40 lines, warns from 35,
+keeps a 4 KiB ceiling, and caps each line at 320 characters. `SHARED_MEMORY.md` is generated
+from the ledger and must not be hand-edited.
+
 ## When to use
 
 Use in CI, before verify/archive, after doctor warnings, or when deciding candidates.
@@ -115,7 +119,12 @@ npx wendkeep validate-memory --vault <v2-vault>
   different, incomplete, or ambiguous identity keeps the candidate queued for curation. `memory
   repair` compares the old and current replay and migrates checkpoint+mirror only with exact
   identity, backup, audit, and CAS; it does not reorder, rewrite, or append a ledger event.
-- `validate-memory <CORE.md>` checks the 25-line cap, required sections, and secrets.
+- `validate-memory <CORE.md>` checks the hard 40-line cap, warns from 35, enforces 4 KiB and
+  320 characters per line, and checks required sections and secrets/PII.
+- `validate-memory --vault` also compares semantic ledger coverage with SHARED and prints a code,
+  counts, and active/projected/missing keys. An empty v2 bundle is neutral; a missing projectable
+  event, exclusive placeholders, or a dead decision link produces a degraded/blocking diagnosis
+  without exposing values.
 - `validate-memory --vault` requires a complete v2 bundle and is not the legacy-vault gate.
 - For `recover-attempt`, exit `0` means a valid dry run/apply, including `unchanged`; exit `1`
   means a precondition, authority, CAS, topology, or lock check failed; exit `2` means a missing

--- a/docs/pt-BR/commands/memory.md
+++ b/docs/pt-BR/commands/memory.md
@@ -7,6 +7,10 @@
 Inspecionar e curar CORE, SHARED, ledger, outbox, attempts e candidates sem confundir autoria
 canônica com estado operacional gerado.
 
+`CORE.md` é a única camada manual e canônica: aceita até 40 linhas, alerta a partir de 35,
+mantém o teto de 4 KiB e limita cada linha a 320 caracteres. `SHARED_MEMORY.md` é uma projeção
+gerada pelo ledger e não deve ser editado à mão.
+
 ## Quando usar
 
 Use no CI, antes de verify/archive, diante de avisos do doctor ou para decidir candidates.
@@ -113,7 +117,12 @@ npx wendkeep validate-memory --vault <cofre-v2>
   divergente, incompleta ou ambígua mantém o candidate para curadoria. `memory repair` compara o
   replay anterior e o atual e só migra checkpoint+espelho com identidade exata, backup, audit e
   CAS; ele não reordena, reescreve nem acrescenta evento ao ledger.
-- `validate-memory <CORE.md>` valida cap de 25 linhas, seções e segredos.
+- `validate-memory <CORE.md>` valida cap rígido de 40 linhas, alerta em 35, 4 KiB, 320 caracteres
+  por linha, seções e segredos/PII.
+- `validate-memory --vault` também compara a cobertura semântica do ledger com SHARED e imprime
+  código, contagens e chaves ativas/projetadas/ausentes. Bundle v2 vazio é neutro; evento
+  projetável ausente, placeholders exclusivos ou link de decisão morto geram diagnóstico
+  degradado/bloqueante sem expor valores.
 - `validate-memory --vault` exige bundle v2 completo; não é o gate correto para vault legado.
 - Para `recover-attempt`, exit `0` indica dry-run/apply válido, inclusive `unchanged`; exit `1`
   indica falha de pré-condição, autoridade, CAS, topologia ou lock; exit `2` indica

--- a/hooks/brain-core.mjs
+++ b/hooks/brain-core.mjs
@@ -4,6 +4,7 @@ import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { ensureDir, stripYamlQuotes, toVaultRelative } from './obsidian-common.mjs';
 import { getLocale } from './locale.mjs';
+import { sanitizeMemoryText } from './memory-schema.mjs';
 
 export function brainDir(vaultBase) {
   return join(vaultBase, '.brain');
@@ -104,6 +105,41 @@ function adrNumber(path) {
   return m ? Number(m[1]) : -1;
 }
 
+function decisionTitle(content, path) {
+  const frontmatter = parseFrontmatter(content);
+  const heading = content.match(/^#\s+(.+?)\s*$/m)?.[1] || '';
+  const raw = frontmatter.title || frontmatter.name || heading;
+  if (!raw) return '';
+  const title = sanitizeMemoryText(String(raw)
+    .replace(/^ADR-\d+\s*(?:[-:—]\s*)?/i, '')
+    .replace(/\s+/g, ' ')
+    .trim());
+  return title.slice(0, 180).trim();
+}
+
+function decisionNotes(vaultBase) {
+  const byPath = new Map();
+  const byBasename = new Map();
+  const decisionsDir = join(vaultBase, getLocale(vaultBase).folders.decisions);
+  for (const filePath of walkMd(decisionsDir)) {
+    let content;
+    try { content = readFileSync(filePath, 'utf8'); } catch { continue; }
+    const rel = toVaultRelative(vaultBase, filePath).replace(/\.md$/i, '');
+    const note = { path: rel, title: decisionTitle(content, rel) };
+    byPath.set(rel, note);
+    const key = basename(rel);
+    if (!byBasename.has(key)) byBasename.set(key, note);
+  }
+  return { byPath, byBasename };
+}
+
+function resolveDecisionTarget(target, notes) {
+  const normalized = String(target || '').replace(/\.md$/i, '').trim();
+  if (!normalized || normalized.includes('...') || normalized.includes('…')) return null;
+  const note = notes.byPath.get(normalized) || notes.byBasename.get(basename(normalized));
+  return note?.title ? note : null;
+}
+
 // Destila index.jsonl em .brain/DIGEST.md (camada quente, determinístico, 0 token LLM).
 // Cap por construção: 1 header + 13 itens (5/4/2/2) + 1 pointer = máx 15 linhas.
 export function buildBrainDigest(vaultBase, rows = null) {
@@ -139,13 +175,21 @@ export function buildBrainDigest(vaultBase, rows = null) {
   };
   const pickLive = (kind, max) => pick(kind, max * 4).filter(resolves).slice(0, max);
 
-  const decisions = pickLive('decisions', DIGEST_CAPS.decisions).sort((a, b) => adrNumber(b) - adrNumber(a));
+  const notes = decisionNotes(vaultBase);
+  const decisions = [];
+  for (const target of pick('decisions', DIGEST_CAPS.decisions * 4)) {
+    const resolved = resolveDecisionTarget(target, notes);
+    if (!resolved || decisions.some((item) => item.path === resolved.path)) continue;
+    decisions.push(resolved);
+    if (decisions.length >= DIGEST_CAPS.decisions) break;
+  }
+  decisions.sort((a, b) => adrNumber(b.path) - adrNumber(a.path));
   const sessions = byDateDesc.slice(0, DIGEST_CAPS.sessions);
   const bugs = pickLive('bugs', DIGEST_CAPS.bugs);
   const learnings = pickLive('learnings', DIGEST_CAPS.learnings);
 
   const lines = ['<!-- AUTO-GERADO por brain-core.mjs (0 token LLM). NÃO editar. Rebuild: node .agent/hooks/brain-reindex.mjs -->'];
-  for (const d of decisions) lines.push(`- Decisão: [[${d}]]`);
+  for (const d of decisions) lines.push(`- Decisão: [[${d.path}]] — ${d.title}`);
   for (const s of sessions) lines.push(`- Sessão ${s.date} (${s.provider || '?'}): ${s.summary || s.file} → [[${String(s.file || '').replace(/\.md$/, '')}]]`);
   for (const b of bugs) lines.push(`- Bug: [[${b}]]`);
   for (const l of learnings) lines.push(`- Aprendizado: [[${l}]]`);

--- a/hooks/brain-inject.mjs
+++ b/hooks/brain-inject.mjs
@@ -19,7 +19,7 @@ import {
   resolveHookOperatingProfile,
 } from './operating-profile-runtime.mjs';
 import { assertVaultPathSafe } from './vault-path-safety.mjs';
-import { validateCore } from '../src/validate-core.mjs';
+import { CORE_LIMITS, validateCore } from '../src/validate-core.mjs';
 
 // The process ROUTER — the enforcement layer. The wk-* skills are passive files; without a
 // standing instruction the model plans in chat, leaves the change scaffold raw and forces the
@@ -52,8 +52,8 @@ function processRouter(localeId) {
 
 const INJECTION_LIMITS = Object.freeze({
   totalBytes: 24 * 1024,
-  lineChars: 320,
-  coreBytes: 4 * 1024,
+  lineChars: CORE_LIMITS.lineChars,
+  coreBytes: CORE_LIMITS.bytes,
   sharedBytes: 6 * 1024,
   attentionBytes: 1024,
   recallBytes: 512,

--- a/hooks/session-ensure.mjs
+++ b/hooks/session-ensure.mjs
@@ -36,9 +36,27 @@ import { resolveSessionIdentity } from './session-identity.mjs';
 import { readCodexRolloutMeta } from './codex-rollout-meta.mjs';
 import { mutateSessionNote } from './session-note-io.mjs';
 import { captureProjectScope, projectScopePatch } from './project-scope.mjs';
+import { sanitizeMemoryText } from './memory-schema.mjs';
 
 function sessionIdFromInput(input) {
   return input.session_id || input.sessionId || input.codex_session_id || '';
+}
+
+function workSessionIdFromInput(input = {}) {
+  const shared = input.shared || input.handoff?.shared;
+  const value = input.work_session_id
+    || input.workSessionId
+    || shared?.work_session_id
+    || shared?.workSessionId
+    || input.handoff?.work_session_id
+    || input.handoff?.workSessionId
+    || '';
+  return sanitizeMemoryText(value).trim();
+}
+
+function workSessionPatch(input = {}) {
+  const workSessionId = workSessionIdFromInput(input);
+  return workSessionId ? { work_session_id: workSessionId } : {};
 }
 
 function turnSequenceFromInput(input = {}) {
@@ -290,6 +308,7 @@ function activateExistingSession({ vaultBase, relPath, startedAt, sessionId, inp
     transcript_path: identity.transcriptPath,
     transcript_id: identity.transcriptId,
     provider: identity.provider,
+    ...workSessionPatch(input),
     ...scopePatch,
     ...causalTurnPatch(input, now),
   });
@@ -318,6 +337,7 @@ function createSession({ vaultBase, sessionId, input, now, identity, scopePatch 
     transcript_path: identity.transcriptPath,
     transcript_id: identity.transcriptId,
     provider: identity.provider,
+    ...workSessionPatch(input),
     ...scopePatch,
     ...causalTurnPatch(input, now),
   });
@@ -361,6 +381,7 @@ function main() {
       upsertSessionRegistry(vaultBase, sessionId, {
         transcript_paths: [identity.transcriptPath],
         provider: identity.provider,
+        ...workSessionPatch(input),
       });
     }
     writeHookOutput({});
@@ -398,6 +419,7 @@ function main() {
           transcript_path: identity.transcriptPath,
           transcript_id: identity.transcriptId,
           provider: identity.provider,
+          ...workSessionPatch(input),
           ...scopePatch,
           ...causalTurnPatch(input, now),
         });
@@ -443,6 +465,7 @@ function main() {
         transcript_path: identity.transcriptPath,
         transcript_id: identity.transcriptId,
         provider: identity.provider,
+        ...workSessionPatch(input),
         ...scopePatch,
         ...causalTurnPatch(input, now),
       });

--- a/hooks/session-identity.mjs
+++ b/hooks/session-identity.mjs
@@ -65,8 +65,10 @@ export function resolveSessionIdentity(vaultBase, input = {}, provider = detectP
 export function resolveSessionEntry(vaultBase, input = {}, provider = detectProvider()) {
   const identity = resolveSessionIdentity(vaultBase, input, provider);
   if (identity.state !== 'resolved') return { identity, entry: null };
+  const entry = readSessionRegistry(vaultBase).sessions?.[identity.canonicalConversationId] || null;
+  const workSessionId = entry?.work_session_id ? String(entry.work_session_id) : '';
   return {
-    identity,
-    entry: readSessionRegistry(vaultBase).sessions?.[identity.canonicalConversationId] || null,
+    identity: workSessionId ? { ...identity, work_session_id: workSessionId } : identity,
+    entry,
   };
 }

--- a/hooks/session-stop.mjs
+++ b/hooks/session-stop.mjs
@@ -521,6 +521,21 @@ function shouldFinalizeSession() {
   return process.env.OBSIDIAN_NO_AUTO_FINALIZE !== '1';
 }
 
+function sharedHandoffFromInput(input = {}, entry = {}) {
+  const supplied = input.shared || input.handoff?.shared;
+  const shared = supplied && typeof supplied === 'object' && !Array.isArray(supplied)
+    ? { ...supplied }
+    : {};
+  const workSessionId = shared.work_session_id
+    || shared.workSessionId
+    || input.work_session_id
+    || input.workSessionId
+    || entry?.work_session_id
+    || '';
+  if (!shared.work_session_id && workSessionId) shared.work_session_id = workSessionId;
+  return Object.keys(shared).length ? shared : null;
+}
+
 export function commitSessionMemory(vaultBase, handoff, { projectOptions = {} } = {}) {
   if (detectMemoryMode(vaultBase).mode === 'legacy') {
     return { status: 'legacy', eventCount: 0, eventIds: [], checkpoint: null };
@@ -1378,6 +1393,7 @@ export async function main({
       summary: finalSummary,
       noteRel: sessionRel,
     });
+    const sharedHandoff = sharedHandoffFromInput(input, entry);
     memoryHandoff = {
       projectId,
       identity,
@@ -1390,6 +1406,7 @@ export async function main({
       observedAt: turnIdentity.observedAt || new Date(0).toISOString(),
       summary: finalSummary,
       evidence: memoryEvidence,
+      ...(sharedHandoff ? { shared: sharedHandoff } : {}),
     };
     memoryAttempt = stageMemory(vaultBase, {
       handoff: memoryHandoff,

--- a/hooks/vault-health.mjs
+++ b/hooks/vault-health.mjs
@@ -231,6 +231,12 @@ function memoryMetrics() {
     pendingOutbox: 0,
     candidates: 0,
     activeConflicts: 0,
+    semanticStatus: null,
+    semanticCode: null,
+    semanticActiveKeys: [],
+    semanticProjectedKeys: [],
+    semanticMissingKeys: [],
+    semanticCounts: {},
   };
 }
 
@@ -505,6 +511,7 @@ export function checkMemoryBundle(vaultBase, { registry } = {}) {
   for (const warning of bundle.warnings || []) warnings.push(warning);
 
   const ok = failures.length === 0;
+  const semantic = bundle.semantic || {};
   return {
     ok,
     status: ok ? (warnings.length ? 'warning' : 'healthy') : 'blocked',
@@ -519,6 +526,12 @@ export function checkMemoryBundle(vaultBase, { registry } = {}) {
       pendingOutbox: outbox.count,
       candidates: candidates.items.length,
       activeConflicts: activeConflicts.length,
+      semanticStatus: semantic.status ?? null,
+      semanticCode: semantic.code ?? null,
+      semanticActiveKeys: semantic.activeKeys || [],
+      semanticProjectedKeys: semantic.projectedKeys || [],
+      semanticMissingKeys: semantic.missingKeys || [],
+      semanticCounts: semantic.counts || {},
     },
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.68.6",
+  "version": "0.69.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.68.6",
+      "version": "0.69.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "acorn": "^8.18.0",
-        "wendkeep": "^0.68.0"
+        "wendkeep": "^0.68.6"
       },
       "engines": {
         "node": ">=18"
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/wendkeep": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/wendkeep/-/wendkeep-0.68.0.tgz",
-      "integrity": "sha512-83sYM5nEW6TPKW+OC4Wm8vfMdxRtiLeheuY6ifGm4O+SqAFjkCm8TQTTlP7Am0iBSq+lCAfA+9njooVAJscntg==",
+      "version": "0.68.6",
+      "resolved": "https://registry.npmjs.org/wendkeep/-/wendkeep-0.68.6.tgz",
+      "integrity": "sha512-N60A9qOgYAITph0VZIipNUenIhDJilZ8QhSLTZhPNKSuYmLfG+M19wHAbFXXES4omUZIQbKaiF4rYWQQMlC4Zw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.68.6",
+  "version": "0.69.0",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [
@@ -70,6 +70,6 @@
   },
   "devDependencies": {
     "acorn": "^8.18.0",
-    "wendkeep": "^0.68.0"
+    "wendkeep": "^0.68.6"
   }
 }

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -107,7 +107,7 @@ Usage:
                            promote <candidate> [--event <event-id>] | reject <candidate>. --vault P.
                            Reconcile is dry-run by default; the original attempt remains audited.
   wendkeep validate-memory [path]  Validate .brain/CORE.md against the compaction
-                           protocol (cap 25, 3 sections, no secrets/PII).
+                           protocol (cap 40, warning 35, 4 KiB, 320 chars/line, 3 sections, no secrets/PII).
                            --vault <path> validates the complete v2 bundle.
   wendkeep sync-defs [opts]    Copy versioned defs from the vault's .brain into the
                            project: .brain/agents/*.toml -> .codex/agents,

--- a/packages/vault/src/memory-handoff.mjs
+++ b/packages/vault/src/memory-handoff.mjs
@@ -4,10 +4,53 @@ import { basename, join, relative } from 'node:path';
 
 import { sanitizeMemoryText } from './memory-schema.mjs';
 
+const SHARED_HANDOFF_FIELDS = Object.freeze([
+  ['objective', 'objective.current'],
+  ['delivered', 'state.delivered'],
+  ['constraints', 'constraint.active'],
+  ['decisions', 'decision.active'],
+  ['next_actions', 'next.action'],
+  ['blockers', 'blocker.active'],
+  ['risks', 'risk.known'],
+]);
+
 function canonicalValue(value) {
   if (Array.isArray(value)) return value.map(canonicalValue);
   if (!value || typeof value !== 'object') return value;
   return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonicalValue(value[key])]));
+}
+
+function sanitizeValue(value) {
+  if (typeof value === 'string') return sanitizeMemoryText(value);
+  if (Array.isArray(value)) return value.map(sanitizeValue);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, sanitizeValue(value[key])]));
+  }
+  return value;
+}
+
+function hasMeaningfulValue(value) {
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (value && typeof value === 'object') return Object.keys(value).length > 0;
+  return value !== undefined && value !== null;
+}
+
+/** Normalize the portable operational handoff without inventing missing identity. */
+export function normalizeSharedHandoff(shared) {
+  if (!shared || typeof shared !== 'object' || Array.isArray(shared)) return null;
+
+  const normalized = {};
+  const workSessionId = sanitizeMemoryText(shared.work_session_id ?? shared.workSessionId ?? '').trim();
+  if (workSessionId) normalized.work_session_id = workSessionId;
+
+  for (const [field] of SHARED_HANDOFF_FIELDS) {
+    if (!Object.hasOwn(shared, field)) continue;
+    const value = sanitizeValue(shared[field]);
+    if (hasMeaningfulValue(value)) normalized[field] = value;
+  }
+
+  return Object.keys(normalized).length ? normalized : null;
 }
 
 function eventId(context, memoryKey, value) {
@@ -26,8 +69,8 @@ function eventId(context, memoryKey, value) {
 }
 
 function makeEvent(context, { memoryKey, value, authority, evidence }) {
-  const cleanValue = typeof value === 'string' ? sanitizeMemoryText(value) : canonicalValue(value);
-  return {
+  const cleanValue = sanitizeValue(value);
+  const event = {
     v: 1,
     event_id: eventId(context, memoryKey, cleanValue),
     project_id: String(context.projectId || ''),
@@ -43,6 +86,8 @@ function makeEvent(context, { memoryKey, value, authority, evidence }) {
     observed_at: context.observedAt,
     evidence: (evidence || []).filter(Boolean).map((item) => sanitizeMemoryText(item)),
   };
+  if (context.workSessionId) event.work_session_id = context.workSessionId;
+  return event;
 }
 
 function readJson(path) {
@@ -133,14 +178,35 @@ export function buildSessionMemoryEvents({
   observedAt,
   summary,
   evidence = {},
+  shared,
 }) {
-  const context = { projectId, identity, activation, turn, observedAt };
-  const events = [makeEvent(context, {
-    memoryKey: 'handoff.latest',
-    value: sanitizeMemoryText(summary),
-    authority: 'reported',
-    evidence: [noteRel],
-  })];
+  const normalizedShared = normalizeSharedHandoff(shared);
+  const context = {
+    projectId, identity, activation, turn, observedAt,
+    workSessionId: normalizedShared?.work_session_id || '',
+  };
+  const events = [];
+
+  if (normalizedShared) {
+    for (const [field, memoryKey] of SHARED_HANDOFF_FIELDS) {
+      if (!Object.hasOwn(normalizedShared, field)) continue;
+      events.push(makeEvent(context, {
+        memoryKey,
+        value: normalizedShared[field],
+        authority: 'reported',
+        evidence: [noteRel],
+      }));
+    }
+  }
+
+  if (!events.length) {
+    events.push(makeEvent(context, {
+      memoryKey: 'handoff.latest',
+      value: sanitizeMemoryText(summary),
+      authority: 'reported',
+      evidence: [noteRel],
+    }));
+  }
 
   if (evidence.change?.slug && evidence.change?.status && evidence.change?.adr) {
     events.push(makeEvent(context, {

--- a/packages/vault/src/memory-store.mjs
+++ b/packages/vault/src/memory-store.mjs
@@ -437,6 +437,29 @@ function conflictCandidate(memoryKey, events, currentEvent = null) {
   };
 }
 
+function conflictReviewEvent(candidate, candidateCount = 1) {
+  const source = candidate.events?.[0] || {};
+  const memoryKey = sanitizeMemoryText(candidate.memory_key || 'unknown');
+  const eventCount = Array.isArray(candidate.event_ids) ? candidate.event_ids.length : 0;
+  return {
+    v: 1,
+    event_id: `mem-review-${candidate.candidate_id}`,
+    project_id: source.project_id || '',
+    memory_key: candidate.memory_key,
+    operation: 'assert',
+    value: `[revisão pendente: ${memoryKey}; candidates: ${candidateCount}; events: ${eventCount}]`,
+    authority: 'candidate',
+    canonical_session_id: source.canonical_session_id || 'memory-reducer',
+    activation_id: source.activation_id || 'memory-reducer',
+    activation_epoch: Number.isInteger(source.activation_epoch) ? source.activation_epoch : 0,
+    turn_sequence: 0,
+    source_turn_id: 'memory-review',
+    observed_at: source.observed_at || new Date(0).toISOString(),
+    evidence: ['MEMORY_CANDIDATES.jsonl'],
+    review_pending: true,
+  };
+}
+
 function sortedObject(entries) {
   return Object.fromEntries([...entries].sort(([left], [right]) => left.localeCompare(right)));
 }
@@ -753,14 +776,19 @@ export function reduceMemoryEvents(inputEvents = [], {
       && !resolvedCandidateIds.has(item.candidate_id));
   unresolvedCandidates.sort((left, right) => left.candidate_id.localeCompare(right.candidate_id));
   superseded.sort((left, right) => left.event_id.localeCompare(right.event_id));
-  const activeEvents = Object.entries(recordObject).map(([memoryKey, record]) => ({
-    ...record.source,
-    memory_key: memoryKey,
-    operation: 'assert',
-    value: record.value,
-  }));
   const eventCursor = events.at(-1)?.event_id || 'none';
   const stateHash = hashMemoryValue({ state, tombstones: tombstoneObject });
+  const activeEvents = [
+    ...Object.entries(recordObject).map(([memoryKey, record]) => ({
+      ...record.source,
+      memory_key: memoryKey,
+      operation: 'assert',
+      value: record.value,
+    })),
+    ...unresolvedCandidates.map((candidate) => (
+      conflictReviewEvent(candidate, unresolvedCandidates.length)
+    )),
+  ];
 
   return {
     state,

--- a/packages/vault/src/validate-core.mjs
+++ b/packages/vault/src/validate-core.mjs
@@ -1,6 +1,7 @@
 // Memory-compaction protocol for the curated .brain/CORE.md layer.
 // Ported from NutriGym-Vision's scripts/validate-brain-core.js to ESM:
-//   - cap 25 lines (hard), 22 (soft warning) — 1 durable item per line
+//   - cap 40 lines (hard), 35 (soft warning) — 1 durable item per line
+//   - 4 KiB and 320 characters per line
 //   - 3 required sections
 //   - no secrets / no real-provider PII emails
 // Plus the seeded skeleton and the protocol reference doc.
@@ -8,8 +9,12 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { isAbsolute, join, resolve } from 'node:path';
 
-const HARD_LIMIT = 25;
-const SOFT_LIMIT = 22;
+export const CORE_LIMITS = Object.freeze({
+  lines: 40,
+  warningLines: 35,
+  bytes: 4 * 1024,
+  lineChars: 320,
+});
 
 // Bilingual (0.8.0): a CORE is valid when it carries the COMPLETE section set of either
 // locale — pt-BR or en. Mixed/partial sets fail (the 3 sections are one contract).
@@ -40,16 +45,25 @@ const SECRET_PATTERNS = [
 
 const PII_EMAIL_REGEX = /\b[A-Za-z0-9._%+-]+@(?!example\.(?:com|org|net)\b)(?:gmail|hotmail|yahoo|outlook|live|icloud|protonmail)\.[A-Za-z]{2,}\b/i;
 
-// Validate CORE.md content. Returns { ok, errors, warnings, lineCount }.
+// Validate CORE.md content. Returns { ok, errors, warnings, lineCount, byteCount }.
 export function validateCore(content) {
   const text = String(content ?? '');
   const lines = text.split('\n');
   const lineCount = text.endsWith('\n') ? lines.length - 1 : lines.length;
+  const byteCount = Buffer.byteLength(text, 'utf8');
   const errors = [];
 
-  if (lineCount > HARD_LIMIT) {
-    errors.push(`Tamanho ${lineCount} > ${HARD_LIMIT} linhas (hard limit). Curar: remover itens resolvidos (detalhe vive no vault/git).`);
+  if (lineCount > CORE_LIMITS.lines) {
+    errors.push(`Tamanho ${lineCount} > ${CORE_LIMITS.lines} linhas (hard limit). Curar: remover itens resolvidos (detalhe vive no vault/git).`);
   }
+  if (byteCount > CORE_LIMITS.bytes) {
+    errors.push(`Tamanho ${byteCount} > ${CORE_LIMITS.bytes} bytes (budget do CORE). Curar: manter apenas estado durável.`);
+  }
+  lines.forEach((line, index) => {
+    if (line.length > CORE_LIMITS.lineChars) {
+      errors.push(`Linha ${index + 1} tem ${line.length} caracteres; limite ${CORE_LIMITS.lineChars}.`);
+    }
+  });
   // Pick the locale set that matches best; require it to be complete.
   const missingBySet = Object.values(SECTION_SETS).map((set) => set.filter(({ regex }) => !regex.test(text)));
   const best = missingBySet.reduce((a, b) => (b.length < a.length ? b : a));
@@ -62,11 +76,11 @@ export function validateCore(content) {
   if (em) errors.push(`Email real detectado: "${em[0]}" — usar user@example.com.`);
 
   const warnings = [];
-  if (lineCount >= SOFT_LIMIT && lineCount <= HARD_LIMIT) {
-    warnings.push(`Tamanho ${lineCount}/${HARD_LIMIT} linhas — perto do limite; remover itens resolvidos (≥${SOFT_LIMIT}).`);
+  if (lineCount >= CORE_LIMITS.warningLines && lineCount <= CORE_LIMITS.lines) {
+    warnings.push(`Tamanho ${lineCount}/${CORE_LIMITS.lines} linhas — perto do limite; remover itens resolvidos (≥${CORE_LIMITS.warningLines}).`);
   }
 
-  return { ok: errors.length === 0, errors, warnings, lineCount };
+  return { ok: errors.length === 0, errors, warnings, lineCount, byteCount };
 }
 
 // The seeded CORE.md (must pass validateCore). Bootstraps the 3 sections so the
@@ -75,7 +89,7 @@ export function renderCoreSkeleton(localeId = 'pt-BR') {
   if (localeId === 'en') {
     return `# CORE — curated memory core (.brain)
 
-> RULE #1 — the project's canonical memory. Hand-curated, 25-line cap (validate: \`wendkeep validate-memory\`). Volatile facts live in DIGEST.md (auto). Depth: /brain-recall <topic>.
+> RULE #1 — the project's canonical memory. Hand-curated, 40-line cap (validate: \`wendkeep validate-memory\`). Volatile facts live in DIGEST.md (auto). Depth: /brain-recall <topic>.
 
 ## User Preferences
 - (durable preferences: language, style, conventions)
@@ -89,7 +103,7 @@ export function renderCoreSkeleton(localeId = 'pt-BR') {
   }
   return `# CORE — núcleo curado da memória (.brain)
 
-> REGRA #1 — memória canônica do projeto. Curado à mão, cap 25 linhas (valide: \`wendkeep validate-memory\`). Volátil vive no DIGEST.md (auto). Profundidade: /brain-recall <tópico>.
+> REGRA #1 — memória canônica do projeto. Curado à mão, cap 40 linhas (valide: \`wendkeep validate-memory\`). Volátil vive no DIGEST.md (auto). Profundidade: /brain-recall <tópico>.
 
 ## Preferências do Usuário
 - (preferências duráveis: idioma, estilo, convenções)
@@ -110,8 +124,8 @@ export function renderCompactionProtocol() {
 
 ## 1. Duas camadas
 
-- **QUENTE** (auto-injetada por sessão, budget ~45 linhas):
-  - \`.brain/CORE.md\` — curado à mão, **≤25 linhas** (1 item/linha): preferências, padrões, pendências.
+- **QUENTE** (auto-injetada por sessão, com budgets por camada):
+  - \`.brain/CORE.md\` — curado à mão, **≤40 linhas** (alerta em 35; 4 KiB; 320 caracteres por linha): preferências, padrões, pendências.
   - \`.brain/DIGEST.md\` — auto-gerado (0 token LLM, ≤15 linhas): decisões/sessões/bugs/aprendizados recentes.
 - **FRIA** (sob demanda):
   - \`.brain/index.jsonl\` — índice de todas as sessões (1/linha, frontmatter).
@@ -120,7 +134,7 @@ export function renderCompactionProtocol() {
 ## 2. Compactação = regra de geração (sem trabalho manual)
 
 - **DIGEST se auto-compacta**: caps determinísticos (5 decisões, 4 sessões, 2 bugs, 2 aprendizados + \`+N mais\`). O velho cai do quente sozinho e permanece no índice/vault. **NUNCA editar** \`DIGEST.md\`/\`index.jsonl\`.
-- **CORE**: quando ≥22 linhas (soft warning), remover itens resolvidos/obsoletos — o detalhe já vive no vault e no histórico do git.
+- **CORE**: quando ≥35 linhas (soft warning), remover itens resolvidos/obsoletos — o detalhe já vive no vault e no histórico do git.
 
 ## 3. O que escrever no CORE
 
@@ -139,7 +153,7 @@ wendkeep validate-memory          # valida <vault>/.brain/CORE.md
 wendkeep validate-memory <path>   # valida outro arquivo
 \`\`\`
 
-Checa: cap 25 (soft 22), 3 seções, sem segredos/PII. Exit 0 = OK, 1 = falha.
+Checa: cap 40 (soft 35), 4 KiB, 320 caracteres por linha, 3 seções, sem segredos/PII. Exit 0 = OK, 1 = falha.
 `;
 }
 

--- a/packages/vault/src/validate-memory.mjs
+++ b/packages/vault/src/validate-memory.mjs
@@ -1,6 +1,7 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { validateMemoryEvent, validateSharedMemory } from './memory-schema.mjs';
+import { readdirSync, readFileSync } from 'node:fs';
+import { basename, join, relative } from 'node:path';
+import { sanitizeMemoryText, validateMemoryEvent, validateSharedMemory } from './memory-schema.mjs';
+import { deriveMemoryProjection } from './memory-store.mjs';
 import { assertVaultPathSafe } from './vault-path-safety.mjs';
 import { validateCore } from './validate-core.mjs';
 
@@ -104,8 +105,208 @@ function validateSharedArtifact(vaultBase, eventIds) {
   return { ...validateSharedMemory(read.content, { eventIds }), path, content: read.content };
 }
 
-export function combineMemoryResults({ project, core, ledger, shared }) {
-  const components = { project, core, ledger, shared };
+const TERMINAL_CANDIDATE_STATUSES = new Set(['resolved', 'rejected', 'superseded']);
+const DECISION_LINK_RE = /\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]/g;
+
+function readCandidateInventory(vaultBase) {
+  const path = join(vaultBase, '.brain', 'MEMORY_CANDIDATES.jsonl');
+  let checked;
+  try {
+    checked = assertVaultPathSafe(vaultBase, path, {
+      allowMissing: true, expectedType: 'file', label: 'MEMORY_CANDIDATES.jsonl',
+    });
+  } catch (error) {
+    return failedComponent(`MEMORY_CANDIDATES.jsonl inseguro: ${error?.message || error}`, {
+      count: 0, activeCount: 0, path,
+    });
+  }
+  if (!checked.exists) return { ok: true, errors: [], warnings: [], count: 0, activeCount: 0, path };
+
+  try {
+    checked = assertVaultPathSafe(vaultBase, checked.target, {
+      allowMissing: false, expectedType: 'file', label: 'MEMORY_CANDIDATES.jsonl',
+    });
+    const lines = readFileSync(checked.target, 'utf8').replace(/\r\n/g, '\n')
+      .split('\n').filter((line) => line.trim());
+    const errors = [];
+    let count = 0;
+    let activeCount = 0;
+    for (const [index, line] of lines.entries()) {
+      try {
+        const item = JSON.parse(line);
+        if (!item || typeof item !== 'object' || Array.isArray(item)) {
+          errors.push(`MEMORY_CANDIDATES.jsonl linha ${index + 1} deve conter um objeto.`);
+          continue;
+        }
+        count += 1;
+        if (!TERMINAL_CANDIDATE_STATUSES.has(item.status || 'active')) activeCount += 1;
+      } catch (error) {
+        errors.push(`MEMORY_CANDIDATES.jsonl linha ${index + 1} contém JSON inválido: ${error?.message || error}`);
+      }
+    }
+    return { ok: errors.length === 0, errors, warnings: [], count, activeCount, path };
+  } catch (error) {
+    return failedComponent(`MEMORY_CANDIDATES.jsonl ilegível: ${error?.message || error}`, {
+      count: 0, activeCount: 0, path,
+    });
+  }
+}
+
+function sharedEventIds(content) {
+  const ids = new Set();
+  for (const line of String(content || '').split('\n')) {
+    const match = line.match(/^\s*-\s+\[([^\]]+)\]/);
+    if (match?.[1]) ids.add(match[1]);
+  }
+  return ids;
+}
+
+function walkDecisionFiles(root, vaultBase, output = []) {
+  let entries;
+  try { entries = readdirSync(root, { withFileTypes: true }); } catch { return output; }
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) walkDecisionFiles(path, vaultBase, output);
+    else if (entry.isFile() && /^ADR-\d+.*\.md$/i.test(entry.name)) {
+      const rel = relative(vaultBase, path).replace(/\\/g, '/').replace(/\.md$/i, '');
+      output.push(rel);
+    }
+  }
+  return output;
+}
+
+function decisionInventory(vaultBase) {
+  const paths = [];
+  for (const folder of ['04-Decisões', '04-Decisions']) {
+    walkDecisionFiles(join(vaultBase, folder), vaultBase, paths);
+  }
+  const byPath = new Set(paths);
+  const byBasename = new Set(paths.map((path) => basename(path)));
+  return { byPath, byBasename };
+}
+
+function unresolvedDecisionLinks(vaultBase, content) {
+  const inventory = decisionInventory(vaultBase);
+  const unresolved = new Set();
+  DECISION_LINK_RE.lastIndex = 0;
+  let match;
+  while ((match = DECISION_LINK_RE.exec(String(content || '')))) {
+    const target = String(match[1] || '').trim().replace(/\\/g, '/').replace(/\.md$/i, '');
+    const targetBase = basename(target);
+    const isDecision = /^ADR-\d+/i.test(targetBase)
+      || /(^|\/)(?:04-Decis(?:õ|o)es|04-Decisions)(?:\/|$)/i.test(target);
+    if (!isDecision) continue;
+    if (!target || target.includes('...') || target.includes('…')
+        || (!inventory.byPath.has(target) && !inventory.byBasename.has(targetBase))) {
+      unresolved.add(sanitizeMemoryText(target).slice(0, 180));
+    }
+  }
+  return [...unresolved].sort();
+}
+
+function semanticMemoryHealth(vaultBase, { ledger, shared, candidates }) {
+  const base = {
+    ok: true,
+    status: 'unavailable',
+    code: 'MEMORY_SEMANTIC_STRUCTURAL_UNAVAILABLE',
+    errors: [],
+    warnings: [],
+    activeKeys: [],
+    projectedKeys: [],
+    missingKeys: [],
+    unresolvedDecisionLinks: [],
+    placeholderOnly: false,
+    counts: { activeKeys: 0, projectedKeys: 0, missingKeys: 0, candidates: candidates?.activeCount || 0, placeholderSections: 0, unresolvedDecisionLinks: 0 },
+  };
+  if (!ledger?.ok || !shared?.ok) return base;
+
+  let replay;
+  try { replay = deriveMemoryProjection(vaultBase, ledger.events); }
+  catch (error) {
+    return {
+      ...base,
+      ok: false,
+      status: 'degraded',
+      code: 'MEMORY_SEMANTIC_REPLAY_UNAVAILABLE',
+      errors: ['[MEMORY_SEMANTIC_REPLAY_UNAVAILABLE] não foi possível rederivar as chaves ativas do ledger.'],
+    };
+  }
+
+  const active = Object.entries(replay.records || {}).map(([memoryKey, record]) => ({
+    memoryKey: sanitizeMemoryText(memoryKey),
+    eventId: record?.source?.event_id,
+  }));
+  const activeKeys = active.map(({ memoryKey }) => memoryKey).sort();
+  const projectedIds = sharedEventIds(shared.content);
+  const projectedKeys = active
+    .filter(({ eventId }) => projectedIds.has(eventId))
+    .map(({ memoryKey }) => memoryKey)
+    .sort();
+  const missingKeys = active
+    .filter(({ eventId }) => !projectedIds.has(eventId))
+    .map(({ memoryKey }) => memoryKey)
+    .sort();
+  const sectionValues = [...(shared.sections?.values?.() || [])].flat();
+  const placeholderSections = sectionValues.filter((line) => /^-\s*\(vazio\)\s*$/i.test(line)).length;
+  const nonPlaceholderLines = sectionValues.filter((line) => !/^-\s*\(vazio\)\s*$/i.test(line));
+  const placeholderOnly = sectionValues.length > 0 && nonPlaceholderLines.length === 0;
+  const unresolvedLinks = unresolvedDecisionLinks(vaultBase, shared.content);
+  const candidateCount = Math.max(candidates?.activeCount || 0, replay.candidates?.length || 0);
+  const errors = [];
+  const warnings = [];
+  const codes = [];
+
+  if (missingKeys.length && placeholderOnly) {
+    codes.push('MEMORY_SEMANTIC_PLACEHOLDER_ONLY');
+    errors.push(`[MEMORY_SEMANTIC_PLACEHOLDER_ONLY] SHARED contém somente placeholders para ${activeKeys.length} chave(s) ativa(s); candidates=${candidateCount}.`);
+  } else if (missingKeys.length) {
+    codes.push('MEMORY_SEMANTIC_COVERAGE_MISSING');
+    errors.push(`[MEMORY_SEMANTIC_COVERAGE_MISSING] SHARED não cobre ${missingKeys.length} chave(s) ativa(s): ${missingKeys.join(', ')}.`);
+  }
+  if (unresolvedLinks.length) {
+    codes.push('MEMORY_SEMANTIC_DECISION_LINK_UNRESOLVED');
+    errors.push(`[MEMORY_SEMANTIC_DECISION_LINK_UNRESOLVED] ${unresolvedLinks.length} link(s) de decisão não resolvido(s).`);
+  }
+
+  let status = 'healthy';
+  let code = 'MEMORY_SEMANTIC_COVERAGE_OK';
+  if (!ledger.events.length && !candidateCount) {
+    status = 'neutral';
+    code = 'MEMORY_SEMANTIC_EMPTY_NEUTRAL';
+  } else if (!activeKeys.length && candidateCount) {
+    status = 'degraded';
+    code = 'MEMORY_SEMANTIC_CANDIDATES_PENDING';
+    warnings.push(`[MEMORY_SEMANTIC_CANDIDATES_PENDING] ${candidateCount} candidate(s) preservado(s); o estado não é memória vazia.`);
+  } else if (codes.length) {
+    status = 'degraded';
+    code = codes[0];
+  }
+
+  return {
+    ok: errors.length === 0,
+    status,
+    code,
+    codes,
+    errors,
+    warnings,
+    activeKeys,
+    projectedKeys,
+    missingKeys,
+    unresolvedDecisionLinks: unresolvedLinks,
+    placeholderOnly,
+    counts: {
+      activeKeys: activeKeys.length,
+      projectedKeys: projectedKeys.length,
+      missingKeys: missingKeys.length,
+      candidates: candidateCount,
+      placeholderSections,
+      unresolvedDecisionLinks: unresolvedLinks.length,
+    },
+  };
+}
+
+export function combineMemoryResults({ project, core, ledger, shared, candidates, semantic }) {
+  const components = { project, core, ledger, shared, candidates, semantic };
   const errors = [];
   const warnings = [];
   for (const [name, result] of Object.entries(components)) {
@@ -124,5 +325,7 @@ export function validateMemoryBundle(vaultBase) {
   const core = validateCoreArtifact(vaultBase);
   const ledger = readLedgerForValidation(vaultBase, { projectId: project.projectId });
   const shared = validateSharedArtifact(vaultBase, ledger.eventIds);
-  return combineMemoryResults({ project, core, ledger, shared });
+  const candidates = readCandidateInventory(vaultBase);
+  const semantic = semanticMemoryHealth(vaultBase, { ledger, shared, candidates });
+  return combineMemoryResults({ project, core, ledger, shared, candidates, semantic });
 }

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -39,6 +39,10 @@ export function renderVaultHealthLines(result) {
     `[memória] ${healthStatusLabel(result.memoryStatus)} — schema: ${metricValue(memory.schemaVersion)} · revisão: ${metricValue(memory.revision)} · cursor: ${metricValue(memory.eventCursor)} · hash: ${metricValue(memory.stateHash)}`,
   );
   lines.push(`  ledger: ${metricValue(memory.ledgerEvents)} evento(s) · outbox: ${metricValue(memory.pendingOutbox)} · candidates: ${metricValue(memory.candidates)} · conflitos: ${metricValue(memory.activeConflicts)}`);
+  const semanticKeys = memory.semanticActiveKeys || [];
+  const semanticProjected = memory.semanticProjectedKeys || [];
+  const semanticMissing = memory.semanticMissingKeys || [];
+  lines.push(`  semântica: ${metricValue(memory.semanticCode)} · ativas: ${semanticKeys.length} [${semanticKeys.join(', ')}] · projetadas: ${semanticProjected.length} · ausentes: ${semanticMissing.length}`);
   for (const failure of memoryFailures) lines.push(`  ✗ ${failure}`);
   for (const warning of memoryWarnings) lines.push(`  ! ${warning}`);
   if (result.memoryStatus === 'healthy' && !memoryFailures.length && !memoryWarnings.length) {

--- a/src/memory.mjs
+++ b/src/memory.mjs
@@ -1874,13 +1874,16 @@ export function runValidateMemoryBundle(argv) {
     return;
   }
   const result = validateMemoryBundle(vault);
+  const semantic = result.semantic || {};
+  const semanticSummary = `semântica ${semantic.code || 'n/a'} · ativas: ${semantic.counts?.activeKeys ?? 0} · projetadas: ${semantic.counts?.projectedKeys ?? 0} · ausentes: ${semantic.counts?.missingKeys ?? 0}`;
   if (!result.ok) {
     process.stderr.write(`❌  bundle de memória inválido (${result.errors.length} erro(s)):\n`);
+    process.stderr.write(`   ${semanticSummary}\n`);
     for (const error of result.errors) process.stderr.write(`   - ${error}\n`);
     process.exitCode = 1;
     return;
   }
-  process.stdout.write('✅  bundle de memória v2 OK (CORE + ledger + SHARED).\n');
+  process.stdout.write(`✅  bundle de memória v2 OK (CORE + ledger + SHARED; ${semanticSummary}).\n`);
   process.exitCode = 0;
 }
 

--- a/tests/brain-core.test.mjs
+++ b/tests/brain-core.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { buildBrainDigest, buildBrainIndex } from '../hooks/brain-core.mjs';
+
+test('[req:MEM-HYB-12] digest renders only a resolved ADR with its sanitized title', () => {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-brain-core-'));
+  const sessionDir = join(vault, '02-Sessões', '2026', '08-AGO', 'DIA 16');
+  const adrDir = join(vault, '04-Decisões', '2026', '08-AGO');
+  try {
+    mkdirSync(join(vault, '.brain'), { recursive: true });
+    mkdirSync(sessionDir, { recursive: true });
+    mkdirSync(adrDir, { recursive: true });
+    writeFileSync(join(vault, '.brain', 'CORE.md'), '# Curated core sentinel\n');
+    writeFileSync(join(sessionDir, '06-02-session.md'), `---
+type: session
+date: 2026-08-16
+provider: codex
+status: active
+summary: fixture session
+---
+
+# Fixture session
+
+## Decisões geradas nesta sessão
+
+- [[04-Decisões/2026/08-AGO/ADR-0123-real-decision]]
+- [[04-Decisões/2026/08-AGO/ADR-0999-missing-decision]]
+- [[04-Decisões/2026/08-AGO/ADR-0888-truncated…]]
+`);
+    writeFileSync(join(adrDir, 'ADR-0123-real-decision.md'), `---
+type: decision
+status: accepted
+---
+
+# ADR-0123 — Decisão real sanitizada
+
+Conteúdo artificial da decisão.
+`);
+
+    const rows = buildBrainIndex(vault);
+    const digest = buildBrainDigest(vault, rows).join('\n');
+
+    assert.match(
+      digest,
+      /Decisão:\s*\[\[04-Decisões\/2026\/08-AGO\/ADR-0123-real-decision\]\].*Decisão real sanitizada/i,
+    );
+    assert.doesNotMatch(digest, /ADR-0999-missing-decision|ADR-0888-truncated/i);
+    assert.doesNotMatch(digest, /Decisão:\s*\[\[[^\]]+\]\]\s*$/m);
+    assert.equal(readFileSync(join(vault, '.brain', 'CORE.md'), 'utf8'), '# Curated core sentinel\n');
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});

--- a/tests/brain-inject-memory.test.mjs
+++ b/tests/brain-inject-memory.test.mjs
@@ -64,7 +64,7 @@ function makeVault({ core = CORE, shared = sharedMemory(), digest = 'DIGEST_RECA
 function criticalMemoryAtLimits() {
   const coreLines = [
     '# CORE', '', '## Preferências do Usuário', '- pt-BR', '', '## Padrões Ativos', '- canonical', '',
-    '## Pendências Abertas', ...Array.from({ length: 16 }, (_, i) => `- durable-${i}`),
+    '## Pendências Abertas', ...Array.from({ length: 31 }, (_, i) => `- durable-${i}`),
   ];
   const core = `${coreLines.join('\n')}\n`;
   const baseShared = sharedMemory();
@@ -74,7 +74,7 @@ function criticalMemoryAtLimits() {
       `- shared-fill-${i} ${'s'.repeat(240)}${i === fillCount - 1 ? ' SHARED_TAIL_MUST_SURVIVE' : ''}`
     )),
   });
-  assert.equal(core.trimEnd().split('\n').length, 25);
+  assert.equal(core.trimEnd().split('\n').length, 40);
   assert.equal(shared.trimEnd().split('\n').length, 48);
   assert.ok(Buffer.byteLength(shared, 'utf8') <= 6 * 1024);
   return { core, shared };
@@ -151,8 +151,27 @@ test('[req:MEM-HYB-2] [req:HOOK-MEM-1] startup, clear and compact receive the sa
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
 
+test('[req:MEM-HYB-2] [req:HOOK-MEM-2] SessionStart exposes SHARED metadata directly and keeps DIGEST recall-only', () => {
+  const digestBody = 'DIGEST_BODY_MUST_REMAIN_RECALL_ONLY';
+  const stateHash = 'state-hash-session-start-contract';
+  const vault = makeVault({
+    shared: sharedMemory({ revision: 31, hash: stateHash }),
+    digest: digestBody,
+  });
+  try {
+    for (const source of ['startup', 'clear', 'compact']) {
+      const out = buildInjection(vault, { source });
+      assert.match(out, new RegExp(`<brain_memory version="2" revision="31" state_hash="${stateHash}">`));
+      assert.match(out, /<wk_core authority="canonical">[\s\S]*CORE_CANONICAL_DIRECT[\s\S]*<\/wk_core>/);
+      assert.match(out, new RegExp(`<wk_shared_state authority="operational">[\\s\\S]*revision: 31[\\s\\S]*state_hash: ${stateHash}[\\s\\S]*<\\/wk_shared_state>`));
+      assert.match(out, /<wk_recall>[\s\S]*\/brain-recall <tópico>[\s\S]*<\/wk_recall>/);
+      assert.doesNotMatch(out, new RegExp(digestBody));
+    }
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
 test('[req:MEM-HYB-6] invalid CORE or SHARED is replaced atomically by wk_memory_error, never a silent prefix slice', () => {
-  const oversizedCore = `${CORE.trimEnd()}\n${Array.from({ length: 20 }, (_, i) => `- core-overflow-${i}`).join('\n')}\n`;
+  const oversizedCore = `${CORE.trimEnd()}\n${Array.from({ length: 32 }, (_, i) => `- core-overflow-${i}`).join('\n')}\n`;
   const oversizedShared = sharedMemory({
     extra: Array.from({ length: 30 }, (_, i) => `- shared-overflow-${i}`),
   });
@@ -170,9 +189,9 @@ test('[req:MEM-HYB-6] invalid CORE or SHARED is replaced atomically by wk_memory
 test('[req:MEM-HYB-6] [req:MEM-HYB-7] global pressure drops lessons then non-current changes while preserving the current blocker and 24 KiB envelope', () => {
   const coreLines = [
     '# CORE', '', '## Preferências do Usuário', '- pt-BR', '', '## Padrões Ativos', '- canonical', '',
-    '## Pendências Abertas', ...Array.from({ length: 16 }, (_, i) => `- durable-${i}`),
+    '## Pendências Abertas', ...Array.from({ length: 31 }, (_, i) => `- durable-${i}`),
   ];
-  assert.equal(coreLines.length, 25);
+  assert.equal(coreLines.length, 40);
   const coreAtLimit = `${coreLines.join('\n')}\n`;
   const baseShared = sharedMemory();
   const fillCount = 48 - baseShared.trimEnd().split('\n').length;

--- a/tests/hook-runtime.test.mjs
+++ b/tests/hook-runtime.test.mjs
@@ -4,11 +4,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { bindProjectVault } from '../src/project-vault.mjs';
+import { resolveSessionEntry } from '../hooks/session-identity.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const BIN = join(here, '..', 'bin', 'wendkeep.mjs');
@@ -62,5 +63,43 @@ test('hook fails closed when no project vault is configured', () => {
     assert.deepEqual(readdirSync(fakeHome), [], 'no fallback vault or session file was created');
   } finally {
     rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-HYB-10] session ensure persists work_session_id without replacing canonical identity', () => {
+  const neutralCwd = mkdtempSync(join(tmpdir(), 'wk-cwd-work-session-'));
+  const vault = join(neutralCwd, '.vault');
+  const workSessionId = 'wk-fixture-example-work-session';
+  try {
+    bindProjectVault({ projectRoot: neutralCwd, vaultPath: vault });
+    const env = { ...process.env, OBSIDIAN_VAULT_PATH: join(neutralCwd, 'wrong-global-vault') };
+    delete env.CLAUDECODE;
+    delete env.CLAUDE_CODE_SESSION_ID;
+    delete env.CLAUDE_PROJECT_DIR;
+    const transcript = join(neutralCwd, 'rollout.jsonl');
+    writeFileSync(transcript, `${JSON.stringify({
+      type: 'session_meta',
+      payload: { id: 'runtime-rollout', session_id: 'runtime-session', model_provider: 'openai' },
+    })}\n`);
+    const r = runHook('session-ensure', {
+      env,
+      cwd: neutralCwd,
+      input: {
+        transcript_path: transcript,
+        session_id: 'runtime-session',
+        shared: { work_session_id: workSessionId },
+      },
+    });
+
+    assert.equal(r.status, 0, `exit 0; stderr=\n${r.stderr}`);
+    const registry = JSON.parse(readFileSync(join(vault, '.brain', 'SESSION_REGISTRY.json'), 'utf8'));
+    assert.equal(registry.sessions['runtime-session'].work_session_id, workSessionId);
+
+    const resolved = resolveSessionEntry(vault, { transcript_path: transcript, session_id: 'runtime-session' }, 'codex');
+    assert.equal(resolved.identity.canonicalConversationId, 'runtime-session');
+    assert.equal(resolved.identity.work_session_id, workSessionId);
+    assert.equal(resolved.entry.work_session_id, workSessionId);
+  } finally {
+    rmSync(neutralCwd, { recursive: true, force: true });
   }
 });

--- a/tests/memory-core-precedence.test.mjs
+++ b/tests/memory-core-precedence.test.mjs
@@ -60,7 +60,8 @@ test('[req:MEM-HYB-3] projector blocks an operational contradiction against an e
 
     assert.equal(readFileSync(corePath, 'utf8'), core, 'projector must not rewrite CORE bytes');
     assert.match(shared, /review-interface/, 'independent operational state remains projectable');
-    assert.doesNotMatch(shared, /automatic|release\.push/, 'contradiction is not promoted to SHARED');
+    assert.match(shared, /\[revisão pendente: release\.push;/, 'blocked contradiction leaves only a safe review marker');
+    assert.doesNotMatch(shared, /automatic/, 'contradictory value is not promoted to SHARED');
     assert.equal(projected.candidates, 1);
     assert.deepEqual(candidates, [{
       v: 1,

--- a/tests/memory-handoff.test.mjs
+++ b/tests/memory-handoff.test.mjs
@@ -26,6 +26,47 @@ test('[req:MEM-STOP-7] synthetic handoff redacts an artificial local path', () =
   assert.doesNotMatch(JSON.stringify(events[0]), /[A-Za-z]:\\Users\\/i);
 });
 
+test('[req:MEM-HYB-10] structured handoff emits portable events for every shared category', () => {
+  const workSessionId = 'wk-fixture-example-work-session';
+  const localPath = syntheticWindowsHomePath();
+  const shared = {
+    work_session_id: workSessionId,
+    objective: `[wk-fixture] Objetivo artificial ${localPath}`,
+    delivered: `[wk-fixture] Estado entregue artificial ${localPath}`,
+    constraints: `[wk-fixture] Restrição artificial ${localPath}`,
+    decisions: `[wk-fixture] Decisão artificial ${localPath}`,
+    next_actions: `[wk-fixture] Próxima ação artificial ${localPath}`,
+    blockers: `[wk-fixture] Bloqueio artificial ${localPath}`,
+    risks: `[wk-fixture] Risco artificial ${localPath}`,
+  };
+  const events = buildSessionMemoryEvents({
+    ...makeSyntheticHandoff({ summary: '[wk-fixture] resumo livre que não deve substituir o handoff estruturado' }),
+    shared,
+  });
+  const expectedKeys = [
+    'objective.current',
+    'state.delivered',
+    'constraint.active',
+    'decision.active',
+    'next.action',
+    'blocker.active',
+    'risk.known',
+  ];
+  const byKey = new Map(events.map((event) => [event.memory_key, event]));
+
+  assert.equal(events.length, expectedKeys.length);
+  assert.deepEqual([...byKey.keys()].sort(), [...expectedKeys].sort());
+  for (const key of expectedKeys) {
+    const event = byKey.get(key);
+    assert.equal(event.canonical_session_id, SYNTHETIC_MEMORY.conversationId);
+    assert.equal(event.work_session_id, workSessionId);
+    assert.equal(event.authority, 'reported');
+    assert.deepEqual(event.evidence, [SYNTHETIC_MEMORY.noteRel]);
+    assert.match(JSON.stringify(event.value), /\[REDACTED_LOCAL_PATH\]/);
+    assert.doesNotMatch(JSON.stringify(event), /[A-Za-z]:\\Users\\/i);
+  }
+});
+
 test('[req:MEM-STOP-7] synthetic lifecycle evidence creates causal memory events', () => {
   const evidence = {
     change: {

--- a/tests/memory-hybrid-e2e.test.mjs
+++ b/tests/memory-hybrid-e2e.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -37,6 +37,20 @@ function runHook(script, { project, vault, input }) {
   return spawnSync(process.execPath, [script], {
     cwd: project,
     env: cleanSyntheticHookEnv(vault),
+    encoding: 'utf8',
+    input: JSON.stringify(input),
+  });
+}
+
+function runHookAs(provider, script, { project, vault, input }) {
+  const env = cleanSyntheticHookEnv(vault);
+  if (provider === 'claude') {
+    env.CLAUDECODE = '1';
+    env.CLAUDE_CODE_SESSION_ID = SYNTHETIC_MEMORY.sessionId;
+  }
+  return spawnSync(process.execPath, [script], {
+    cwd: project,
+    env,
     encoding: 'utf8',
     input: JSON.stringify(input),
   });
@@ -152,6 +166,121 @@ test('[req:MEM-STOP-7] synthetic Stop projects lifecycle memory and remains idem
       new RegExp(escapeRegExp(fact), 'i'),
       '[wk-fixture] injected context contains projected memory',
     );
+  }
+});
+
+test('[req:MEM-HYB-10] Stop forwards structured shared handoff into the projected ledger', () => {
+  const { project, vault, brain, transcript } = seedSyntheticHybridLifecycle();
+  const workSessionId = 'wk-fixture-example-work-session';
+  try {
+    const stop = runHook(STOP, {
+      project,
+      vault,
+      input: {
+        ...stopInput(project, transcript),
+        shared: {
+          work_session_id: workSessionId,
+          objective: '[wk-fixture] continue the artificial lifecycle.',
+          next_actions: '[wk-fixture] inspect the next artificial checkpoint.',
+        },
+      },
+    });
+
+    assert.equal(stop.status, 0, stop.stderr);
+    const events = readMemoryLedger(vault).events;
+    const structured = events.filter((event) => ['objective.current', 'next.action'].includes(event.memory_key));
+    assert.deepEqual(structured.map((event) => event.memory_key).sort(), ['next.action', 'objective.current']);
+    assert.equal(events.some((event) => event.memory_key === 'handoff.latest'), false);
+    assert.ok(structured.every((event) => event.work_session_id === workSessionId));
+    assert.equal(structured.find((event) => event.memory_key === 'objective.current').value, '[wk-fixture] continue the artificial lifecycle.');
+    assert.equal(structured.find((event) => event.memory_key === 'next.action').value, '[wk-fixture] inspect the next artificial checkpoint.');
+    assert.match(readFileSync(join(brain, 'SHARED_MEMORY.md'), 'utf8'), /continue the artificial lifecycle/i);
+  } finally {
+    // The fixture is intentionally local-only; remove it after the proof.
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-HYB-10] [req:MEM-HYB-2] Codex and Claude carry a structured Stop handoff into a new SessionStart', () => {
+  const providers = [
+    {
+      name: 'codex',
+      objective: '[wk-fixture] Codex objective survives the next session.',
+      next: '[wk-fixture] Codex next action is inspect the checkpoint.',
+    },
+    {
+      name: 'claude',
+      objective: '[wk-fixture] Claude objective survives the next session.',
+      next: '[wk-fixture] Claude next action is inspect the checkpoint.',
+    },
+  ];
+
+  for (const { name, objective, next } of providers) {
+    const fixture = seedSyntheticHybridLifecycle();
+    const { project, vault, brain, transcript } = fixture;
+    try {
+      if (name === 'claude') {
+        writeFileSync(transcript, [
+          { type: 'user', uuid: SYNTHETIC_MEMORY.turnOne, timestamp: SYNTHETIC_MEMORY.observedAt, sessionId: SYNTHETIC_MEMORY.sessionId, message: { role: 'user', content: '[wk-fixture] Claude request.' } },
+          { type: 'assistant', uuid: 'wk-fixture-claude-assistant', timestamp: SYNTHETIC_MEMORY.observedAt, sessionId: SYNTHETIC_MEMORY.sessionId, message: { role: 'assistant', content: [{ type: 'text', text: '[wk-fixture] Claude response.' }] } },
+        ].map((event) => JSON.stringify(event)).join('\n') + '\n');
+        const registryPath = join(brain, 'SESSION_REGISTRY.json');
+        const registry = JSON.parse(readFileSync(registryPath, 'utf8'));
+        registry.sessions[SYNTHETIC_MEMORY.sessionId].provider = 'claude';
+        registry.sessions[SYNTHETIC_MEMORY.sessionId].activations[SYNTHETIC_MEMORY.activationOne].provider = 'claude';
+        writeFileSync(registryPath, JSON.stringify(registry));
+      }
+
+      const workSessionId = `wk-fixture-${name}-vertical-work-session`;
+      const stop = runHookAs(name, STOP, {
+        project,
+        vault,
+        input: {
+          ...stopInput(project, transcript),
+          shared: { work_session_id: workSessionId, objective, next_actions: next },
+        },
+      });
+      assert.equal(stop.status, 0, `${name} Stop: ${stop.stderr}`);
+
+      const events = readMemoryLedger(vault).events;
+      const objectiveEvent = events.find((event) => event.memory_key === 'objective.current');
+      const nextEvent = events.find((event) => event.memory_key === 'next.action');
+      assert.equal(objectiveEvent?.value, objective, `${name} objective event`);
+      assert.equal(nextEvent?.value, next, `${name} next action event`);
+      assert.equal(objectiveEvent?.work_session_id, workSessionId);
+      assert.equal(nextEvent?.work_session_id, workSessionId);
+
+      const start = runHookAs(name, START, {
+        project,
+        vault,
+        input: {
+          hook_event_name: 'SessionStart',
+          cwd: project,
+          session_id: SYNTHETIC_MEMORY.sessionId,
+          transcript_path: transcript,
+          activation_id: SYNTHETIC_MEMORY.activationTwo,
+        },
+      });
+      assert.equal(start.status, 0, `${name} SessionStart: ${start.stderr}`);
+
+      const inject = runHookAs(name, INJECT, {
+        project,
+        vault,
+        input: {
+          hook_event_name: 'UserPromptSubmit',
+          source: 'startup',
+          cwd: project,
+          session_id: SYNTHETIC_MEMORY.sessionId,
+        },
+      });
+      assert.equal(inject.status, 0, `${name} reinjection: ${inject.stderr}`);
+      const context = JSON.parse(inject.stdout).hookSpecificOutput.additionalContext;
+      assert.match(context, /<wk_shared_state authority="operational">/);
+      assert.match(context, new RegExp(escapeRegExp(objective)));
+      assert.match(context, new RegExp(escapeRegExp(next)));
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
   }
 });
 

--- a/tests/memory-semantic-health.test.mjs
+++ b/tests/memory-semantic-health.test.mjs
@@ -1,0 +1,130 @@
+// [req:DIAG-12] [req:MEM-HYB-7]
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validateMemoryBundle } from '../src/validate-memory.mjs';
+import { renderSharedMemory } from '../hooks/memory-schema.mjs';
+import { reduceMemoryEvents } from '../hooks/memory-store.mjs';
+import { renderCoreSkeleton } from '../src/validate-core.mjs';
+
+const PROJECT_ID = 'semantic-health-project';
+const BIN = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'wendkeep.mjs');
+
+function memoryEvent(eventId, memoryKey, value) {
+  return {
+    v: 1,
+    project_id: PROJECT_ID,
+    event_id: eventId,
+    memory_key: memoryKey,
+    operation: 'assert',
+    value,
+    authority: 'verified',
+    canonical_session_id: 'semantic-session',
+    activation_id: 'semantic-activation',
+    activation_epoch: 1,
+    turn_sequence: 1,
+    source_turn_id: 'semantic-turn',
+    observed_at: '2026-08-16T10:00:00Z',
+    evidence: ['tests/memory-semantic-health.test.mjs'],
+  };
+}
+
+function writeBundle({ events = [], sharedEvents = undefined, candidates = '' } = {}) {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-semantic-health-'));
+  const brain = join(vault, '.brain');
+  mkdirSync(brain, { recursive: true });
+  const reduced = reduceMemoryEvents(events);
+  writeFileSync(join(brain, 'PROJECT.json'), `${JSON.stringify({ schemaVersion: 1, projectId: PROJECT_ID })}\n`);
+  writeFileSync(join(brain, 'CORE.md'), renderCoreSkeleton());
+  writeFileSync(
+    join(brain, 'MEMORY_EVENTS.jsonl'),
+    events.map((event) => JSON.stringify(event)).join('\n') + (events.length ? '\n' : ''),
+  );
+  writeFileSync(join(brain, 'SHARED_MEMORY.md'), renderSharedMemory({
+    revision: reduced.revision,
+    eventCursor: reduced.eventCursor,
+    stateHash: reduced.stateHash,
+    events: sharedEvents === undefined ? reduced.activeEvents : sharedEvents,
+    updatedAt: '2026-08-16T10:00:00Z',
+    reviewAfter: '2026-08-23T10:00:00Z',
+  }));
+  writeFileSync(join(brain, 'MEMORY_CANDIDATES.jsonl'), candidates);
+  return vault;
+}
+
+function diagnostics(result) {
+  return JSON.stringify({ errors: result.errors, warnings: result.warnings, semantic: result.semantic });
+}
+
+function runCli(args) {
+  return spawnSync(process.execPath, [BIN, ...args], { encoding: 'utf8' });
+}
+
+test('v2 sem eventos é semanticamente vazio neutro, não um erro', () => {
+  const vault = writeBundle();
+  try {
+    const result = validateMemoryBundle(vault);
+    assert.equal(result.ok, true, result.errors.join('; '));
+    assert.equal(result.semantic.status, 'neutral');
+    assert.equal(result.semantic.code, 'MEMORY_SEMANTIC_EMPTY_NEUTRAL');
+    assert.deepEqual(result.semantic.missingKeys, []);
+    const cli = runCli(['validate-memory', '--vault', vault]);
+    assert.equal(cli.status, 0, cli.stderr);
+    assert.match(cli.stdout, /MEMORY_SEMANTIC_EMPTY_NEUTRAL/);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('v2 reports a conflict-free ledger key missing from SHARED without exposing its value', () => {
+  const missing = memoryEvent('mem-semantic-missing', 'next.action', 'PRIVATE_COVERAGE_VALUE');
+  const present = memoryEvent('mem-semantic-present', 'objective.current', 'PRIVATE_PRESENT_VALUE');
+  const reduced = reduceMemoryEvents([missing, present]);
+  const presentEvent = reduced.activeEvents.find((event) => event.memory_key === present.memory_key);
+  const vault = writeBundle({ events: [missing, present], sharedEvents: [presentEvent] });
+  try {
+    const result = validateMemoryBundle(vault);
+    assert.equal(result.ok, false);
+    assert.equal(result.semantic.code, 'MEMORY_SEMANTIC_COVERAGE_MISSING');
+    assert.deepEqual(result.semantic.missingKeys, ['next.action']);
+    assert.match(diagnostics(result), /MEMORY_SEMANTIC_COVERAGE_MISSING/);
+    assert.doesNotMatch(diagnostics(result), /PRIVATE_(?:COVERAGE|PRESENT)_VALUE/);
+    const bundleCli = runCli(['validate-memory', '--vault', vault]);
+    assert.equal(bundleCli.status, 1);
+    assert.match(bundleCli.stderr, /MEMORY_SEMANTIC_COVERAGE_MISSING/);
+    assert.doesNotMatch(bundleCli.stderr, /PRIVATE_(?:COVERAGE|PRESENT)_VALUE/);
+    const statusCli = runCli(['memory', 'status', '--gate', '--vault', vault]);
+    assert.equal(statusCli.status, 1);
+    const status = JSON.parse(statusCli.stdout);
+    assert.equal(status.status, 'blocked');
+    assert.equal(status.metrics.semanticCode, 'MEMORY_SEMANTIC_COVERAGE_MISSING');
+    assert.deepEqual(status.metrics.semanticMissingKeys, ['next.action']);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('v2 with only placeholders is degraded and reports counts without values', () => {
+  const event = memoryEvent('mem-semantic-placeholder', 'objective.current', 'PRIVATE_PLACEHOLDER_VALUE');
+  const vault = writeBundle({ events: [event], sharedEvents: [] });
+  try {
+    const result = validateMemoryBundle(vault);
+    assert.equal(result.ok, false);
+    assert.equal(result.semantic.code, 'MEMORY_SEMANTIC_PLACEHOLDER_ONLY');
+    assert.equal(result.semantic.placeholderOnly, true);
+    assert.equal(result.semantic.counts.activeKeys, 1);
+    assert.doesNotMatch(diagnostics(result), /PRIVATE_PLACEHOLDER_VALUE/);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});
+
+test('semantic health rejects an unresolved decision link without printing event values', () => {
+  const event = memoryEvent('mem-semantic-decision', 'decision.active', 'PRIVATE_DECISION_VALUE [[ADR-9999-missing]]');
+  const vault = writeBundle({ events: [event] });
+  try {
+    const result = validateMemoryBundle(vault);
+    assert.equal(result.ok, false);
+    assert.equal(result.semantic.code, 'MEMORY_SEMANTIC_DECISION_LINK_UNRESOLVED');
+    assert.deepEqual(result.semantic.unresolvedDecisionLinks, ['ADR-9999-missing']);
+    assert.doesNotMatch(diagnostics(result), /PRIVATE_DECISION_VALUE/);
+  } finally { rmSync(vault, { recursive: true, force: true }); }
+});

--- a/tests/memory-store.test.mjs
+++ b/tests/memory-store.test.mjs
@@ -14,6 +14,7 @@ import {
   deriveMemoryProjection,
   enqueueMemoryEvent,
   hashMemoryValue,
+  prepareMemoryProjection,
   projectMemoryOutbox,
   readMemoryLedger,
   reduceMemoryEvents,
@@ -188,6 +189,49 @@ test('[req:MEM-HYB-4] concurrent scalar patches preserve the common base and bot
   assert.equal(forward.candidates[0].reason, 'conflict');
   assert.deepEqual(forward.candidates[0].event_ids, ['mem-2', 'mem-3']);
   assert.deepEqual(forward.candidates[0].values, ['approve', 'discard']);
+});
+
+test('[req:MEM-HYB-11] pending conflict keeps independent state and renders a safe review marker', () => {
+  const base = event('mem-review-base', 'next.ui', 'assert', 'review', {
+    activation_id: 'activation-review-base',
+    activation_epoch: 1,
+    source_turn_id: 'turn-review-base',
+  });
+  const baseHash = hashMemoryValue(base.value);
+  const approve = event('mem-review-approve', 'next.ui', 'replace', 'approve', {
+    activation_id: 'activation-review-approve',
+    activation_epoch: 1,
+    source_turn_id: 'turn-review-approve',
+    base_revision: 1,
+    base_value_hash: baseHash,
+  });
+  const discard = event('mem-review-discard', 'next.ui', 'replace', 'discard', {
+    activation_id: 'activation-review-discard',
+    activation_epoch: 1,
+    source_turn_id: 'turn-review-discard',
+    base_revision: 1,
+    base_value_hash: baseHash,
+  });
+  const independent = event('mem-review-independent', 'objective.current', 'assert', 'continue');
+  const events = [base, approve, discard, independent];
+  const reduced = reduceMemoryEvents(events);
+
+  assert.equal(reduced.state['next.ui'], 'review', 'conflict keeps the last known common base');
+  assert.equal(reduced.state['objective.current'], 'continue');
+  assert.equal(reduced.candidates.length, 1);
+  assert.deepEqual(reduced.candidates[0].event_ids, ['mem-review-approve', 'mem-review-discard']);
+
+  const vault = scratch();
+  try {
+    const prepared = prepareMemoryProjection(vault, events);
+    assert.match(prepared.sharedContent, /revis[aã]o pendente.*next\.ui/i);
+    assert.match(prepared.sharedContent, /candidates?:\s*1/i);
+    assert.match(prepared.sharedContent, /continue/);
+    assert.doesNotMatch(prepared.sharedContent, /approve|discard/);
+    assert.match(prepared.candidatesContent, /mem-review-approve/);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
 });
 
 test('[req:MEM-HYB-4] stale same-activation event is superseded and tombstone keeps provenance', () => {

--- a/tests/prose-decisions.test.mjs
+++ b/tests/prose-decisions.test.mjs
@@ -9,6 +9,7 @@ import { join } from 'node:path';
 import { extractProseDecisions, captureProseDecisions } from '../hooks/decision-capture.mjs';
 import { createLinkedNotes } from '../hooks/linked-notes.mjs';
 import { importSession, rescanDecisions } from '../hooks/import-sessions.mjs';
+import { buildBrainDigest, buildBrainIndex } from '../hooks/brain-core.mjs';
 
 function turnWith(conv) { return { turnId: 't', timestamp: '', userPrompts: [], assistantMessages: [], tools: [], consultedFiles: [], changedFiles: [], conversation: conv, usage: {} }; }
 
@@ -64,6 +65,11 @@ test('captureProseDecisions writes the decision note; createLinkedNotes links it
     assert.match(note, /Painel HTML local/);
     assert.match(note, /Runner Scalp operacional/);
     assert.match(note, /\*\*Escolhido:\*\* `as duas`/);
+    const sessionRel = '02-Sessões/2026/07-JUL/DIA 09/09-00-s.md';
+    mkdirSync(join(vault, '02-Sessões', '2026', '07-JUL', 'DIA 09'), { recursive: true });
+    writeFileSync(join(vault, sessionRel), `---\ntype: session\ndate: 2026-07-09\nprovider: codex\nsummary: prose fixture\n---\n\n## Decisões geradas nesta sessão\n\n- [[${linked.decisions[0].replace(/\.md$/i, '')}]]\n`);
+    const digest = buildBrainDigest(vault, buildBrainIndex(vault)).join('\n');
+    assert.match(digest, /Decisão:.*ADR-.*Minha recomendação é a 2\. Qual você prefere\?/i);
     // idempotent
     const again = createLinkedNotes(vault, '2026-07-09', '02-Sessões/2026/07-JUL/DIA 09/09-00-s.md', tx, { provider: 'codex' });
     assert.equal(again.decisions.length, 0, 'no duplicate on re-run');

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -81,15 +81,21 @@ test('extractReleaseNotes: throws when the version is absent', () => {
   assert.throws(() => extractReleaseNotes(FIXTURE, '9.9.9'), /9\.9\.9/);
 });
 
-test('[sensor:release-tests] 0.68.6 notes are extractable and match the package', () => {
-  const release = extractReleaseNotes(CHANGELOG, '0.68.6');
-  assert.equal(PACKAGE.version, '0.68.6');
+test('[sensor:release-tests] current release notes are extractable and match the package', () => {
+  const release = extractReleaseNotes(CHANGELOG, PACKAGE.version);
   assert.equal(release.date, '2026-08-16');
+  assert.match(release.notes, /Shared Project Memory v2/i);
+  assert.match(release.notes, /work_session_id/);
+  assert.match(release.notes, /cobertura/i);
+  assert.doesNotMatch(release.notes, /019f[0-9a-f-]+/i);
+});
+
+test('[sensor:release-tests] 0.68.6 notes remain extractable after the bump', () => {
+  const release = extractReleaseNotes(CHANGELOG, '0.68.6');
   assert.match(release.notes, /monorepos pnpm/i);
   assert.match(release.notes, /X\.Y\.Z/);
   assert.match(release.notes, /cooldown/i);
   assert.match(release.notes, /integridade/i);
-  assert.doesNotMatch(release.notes, /019f[0-9a-f-]+/i);
 });
 
 test('[sensor:release-tests] as notas de 0.68.1 seguem extraíveis depois do bump', () => {

--- a/tests/validate-core.test.mjs
+++ b/tests/validate-core.test.mjs
@@ -1,5 +1,5 @@
 // CORE.md memory-compaction validator (ported from NutriGym's validate-brain-core.js):
-// cap 25 lines (soft 22), 3 required sections, no secrets/PII. Plus the seeded
+// cap 40 lines (soft 35), 4 KiB/320 chars per line, 3 required sections, no secrets/PII. Plus the seeded
 // skeleton and the protocol doc.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -11,6 +11,11 @@ import {
 
 const SECTIONS = '## Preferências do Usuário\n- a\n\n## Padrões Ativos\n- b\n\n## Pendências Abertas\n- c\n';
 
+function coreWithFiller(itemCount, item = (index) => `- item ${index}`) {
+  const filler = Array.from({ length: itemCount }, (_, index) => item(index)).join('\n');
+  return `# CORE\n## Preferências do Usuário\n## Padrões Ativos\n## Pendências Abertas\n${filler}\n`;
+}
+
 test('validateCore: a small, well-formed CORE passes clean', () => {
   const r = validateCore(`# CORE\n\n${SECTIONS}`);
   assert.equal(r.ok, true);
@@ -18,11 +23,11 @@ test('validateCore: a small, well-formed CORE passes clean', () => {
   assert.deepEqual(r.warnings, []);
 });
 
-test('validateCore: over 25 lines fails (hard limit)', () => {
-  const filler = Array.from({ length: 30 }, (_, i) => `- item ${i}`).join('\n');
-  const r = validateCore(`# CORE\n## Preferências do Usuário\n## Padrões Ativos\n## Pendências Abertas\n${filler}\n`);
+test('validateCore: 41 lines fails (hard limit)', () => {
+  const r = validateCore(coreWithFiller(37));
   assert.equal(r.ok, false);
-  assert.ok(r.errors.some((e) => /25/.test(e)), 'reports hard limit');
+  assert.equal(r.lineCount, 41);
+  assert.ok(r.errors.some((e) => /41.*40|40.*linhas/.test(e)), 'reports hard limit');
 });
 
 test('validateCore: missing a required section fails', () => {
@@ -44,11 +49,28 @@ test('validateCore: a real PII email is rejected', () => {
   assert.ok(r.errors.some((e) => /email/i.test(e)));
 });
 
-test('validateCore: 22..25 lines is OK but warns (soft limit)', () => {
-  const filler = Array.from({ length: 18 }, (_, i) => `- item ${i}`).join('\n');
-  const r = validateCore(`# CORE\n## Preferências do Usuário\n## Padrões Ativos\n## Pendências Abertas\n${filler}\n`);
+test('validateCore: 35 lines is OK but warns (soft limit)', () => {
+  const r = validateCore(coreWithFiller(31));
   assert.equal(r.ok, true);
+  assert.equal(r.lineCount, 35);
   assert.ok(r.warnings.length >= 1, 'soft warning near the cap');
+});
+
+test('validateCore: exactly 40 lines is valid', () => {
+  const r = validateCore(coreWithFiller(36));
+  assert.equal(r.ok, true);
+  assert.equal(r.lineCount, 40);
+  assert.ok(r.warnings.length >= 1, 'warns at the upper edge');
+});
+
+test('validateCore: preserves byte and line-character budgets', () => {
+  const overBytes = validateCore(coreWithFiller(36, () => `- ${'x'.repeat(320)}`));
+  assert.equal(overBytes.ok, false);
+  assert.ok(overBytes.errors.some((e) => /bytes/i.test(e)), 'reports byte budget');
+
+  const overLineChars = validateCore(coreWithFiller(1, () => `- ${'x'.repeat(320)}`));
+  assert.equal(overLineChars.ok, false);
+  assert.ok(overLineChars.errors.some((e) => /caracteres|characters/i.test(e)), 'reports line-character budget');
 });
 
 test('renderCoreSkeleton: the seeded CORE passes its own validator', () => {
@@ -58,7 +80,7 @@ test('renderCoreSkeleton: the seeded CORE passes its own validator', () => {
 
 test('renderCompactionProtocol: documents the protocol essentials', () => {
   const md = renderCompactionProtocol();
-  assert.match(md, /cap 25|25 linhas/i);
+  assert.match(md, /cap 40|40 linhas/i);
   assert.match(md, /Preferências do Usuário/);
   assert.match(md, /wendkeep validate-memory/);
   assert.match(md, /DIGEST/);

--- a/tests/vault-health-memory.test.mjs
+++ b/tests/vault-health-memory.test.mjs
@@ -692,7 +692,7 @@ test('[req:DIAG-8] ledger/projection lag and hash divergence are blocking', () =
   } finally { rmSync(vault, { recursive: true, force: true }); }
 });
 
-test('[req:DIAG-8] active semantic conflicts explain safe human curation without leaking or mutating', () => {
+test('[req:DIAG-8] [req:DIAG-12] [req:MEM-HYB-7] active semantic conflicts explain safe human curation without leaking or mutating', () => {
   const vault = createBundle();
   try {
     writeFileSync(join(vault, '.brain', 'MEMORY_CANDIDATES.jsonl'), [
@@ -710,6 +710,8 @@ test('[req:DIAG-8] active semantic conflicts explain safe human curation without
     const result = checkMemoryBundle(vault);
     assert.equal(result.ok, false);
     assert.equal(result.metrics.activeConflicts, 2);
+    assert.notEqual(result.metrics.semanticCode, 'MEMORY_SEMANTIC_EMPTY_NEUTRAL');
+    assert.ok(result.metrics.semanticCounts.candidates >= 2, 'preserved candidates are visible to semantic health');
     const failure = result.failures.find((item) => /conflitos? ativos?/i.test(item));
     assert.ok(failure);
     assert.match(failure, /conflito semântico.*curadoria humana/i);

--- a/wendkeep.sensors.json
+++ b/wendkeep.sensors.json
@@ -106,6 +106,46 @@
       "command": "node bin/wendkeep.mjs memory status --gate"
     },
     {
+      "id": "decision-digest-writer",
+      "name": "Decision digest writer",
+      "description": "Validates resolved ADR links and deterministic decision titles in the digest",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test tests/brain-core.test.mjs tests/prose-decisions.test.mjs"
+    },
+    {
+      "id": "shared-memory-injection",
+      "name": "Shared memory injection",
+      "description": "Validates direct CORE/SHARED SessionStart blocks and recall-only digest behavior",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test tests/brain-inject-memory.test.mjs tests/init-codex-hooks.test.mjs"
+    },
+    {
+      "id": "core-curation-limit",
+      "name": "CORE curation limit",
+      "description": "Validates the 40-line CORE cap, 35-line warning and byte/character budgets",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test tests/validate-core.test.mjs"
+    },
+    {
+      "id": "semantic-memory-health",
+      "name": "Semantic memory health",
+      "description": "Validates semantic coverage diagnostics without exposing memory values",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test tests/memory-semantic-health.test.mjs tests/validate-memory-cli.test.mjs tests/vault-health-memory.test.mjs"
+    },
+    {
+      "id": "memory-vertical-e2e",
+      "name": "Memory vertical E2E",
+      "description": "Validates Codex and Claude Stop-to-SessionStart structured handoff continuity",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test tests/memory-hybrid-e2e.test.mjs tests/session-memory-lifecycle.test.mjs tests/brain-inject-memory.test.mjs"
+    },
+    {
       "id": "doctor-copyable-repair-commands",
       "name": "Doctor copyable repair commands",
       "description": "Validates local executable prefix, resolved Vault quoting and dry-run/apply ordering in doctor output",


### PR DESCRIPTION
## O que mudou

- adiciona handoff estruturado entre providers com `work_session_id` e sete categorias operacionais;
- preserva CORE curado, amplia o budget para 40/35 linhas e mantém SHARED gerado;
- adiciona marcador seguro para conflitos, cobertura semântica do bundle e diagnóstico sem vazamento;
- resolve títulos de ADR no DIGEST e prova Codex/Claude Stop → SessionStart;
- atualiza sensores, definições, documentação bilíngue e release para `0.69.0`.

## Verificação

- `npm test` — verde após o bump;
- `npm run check` — verde;
- `node --test tests/docs-bilingual.test.mjs tests/readme-packaging.test.mjs` — 21/21;
- `node scripts/privacy-hygiene.mjs` — verde;
- `node bin/wendkeep.mjs sync-defs --check --vault .WendKeep-vault --project .` — verde;
- `npm run release -- --dry-run` — publish/tag/push planejados.

## Release

O pacote está em `0.69.0`; a versão `0.68.6` já existe no npm. A publicação efetiva será feita após revisão/merge e autenticação npm válida.