### PR TITLE
fix: extend timeout for oversized Observer batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to **wendkeep** are documented here. Format based on
   inteiro exato e tolera a inconsistência conhecida do serial de volume do libuv antigo, evitando
   falsos `VAULT_PATH_UNSAFE` no Node.js 22.13 sem relaxar a rejeição de hardlinks ou reparses.
 - **Ingestão SQL grande em runners lentos.** O timeout HTTP cresce com o tamanho bruto do lote até
-  60 segundos, preservando 15 segundos para payloads vazios/pequenos e evitando outbox falsa para
+  120 segundos, preservando 15 segundos para payloads vazios/pequenos e evitando outbox falsa para
   lotes gzip válidos acima de 64 MB.
 - **Trusted Publisher preservado após o gate de CI.** `auto-tag.yml`, o workflow já autorizado no
   npm, passa a executar a matriz da `main` e mantém o publish em um job com `needs: test`;

--- a/src/observer-sql-publish.mjs
+++ b/src/observer-sql-publish.mjs
@@ -22,7 +22,7 @@ const SQL_SCHEMA_VERSION = 1;
 export const SQL_EVENT_BATCH_SIZE = 64;
 export const SQL_EVENT_BATCH_BYTES = 8 * 1024 * 1024;
 const REQUEST_TIMEOUT_MS = 15000;
-const MAX_REQUEST_TIMEOUT_MS = 60000;
+const MAX_REQUEST_TIMEOUT_MS = 120000;
 const REQUEST_TIMEOUT_BYTES_STEP = 1024 * 1024;
 const CAPTURE_LEVELS = new Set(['metadata', 'messages', 'full-transcript']);
 
@@ -31,7 +31,7 @@ export function observerSqlRequestTimeoutMs(rawBytes) {
   const oversizedBytes = Math.max(0, size - SQL_EVENT_BATCH_BYTES);
   return Math.min(
     MAX_REQUEST_TIMEOUT_MS,
-    REQUEST_TIMEOUT_MS + Math.ceil(oversizedBytes / REQUEST_TIMEOUT_BYTES_STEP) * 500,
+    REQUEST_TIMEOUT_MS + Math.ceil(oversizedBytes / REQUEST_TIMEOUT_BYTES_STEP) * 1000,
   );
 }
 

--- a/tests/observer-sql-publish.test.mjs
+++ b/tests/observer-sql-publish.test.mjs
@@ -21,8 +21,8 @@ const MUTATION_HEADERS = { 'content-type': 'application/json', authorization: `B
 test('[req:SQL-OBS-10] timeout de ingestão cresce com o payload e permanece limitado', () => {
   assert.equal(observerSqlRequestTimeoutMs(0), 15_000);
   assert.equal(observerSqlRequestTimeoutMs(8 * 1024 * 1024), 15_000);
-  assert.equal(observerSqlRequestTimeoutMs(70 * 1024 * 1024), 46_000);
-  assert.equal(observerSqlRequestTimeoutMs(1024 * 1024 * 1024), 60_000);
+  assert.equal(observerSqlRequestTimeoutMs(70 * 1024 * 1024), 77_000);
+  assert.equal(observerSqlRequestTimeoutMs(1024 * 1024 * 1024), 120_000);
 });
 
 function sessionFixture(fixture, transcriptPath) {


### PR DESCRIPTION
## Resumo

- mantém 15 s para lotes de até 8 MB;
- aumenta a janela proporcional dos lotes maiores para 1 s/MiB excedente;
- limita o timeout em 120 s;
- atualiza o teste e as notas da 0.72.1.

## Evidência

No run 49 de `auto-tag-release`, o lote bruto de ~70 MB levou ~56 s no Windows/Node 24 e excedeu a janela anterior de 46 s. Com a nova fórmula, esse lote recebe 77 s.

## Validação local

- teste real de transporte gzip >64 MB;
- teste puro da função de timeout;
- syntax check e `git diff --check`.