### PR TITLE
fix: preserve npm trusted publisher identity

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,8 +1,7 @@
-name: release
+name: auto-tag-release
 
 on:
   workflow_call:
-  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,5 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    uses: ./.github/workflows/release.yml
+    uses: ./.github/workflows/auto-tag.yml
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ All notable changes to **wendkeep** are documented here. Format based on
 - **Ingestão SQL grande em runners lentos.** O timeout HTTP cresce com o tamanho bruto do lote até
   60 segundos, preservando 15 segundos para payloads vazios/pequenos e evitando outbox falsa para
   lotes gzip válidos acima de 64 MB.
+- **Trusted Publisher preservado após o gate de CI.** O workflow reutilizável mantém o nome
+  `auto-tag.yml` já autorizado no npm, mas só é chamado pelo job de release depois que toda a
+  matriz da `main` fica verde.
 
 ## [0.72.0] — 2026-08-17
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Atomic release: publish to npm, tag, and push — so the tag always exists on
-// origin. Creating the GitHub Release itself is left to .github/workflows/release.yml
+// origin. Creating the GitHub Release itself is left to .github/workflows/auto-tag.yml
 // (fires on the tag push), which keeps a single source of truth and means even a
 // bare `git push --tags` produces a release.
 //
@@ -110,6 +110,6 @@ executeRelease(commands, {
 
 console.log(
   `\n✔ ${tag} publicado e pushado.` +
-    `\n  A GitHub Release é criada pelo workflow release.yml no push da tag.` +
+    `\n  A GitHub Release é criada pelo workflow auto-tag.yml após a CI verde da main.` +
     (DRY ? '\n  (dry-run: nada foi executado)\n' : '\n')
 );

--- a/src/release-changelog.mjs
+++ b/src/release-changelog.mjs
@@ -1,5 +1,5 @@
 // Pure helper: extract a single version's release notes from a Keep-a-Changelog
-// file. Reused by scripts/release.mjs and .github/workflows/release.yml so the
+// file. Reused by scripts/release.mjs and .github/workflows/auto-tag.yml so the
 // GitHub Release body always matches the committed CHANGELOG.
 
 const HEADER_RE = /^##\s*\[([^\]]+)\]\s*[—–-]\s*(.+?)\s*$/;

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -13,7 +13,7 @@ import {
 } from '../scripts/release-plan.mjs';
 
 const TEST_WORKFLOW = readFileSync(new URL('../.github/workflows/test.yml', import.meta.url), 'utf8');
-const RELEASE_WORKFLOW = readFileSync(new URL('../.github/workflows/release.yml', import.meta.url), 'utf8');
+const RELEASE_WORKFLOW = readFileSync(new URL('../.github/workflows/auto-tag.yml', import.meta.url), 'utf8');
 const AGENT_RULES = readFileSync(new URL('../AGENTS.md', import.meta.url), 'utf8');
 const CHANGELOG = readFileSync(new URL('../CHANGELOG.md', import.meta.url), 'utf8');
 const PACKAGE = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
@@ -128,7 +128,7 @@ test('[sensor:release-tests] as notas de 0.68.1 seguem extraíveis depois do bum
 test('[sensor:release-tests] [req:REL-CI-1] release depende da matriz verde do mesmo SHA', () => {
   assert.match(TEST_WORKFLOW, /^  release:\r?\n    needs:\s*test$/m);
   assert.match(TEST_WORKFLOW, /github\.event_name\s*==\s*'push'[\s\S]*github\.ref\s*==\s*'refs\/heads\/main'/);
-  assert.match(TEST_WORKFLOW, /uses:\s*\.\/\.github\/workflows\/release\.yml/);
+  assert.match(TEST_WORKFLOW, /uses:\s*\.\/\.github\/workflows\/auto-tag\.yml/);
   assert.doesNotMatch(RELEASE_WORKFLOW, /^\s{2}push:/m, 'release não pode disparar em paralelo por push/tag');
   assert.match(RELEASE_WORKFLOW, /^\s{2}workflow_call:\s*$/m);
 });


### PR DESCRIPTION
## Resumo

- mantém `.github/workflows/auto-tag.yml`, o filename já autorizado no Trusted Publisher do npm;
- transforma esse workflow em reutilizável, sem gatilho próprio de push ou dispatch;
- chama a publicação somente pelo job `release`, após `needs: test` na `main`;
- atualiza testes, documentação e notas da 0.72.1.

## Evidência

A matriz da `main` no commit `fd31d3f6…` ficou 8/8 verde. O job de release começou somente depois e o npm recusou `release.yml` com E404 de autorização. A documentação oficial do npm vincula o Trusted Publisher ao **workflow filename**.

## Validação local

- testes de release/changelog e proveniência: 46/46;
- syntax check dos módulos alterados;
- `git diff --check`.