### PR TITLE
chore: wire local observer hooks in repository

### DIFF
--- a/.agents/skills/example-skill/.wendkeep-meta.json
+++ b/.agents/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.69.0",
+  "wendkeepVersion": "0.70.0",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.agents/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.agents/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.69.0",
+  "wendkeepVersion": "0.70.0",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.agents/skills/wk-debugging/.wendkeep-meta.json
+++ b/.agents/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.69.0",
+  "wendkeepVersion": "0.70.0",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.agents/skills/wk-planning/.wendkeep-meta.json
+++ b/.agents/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.69.0",
+  "wendkeepVersion": "0.70.0",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.agents/skills/wk-tdd/.wendkeep-meta.json
+++ b/.agents/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.69.0",
+  "wendkeepVersion": "0.70.0",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.agents/skills/wk-verify/.wendkeep-meta.json
+++ b/.agents/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.69.0",
+  "wendkeepVersion": "0.70.0",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.agents/skills/wk-workflow/.wendkeep-meta.json
+++ b/.agents/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.69.0",
+  "wendkeepVersion": "0.70.0",
   "sourceHash": "ee0cb172a5b5bbd2ebb5c7e4039ba1a9081992f0461da98d508a5cba67ab23db"
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,17 @@
             "statusMessage": "wendkeep: opening Obsidian session"
           }
         ]
+      },
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx wendkeep hook observer-publish",
+            "timeout": 5,
+            "statusMessage": "wendkeep: publishing local observer snapshot"
+          }
+        ]
       }
     ],
     "Stop": [
@@ -45,6 +56,16 @@
             "args": [
               "${CLAUDE_PROJECT_DIR}/node_modules/wendkeep/hooks/change-nag.mjs"
             ]
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx wendkeep hook observer-publish",
+            "timeout": 5,
+            "statusMessage": "wendkeep: publishing local observer snapshot"
           }
         ]
       }

--- a/.claude/skills/example-skill/.wendkeep-meta.json
+++ b/.claude/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.69.0",
+  "wendkeepVersion": "0.70.0",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.claude/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.claude/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.69.0",
+  "wendkeepVersion": "0.70.0",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.claude/skills/wk-debugging/.wendkeep-meta.json
+++ b/.claude/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.69.0",
+  "wendkeepVersion": "0.70.0",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.claude/skills/wk-planning/.wendkeep-meta.json
+++ b/.claude/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.69.0",
+  "wendkeepVersion": "0.70.0",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.claude/skills/wk-tdd/.wendkeep-meta.json
+++ b/.claude/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.69.0",
+  "wendkeepVersion": "0.70.0",
   "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
 }

--- a/.claude/skills/wk-verify/.wendkeep-meta.json
+++ b/.claude/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.69.0",
+  "wendkeepVersion": "0.70.0",
   "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
 }

--- a/.claude/skills/wk-workflow/.wendkeep-meta.json
+++ b/.claude/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.69.0",
+  "wendkeepVersion": "0.70.0",
   "sourceHash": "ee0cb172a5b5bbd2ebb5c7e4039ba1a9081992f0461da98d508a5cba67ab23db"
 }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -22,6 +22,17 @@
             "statusMessage": "wendkeep: opening Obsidian session"
           }
         ]
+      },
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx wendkeep hook observer-publish",
+            "timeoutSec": 5,
+            "statusMessage": "wendkeep: publishing local observer snapshot"
+          }
+        ]
       }
     ],
     "Stop": [
@@ -42,6 +53,16 @@
             "command": "npx wendkeep hook change-nag",
             "timeoutSec": 15,
             "statusMessage": "wendkeep: open tasks check"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx wendkeep hook observer-publish",
+            "timeoutSec": 5,
+            "statusMessage": "wendkeep: publishing local observer snapshot"
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- wendkeep:skills:start -->
-<!-- wendkeep-version: 0.69.0; skills-sha256: d170f56e18f94318178d4062b722c40275d07c10e76021f95d16f441d498328d -->
+<!-- wendkeep-version: 0.70.0; skills-sha256: d170f56e18f94318178d4062b722c40275d07c10e76021f95d16f441d498328d -->
 ## wendkeep — Keep Core & operating profiles
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. **Keep Core is always active**


### PR DESCRIPTION
## Resumo

Persiste a configuração gerada pelo WendKeep 0.70.0 no próprio repositório.

## Incluído

- publica snapshot sanitizado no Observer em startup/resume/clear/compact;
- publica snapshot sanitizado no Stop;
- aplica o wiring ao Codex e ao Claude;
- atualiza os metadados/AGENTS para refletir a versão instalada 0.70.0.

## Evidência

- JSON de `.codex/hooks.json` e `.claude/settings.json` válido;
- 4 entradas `observer-publish` presentes;
- hook real já publicou snapshot do WendKeep no container `127.0.0.1:8787`;
- sem mudança de versão npm ou conteúdo de vault.