### PR TITLE
fix: gate trusted publish in top-level workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,7 +1,8 @@
 name: auto-tag-release
 
 on:
-  workflow_call:
+  push:
+    branches: [main]
 
 permissions:
   contents: write
@@ -12,7 +13,34 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, node: 18, scope: core }
+          - { os: windows-latest, node: 18, scope: core }
+          - { os: ubuntu-latest, node: 20, scope: core }
+          - { os: windows-latest, node: 20, scope: core }
+          - { os: ubuntu-latest, node: 22.13.0, scope: full }
+          - { os: windows-latest, node: 22.13.0, scope: full }
+          - { os: ubuntu-latest, node: 24, scope: full }
+          - { os: windows-latest, node: 24, scope: full }
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci --ignore-scripts
+      - if: matrix.scope == 'core'
+        run: npm run test:core
+      - if: matrix.scope == 'full'
+        run: npm test
+      - run: npm run check
+
   release:
+    needs: test
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: test
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 jobs:
@@ -31,12 +29,3 @@ jobs:
       - if: matrix.scope == 'full'
         run: npm test
       - run: npm run check
-
-  release:
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: write
-      id-token: write
-    uses: ./.github/workflows/auto-tag.yml
-    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@ All notable changes to **wendkeep** are documented here. Format based on
 - **Ingestão SQL grande em runners lentos.** O timeout HTTP cresce com o tamanho bruto do lote até
   60 segundos, preservando 15 segundos para payloads vazios/pequenos e evitando outbox falsa para
   lotes gzip válidos acima de 64 MB.
-- **Trusted Publisher preservado após o gate de CI.** O workflow reutilizável mantém o nome
-  `auto-tag.yml` já autorizado no npm, mas só é chamado pelo job de release depois que toda a
-  matriz da `main` fica verde.
+- **Trusted Publisher preservado após o gate de CI.** `auto-tag.yml`, o workflow já autorizado no
+  npm, passa a executar a matriz da `main` e mantém o publish em um job com `needs: test`;
+  `test.yml` fica exclusivo para pull requests.
 
 ## [0.72.0] — 2026-08-17
 

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -126,14 +126,14 @@ test('[sensor:release-tests] as notas de 0.68.1 seguem extraíveis depois do bum
 });
 
 test('[sensor:release-tests] [req:REL-CI-1] release depende da matriz verde do mesmo SHA', () => {
-  assert.match(TEST_WORKFLOW, /^  release:\r?\n    needs:\s*test$/m);
-  assert.match(TEST_WORKFLOW, /github\.event_name\s*==\s*'push'[\s\S]*github\.ref\s*==\s*'refs\/heads\/main'/);
-  assert.match(TEST_WORKFLOW, /uses:\s*\.\/\.github\/workflows\/auto-tag\.yml/);
-  assert.doesNotMatch(RELEASE_WORKFLOW, /^\s{2}push:/m, 'release não pode disparar em paralelo por push/tag');
-  assert.match(RELEASE_WORKFLOW, /^\s{2}workflow_call:\s*$/m);
+  assert.match(RELEASE_WORKFLOW, /^  release:\r?\n    needs:\s*test$/m);
+  assert.match(RELEASE_WORKFLOW, /^  push:\r?\n    branches:\s*\[main\]$/m);
+  assert.match(RELEASE_WORKFLOW, /^  test:\r?\n    strategy:/m);
+  assert.doesNotMatch(TEST_WORKFLOW, /^\s{2}push:/m, 'test.yml fica exclusivo para pull requests');
+  assert.match(TEST_WORKFLOW, /^\s{2}pull_request:\s*$/m);
 });
 
-test('[sensor:release-tests] [req:REL-CI-2] workflow chamado publica antes de criar a tag no SHA testado', () => {
+test('[sensor:release-tests] [req:REL-CI-2] workflow confiável publica antes de criar a tag no SHA testado', () => {
   const permissions = RELEASE_WORKFLOW.match(/^permissions:\r?\n(?:  [^\r\n]+\r?\n?)+/m)?.[0] || '';
   assert.match(permissions, /id-token:\s*write/);
   assert.match(RELEASE_WORKFLOW, /registry-url:\s*['"]https:\/\/registry\.npmjs\.org['"]/);


### PR DESCRIPTION
## Resumo

- torna `auto-tag.yml` o workflow de push da `main`, preservando a identidade já autorizada no npm;
- executa a matriz completa dentro desse mesmo workflow;
- mantém `release` com `needs: test`, no mesmo SHA;
- deixa `test.yml` exclusivo para pull requests.

## Causa comprovada

O npm valida o workflow **chamador** quando há `workflow_call`. Por isso, o publish do run 160 ainda foi identificado como `test.yml`, apesar de o filho ser `auto-tag.yml`, e recebeu E404. A arquitetura desta PR remove o `workflow_call` do caminho de publicação.

## Validação local

- testes de release/changelog e proveniência: 46/46;
- `git diff --check`;
- regras de workflow cobertas por teste estrutural.