### PR TITLE
fix: harden Observer incremental publication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- wendkeep:skills:start -->
-<!-- wendkeep-version: 0.75.0; skills-sha256: 416206a455a3834f8d025f7a2827796b6a0e9c2b3f45cb45adb110a06cea0eee -->
+<!-- wendkeep-version: 0.75.1; skills-sha256: 416206a455a3834f8d025f7a2827796b6a0e9c2b3f45cb45adb110a06cea0eee -->
 ## wendkeep — Keep Core & operating profiles
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. **Keep Core is always active**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.75.1] — 2026-08-20
+
+### Fixed
+
+- **Coalescência sem perda.** A outbox seleciona o identificador próprio de cada tipo de evento;
+  chamadas, agentes, rollups e transcripts distintos da mesma sessão não disputam mais a mesma chave.
+- **Reconciliação realmente integral.** `observer reconcile --url` e `observer memory import`
+  ignoram o cursor incremental local, consultam as revisões remotas e regeneram documentos,
+  consumo, chamadas e transcripts mesmo após restauração ou troca do Observer.
+- **Leases compatíveis com o transporte.** Locks de batch e publisher permanecem válidos além do
+  timeout máximo de request e só podem ser liberados pelo proprietário que os adquiriu.
+
 ## [0.75.0] — 2026-08-20
 
 ### Added

--- a/README.en.md
+++ b/README.en.md
@@ -88,7 +88,7 @@ Decisions, dead ends, the reason you chose X over Y — gone next session. The p
 | **Cost** — what it all cost | Per‑model, cache‑aware token pricing per session — plus `cost --trend` with a run‑rate projection across the whole vault; research previews without a final rate remain unestimated. |
 | **Multi‑agent** — one vault, both agents | `init` wires the session hooks into `.claude/settings.json` *and* `.codex/hooks.json`, and every note is tagged with the agent that wrote it: Claude Code is detected from its environment, anything else is recorded as Codex. One shared graph, whichever agent you are in. |
 | **Local‑first** — no cloud, no account | Everything is plain Markdown on your disk. An optional MCP server (`@bitbonsai/mcpvault`) lets the agent read/write the vault. |
-| **Local Observer** — many projects, one view | `wendkeep observer` keeps documents, FTS5 chunks, sessions, agents, tokens, costs, calls, and transcripts in SQLite. Identities and foreign keys are project-scoped; each event is atomic. Hooks publish only what changed, while `observer reconcile` reserves full scans for explicit recovery. |
+| **Local Observer** — many projects, one view | `wendkeep observer` keeps documents, FTS5 chunks, sessions, agents, tokens, costs, calls, and transcripts in SQLite. Identities and foreign keys are project-scoped; each event is atomic. Hooks publish only what changed; `observer reconcile --url` ignores the incremental cursor to regenerate the complete projection while preserving local/remote revision baselines. |
 
 During historical migration, the Observer preserves differences between frontmatter totals and the
 ledger as explicit reconciliation rows, and disambiguates duplicate `session_id` values per file

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Decisões, becos sem saída, o motivo de você ter escolhido X em vez de Y — s
 | **Custo** — quanto tudo custou | Preço por modelo, ciente de cache, por sessão — mais `cost --trend` com projeção run‑rate no cofre inteiro; research previews sem tarifa final ficam como custo não estimado. |
 | **Multi‑agente** — um cofre, os dois agentes | O `init` wira os hooks de sessão no `.claude/settings.json` *e* no `.codex/hooks.json`, e cada nota é marcada com o agente que a escreveu: o Claude Code é detectado pelo ambiente dele, qualquer outro é registrado como Codex. Um grafo só, esteja você em qual agente estiver. |
 | **Local‑first** — sem nuvem, sem conta | Tudo é Markdown puro no seu disco. Um MCP opcional (`@bitbonsai/mcpvault`) deixa o agente ler/escrever o cofre. |
-| **Observer local** — vários projetos, uma visão | `wendkeep observer` mantém no SQLite documentos, chunks FTS5, sessões, agentes, tokens, custos, chamadas e transcripts. Identidades e foreign keys são escopadas por projeto; cada evento é atômico. Hooks publicam apenas o que mudou e `observer reconcile` reserva a varredura integral para recuperação explícita. |
+| **Observer local** — vários projetos, uma visão | `wendkeep observer` mantém no SQLite documentos, chunks FTS5, sessões, agentes, tokens, custos, chamadas e transcripts. Identidades e foreign keys são escopadas por projeto; cada evento é atômico. Hooks publicam apenas o que mudou; `observer reconcile --url` ignora o cursor incremental para regenerar toda a projeção, preservando os baselines de revisão local/remoto. |
 
 Na migração histórica, o Observer preserva diferenças entre o total do frontmatter e o ledger em
 linhas explícitas de reconciliação, e desambigua `session_id` duplicado por arquivo sem inventar

--- a/docs/en/commands/observer.md
+++ b/docs/en/commands/observer.md
@@ -92,8 +92,13 @@ agent sessions, cost rollups, and calls. Messages and transcripts are only sent 
 that explicitly enable them. The container stores everything in
 `/data/observer.sqlite`; it does not mount `C:\GitHub` or any `.WendKeep-vault`. Markdown is only
 the text held in SQL and is recreated as files only by an explicit read-only export.
-`memory import` performs the initial load and returns file/hash parity. During migration, the
-cost/token total recorded in frontmatter is preserved through an explicit reconciliation row when
+`memory import` performs the initial load and returns file/hash parity. The remote recovery
+commands `observer reconcile --url` and `observer memory import` do not use the
+incremental cursor to decide what to omit: they regenerate documents, sessions, usage, calls, and
+transcripts. The cursor still supplies the local revision baseline and the remote tree, when
+available, supplies the highest known baseline; a transient read failure never lowers the locally
+persisted revision. During migration, the cost/token total recorded in frontmatter is preserved
+through an explicit reconciliation row when
 the detailed ledger does not add up; that row does not invent calls. Historical sessions sharing
 one `session_id` receive a canonical per-file identity so one rollup cannot overwrite the other.
 

--- a/docs/pt-BR/commands/observer.md
+++ b/docs/pt-BR/commands/observer.md
@@ -94,6 +94,11 @@ níveis de captura que os habilitam. O container grava tudo em
 `/data/observer.sqlite`; não monta `C:\GitHub` nem qualquer `.WendKeep-vault`. Markdown é aceito
 somente como conteúdo de uma coluna SQL e volta a existir como arquivo apenas pela exportação
 read-only sob demanda. `memory import` faz a carga inicial e retorna a paridade por arquivo e hash.
+Na recuperação remota, `observer reconcile --url` e `observer memory import` não usam o cursor
+incremental para decidir o que omitir: regeneram documentos, sessões, consumo, chamadas e
+transcripts. O cursor continua fornecendo o baseline local de revisão e a árvore remota, quando
+disponível, fornece o maior baseline conhecido; uma falha temporária nessa leitura nunca reduz a
+revisão persistida localmente.
 Na migração, o total de custo/token registrado no frontmatter é preservado por uma linha de
 reconciliação quando o ledger detalhado não fecha com ele; essa linha não inventa chamadas.
 Sessões históricas com o mesmo `session_id` recebem uma identidade canônica por arquivo para

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.75.0",
+  "version": "0.75.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.75.0",
+      "version": "0.75.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.75.0",
+  "version": "0.75.1",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [

--- a/src/observer-sql-publish.mjs
+++ b/src/observer-sql-publish.mjs
@@ -263,7 +263,7 @@ function dedupeEvents(events) {
   });
 }
 
-export function buildObserverSqlEventBatch({ vaultBase, projectId, input = {}, now = new Date(), state = readState(vaultBase), remoteDocuments = {}, captureLevel = process.env.WENDKEEP_OBSERVER_CAPTURE_LEVEL || 'metadata' } = {}) {
+export function buildObserverSqlEventBatch({ vaultBase, projectId, input = {}, now = new Date(), state = readState(vaultBase), remoteDocuments = {}, captureLevel = process.env.WENDKEEP_OBSERVER_CAPTURE_LEVEL || 'metadata', forceFull = false } = {}) {
   if (!vaultBase || !projectId) throw new Error('vaultBase e projectId são obrigatórios.');
   const occurredAt = isoNow(now);
   const resolvedCaptureLevel = normalizeObserverCaptureLevel(captureLevel);
@@ -290,7 +290,7 @@ export function buildObserverSqlEventBatch({ vaultBase, projectId, input = {}, n
     nextState.files[file.logicalPath] = { content_hash: contentHash, revision: revision || 1 };
     const fm = parseFrontmatter(content);
     if (fm.type === 'session') sessionContexts.push({ file, content, fm, contentHash, revision: revision || 1, sessionId: sessionIdentity.get(file.logicalPath) });
-    if (previous?.content_hash === contentHash) continue;
+    if (!forceFull && previous?.content_hash === contentHash) continue;
     changed += 1;
     events.push(documentEvent({ projectId, logicalPath: file.logicalPath, content, metadata: fm, revision: revision || 1, occurredAt }));
     if (fm.type === 'session') {
@@ -310,7 +310,7 @@ export function buildObserverSqlEventBatch({ vaultBase, projectId, input = {}, n
       const content = readFileSync(source.path, 'utf8');
       const fingerprint = hash(content);
       const previousTranscript = state.transcripts?.[source.transcriptId];
-      if (previousTranscript?.content_hash === fingerprint && previousTranscript?.coverage === resolvedCaptureLevel) continue;
+      if (!forceFull && previousTranscript?.content_hash === fingerprint && previousTranscript?.coverage === resolvedCaptureLevel) continue;
       const complete = completeTranscriptEvents({ projectId, sessionId, mainAgentId, provider, model, source, now: occurredAt, captureLevel: resolvedCaptureLevel });
       nextState.transcripts[source.transcriptId] = { content_hash: complete.fingerprint, coverage: resolvedCaptureLevel };
       const summaryId = complete.transcriptId;
@@ -787,14 +787,11 @@ export async function publishObserverSqlIncremental({
 export async function publishObserverSql({ vaultBase, projectId, url = process.env.WENDKEEP_OBSERVER_URL || '', input = {}, now = new Date(), fetchImpl = globalThis.fetch, token = process.env.WENDKEEP_OBSERVER_TOKEN || '', captureLevel = process.env.WENDKEEP_OBSERVER_CAPTURE_LEVEL || 'metadata', forceFull = false } = {}) {
   if (!vaultBase || !projectId) throw new Error('vaultBase e projectId são obrigatórios.');
   const replay = await retryObserverSqlOutbox({ vaultBase, projectId, url, fetchImpl, token });
-  const persistedState = readState(vaultBase);
-  const state = forceFull
-    ? { schema_version: SQL_SCHEMA_VERSION, files: {}, transcripts: {} }
-    : persistedState;
+  const state = readState(vaultBase);
   const remoteDocuments = forceFull || Object.keys(state.files || {}).length === 0
     ? await readRemoteDocuments({ url, projectId, fetchImpl, token })
     : {};
-  const batch = buildObserverSqlEventBatch({ vaultBase, projectId, input, now, state, remoteDocuments, captureLevel });
+  const batch = buildObserverSqlEventBatch({ vaultBase, projectId, input, now, state, remoteDocuments, captureLevel, forceFull });
   if (!batch.events.length) {
     atomicJson(statePath(vaultBase), batch.nextState);
     return { ok: true, queued: false, scanned: batch.scanned, changed: batch.changed, pending: listSqlOutbox(vaultBase).length, replay };

--- a/src/observer-sql-publish.mjs
+++ b/src/observer-sql-publish.mjs
@@ -26,6 +26,7 @@ export const SQL_EVENT_BATCH_SIZE = 64;
 export const SQL_EVENT_BATCH_BYTES = 8 * 1024 * 1024;
 const REQUEST_TIMEOUT_MS = 15000;
 const MAX_REQUEST_TIMEOUT_MS = 120000;
+export const SQL_LEASE_STALE_MS = MAX_REQUEST_TIMEOUT_MS + 30000;
 const REQUEST_TIMEOUT_BYTES_STEP = 1024 * 1024;
 const CAPTURE_LEVELS = new Set(['metadata', 'messages', 'full-transcript']);
 
@@ -467,11 +468,20 @@ function queueOutbox(vaultBase, batch) {
 
 function eventCoalesceKey(event) {
   const payload = event.payload || {};
+  const entityFields = {
+    'document.upsert': ['logical_path'],
+    'document.delete': ['logical_path'],
+    'session.upsert': ['session_id'],
+    'agent.upsert': ['agent_id'],
+    'usage.rollup': ['rollup_key'],
+    llm_call: ['call_id'],
+    'transcript.upsert': ['transcript_id'],
+  }[event.kind] || [];
+  const entityId = entityFields.map((field) => payload[field]).find(Boolean) || event.event_id;
   return [
     event.project_id,
     event.kind,
-    payload.logical_path || payload.session_id || payload.agent_id || payload.rollup_key
-      || payload.call_id || payload.transcript_id || event.event_id,
+    entityId,
   ].join('\u001f');
 }
 
@@ -480,15 +490,17 @@ function waitSync(milliseconds) { Atomics.wait(WAIT_ARRAY, 0, 0, milliseconds); 
 
 function acquireBatchFileLease(path, waitMs = 0) {
   const lock = `${path}.lock`;
+  const token = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const deadline = Date.now() + Math.max(0, waitMs);
   do {
     try {
       mkdirSync(lock);
-      return lock;
+      atomicJson(join(lock, 'owner.json'), { token, pid: process.pid, acquired_at: new Date().toISOString() });
+      return { path: lock, token };
     } catch (error) {
       if (error?.code !== 'EEXIST') throw error;
       try {
-        if (Date.now() - statSync(lock).mtimeMs > 60_000) {
+        if (Date.now() - statSync(lock).mtimeMs > SQL_LEASE_STALE_MS) {
           const stale = `${lock}.stale-${process.pid}-${Date.now()}`;
           renameSync(lock, stale);
           rmSync(stale, { recursive: true, force: true });
@@ -502,8 +514,10 @@ function acquireBatchFileLease(path, waitMs = 0) {
   return null;
 }
 
-function releaseBatchFileLease(lock) {
-  if (lock) rmSync(lock, { recursive: true, force: true });
+function releaseBatchFileLease(lease) {
+  if (!lease) return;
+  const owner = readJson(join(lease.path, 'owner.json'), {});
+  if (owner.token === lease.token) rmSync(lease.path, { recursive: true, force: true });
 }
 
 /** Queue a precise writer batch and replace older pending state for the same logical scope. */
@@ -625,7 +639,7 @@ function acquirePublisherLease(vaultBase, currentTime = Date.now()) {
     if (error?.code !== 'EEXIST') throw error;
     let age = 0;
     try { age = currentTime - statSync(path).mtimeMs; } catch { return null; }
-    if (age <= 60_000) return null;
+    if (age <= SQL_LEASE_STALE_MS) return null;
     const stale = `${path}.stale-${token}`;
     try {
       renameSync(path, stale);
@@ -770,11 +784,14 @@ export async function publishObserverSqlIncremental({
   };
 }
 
-export async function publishObserverSql({ vaultBase, projectId, url = process.env.WENDKEEP_OBSERVER_URL || '', input = {}, now = new Date(), fetchImpl = globalThis.fetch, token = process.env.WENDKEEP_OBSERVER_TOKEN || '', captureLevel = process.env.WENDKEEP_OBSERVER_CAPTURE_LEVEL || 'metadata' } = {}) {
+export async function publishObserverSql({ vaultBase, projectId, url = process.env.WENDKEEP_OBSERVER_URL || '', input = {}, now = new Date(), fetchImpl = globalThis.fetch, token = process.env.WENDKEEP_OBSERVER_TOKEN || '', captureLevel = process.env.WENDKEEP_OBSERVER_CAPTURE_LEVEL || 'metadata', forceFull = false } = {}) {
   if (!vaultBase || !projectId) throw new Error('vaultBase e projectId são obrigatórios.');
   const replay = await retryObserverSqlOutbox({ vaultBase, projectId, url, fetchImpl, token });
-  const state = readState(vaultBase);
-  const remoteDocuments = Object.keys(state.files || {}).length === 0
+  const persistedState = readState(vaultBase);
+  const state = forceFull
+    ? { schema_version: SQL_SCHEMA_VERSION, files: {}, transcripts: {} }
+    : persistedState;
+  const remoteDocuments = forceFull || Object.keys(state.files || {}).length === 0
     ? await readRemoteDocuments({ url, projectId, fetchImpl, token })
     : {};
   const batch = buildObserverSqlEventBatch({ vaultBase, projectId, input, now, state, remoteDocuments, captureLevel });

--- a/src/observer.mjs
+++ b/src/observer.mjs
@@ -147,6 +147,7 @@ export async function runObserver(argv = [], { write = (chunk) => process.stdout
       projectId: snapshot.project_id,
       url,
       token,
+      forceFull: true,
       captureLevel: optionValue(argv, '--capture-level') || process.env.WENDKEEP_OBSERVER_CAPTURE_LEVEL || 'metadata',
     });
     const snapshotResponse = await fetch(`${String(url).replace(/\/$/, '')}/v1/projects/${encodeURIComponent(snapshot.project_id)}/snapshot`, {
@@ -209,6 +210,7 @@ export async function runObserver(argv = [], { write = (chunk) => process.stdout
       projectId: snapshot.project_id,
       url,
       token,
+      forceFull: true,
       captureLevel: optionValue(argv, '--capture-level') || process.env.WENDKEEP_OBSERVER_CAPTURE_LEVEL || 'metadata',
     });
     const snapshotResponse = await fetch(`${String(url).replace(/\/$/, '')}/v1/projects/${encodeURIComponent(snapshot.project_id)}/snapshot`, {

--- a/tests/observer-incremental-publication.test.mjs
+++ b/tests/observer-incremental-publication.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, utimesSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { performance } from 'node:perf_hooks';
 import {
@@ -9,7 +9,9 @@ import {
   enqueueObserverSqlBatch,
   inspectObserverSqlOutbox,
   listSqlOutbox,
+  observerSqlRequestTimeoutMs,
   retryObserverSqlOutbox,
+  SQL_LEASE_STALE_MS,
 } from '../src/observer-sql-publish.mjs';
 import { makeObserverFixture } from './helpers/observer-fixture.mjs';
 
@@ -153,5 +155,66 @@ test('[req:SQL-INCR-4] only one publisher lease drains an outbox', async () => {
     const completed = await first;
     assert.equal(completed.confirmed, 1);
     assert.equal(listSqlOutbox(fixture.vaultBase).length, 0);
+  } finally { fixture.cleanup(); }
+});
+
+test('[req:SQL-INCR-3] coalescing preserves every operational entity in one session', () => {
+  const fixture = makeObserverFixture();
+  try {
+    const base = {
+      schema_version: 1,
+      project_id: fixture.projectId,
+      occurred_at: '2026-08-20T12:00:00Z',
+    };
+    const events = [
+      { ...base, event_id: 'call-event-1', kind: 'llm_call', payload: { session_id: 'same-session', call_id: 'call-1' } },
+      { ...base, event_id: 'call-event-2', kind: 'llm_call', payload: { session_id: 'same-session', call_id: 'call-2' } },
+      { ...base, event_id: 'agent-event-1', kind: 'agent.upsert', payload: { session_id: 'same-session', agent_id: 'agent-1' } },
+      { ...base, event_id: 'agent-event-2', kind: 'agent.upsert', payload: { session_id: 'same-session', agent_id: 'agent-2' } },
+      { ...base, event_id: 'rollup-event-1', kind: 'usage.rollup', payload: { session_id: 'same-session', rollup_key: 'rollup-1' } },
+      { ...base, event_id: 'rollup-event-2', kind: 'usage.rollup', payload: { session_id: 'same-session', rollup_key: 'rollup-2' } },
+      { ...base, event_id: 'transcript-event-1', kind: 'transcript.upsert', payload: { session_id: 'same-session', transcript_id: 'transcript-1' } },
+      { ...base, event_id: 'transcript-event-2', kind: 'transcript.upsert', payload: { session_id: 'same-session', transcript_id: 'transcript-2' } },
+    ];
+    enqueueObserverSqlBatch(fixture.vaultBase, {
+      schema_version: 1, project_id: fixture.projectId, events,
+    }, { scope: 'session:same-session' });
+    const pending = listSqlOutbox(fixture.vaultBase);
+    assert.equal(pending.length, 1);
+    assert.deepEqual(new Set(pending[0].events.map((event) => event.event_id)), new Set(events.map((event) => event.event_id)));
+  } finally { fixture.cleanup(); }
+});
+
+test('[req:SQL-INCR-4] a live batch lease outlives the maximum request timeout', () => {
+  const fixture = makeObserverFixture();
+  try {
+    const event = {
+      schema_version: 1,
+      event_id: 'lease-event-1',
+      kind: 'document.upsert',
+      project_id: fixture.projectId,
+      occurred_at: '2026-08-20T12:00:00Z',
+      payload: { logical_path: 'CORE.md', revision: 1 },
+    };
+    enqueueObserverSqlBatch(fixture.vaultBase, {
+      schema_version: 1, project_id: fixture.projectId, events: [event],
+    }, { scope: 'lease-duration' });
+    const livePath = listSqlOutbox(fixture.vaultBase)[0].path;
+    const lockPath = `${livePath}.lock`;
+    mkdirSync(lockPath);
+    writeFileSync(join(lockPath, 'owner.json'), JSON.stringify({ token: 'still-live' }));
+    const sixtyOneSecondsAgo = new Date(Date.now() - 61_000);
+    utimesSync(lockPath, sixtyOneSecondsAgo, sixtyOneSecondsAgo);
+
+    const fallback = enqueueObserverSqlBatch(fixture.vaultBase, {
+      schema_version: 1,
+      project_id: fixture.projectId,
+      events: [{ ...event, event_id: 'lease-event-2', payload: { logical_path: 'DIGEST.md', revision: 1 } }],
+    }, { scope: 'lease-duration' });
+
+    assert.ok(SQL_LEASE_STALE_MS > observerSqlRequestTimeoutMs(1024 * 1024 * 1024));
+    assert.equal(fallback.coalesced, false);
+    assert.equal(existsSync(lockPath), true);
+    assert.equal(JSON.parse(readFileSync(join(lockPath, 'owner.json'), 'utf8')).token, 'still-live');
   } finally { fixture.cleanup(); }
 });

--- a/tests/observer-sql-publish.test.mjs
+++ b/tests/observer-sql-publish.test.mjs
@@ -83,6 +83,45 @@ test('[req:SQL-OBS-SEC] captura padrão omite mensagens, transcript bruto e cami
   }
 });
 
+test('[req:SQL-INCR-5] forced reconciliation rebuilds operational rows despite a complete local cursor', async () => {
+  const fixture = makeObserverFixture();
+  const transcriptPath = join(fixture.projectRoot, 'reconcile-transcript.jsonl');
+  transcriptFixture(transcriptPath);
+  sessionFixture(fixture, transcriptPath);
+  try {
+    const input = { session_id: 'live-session', transcript_path: transcriptPath, transcript_id: 'live-transcript' };
+    const baseline = buildObserverSqlEventBatch({
+      vaultBase: fixture.vaultBase,
+      projectId: fixture.projectId,
+      input,
+      captureLevel: 'full-transcript',
+      now: '2026-08-20T12:00:00Z',
+    });
+    writeFileSync(join(fixture.vaultBase, '.brain', 'observer-sql-state.json'), `${JSON.stringify(baseline.nextState, null, 2)}\n`);
+    const posted = [];
+    const result = await publishObserverSql({
+      vaultBase: fixture.vaultBase,
+      projectId: fixture.projectId,
+      url: 'http://observer.test',
+      input,
+      captureLevel: 'full-transcript',
+      forceFull: true,
+      now: '2026-08-20T12:01:00Z',
+      fetchImpl: async (url, init = {}) => {
+        if (!init.method) return { ok: true, status: 200, json: async () => ({ documents: [] }) };
+        const body = JSON.parse(gunzipSync(init.body).toString('utf8'));
+        posted.push(...body.events);
+        return { ok: true, status: 201, json: async () => ({ accepted: body.events.length }) };
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.ok(posted.some((event) => event.kind === 'document.upsert'));
+    assert.ok(posted.some((event) => event.kind === 'usage.rollup'));
+    assert.ok(posted.some((event) => event.kind === 'llm_call'));
+    assert.ok(posted.some((event) => event.kind === 'transcript.upsert' && event.payload.coverage === 'complete'));
+  } finally { fixture.cleanup(); }
+});
+
 test('[req:SQL-OBS-10] publisher envia lote gzip quando o JSON puro excede 64 MB', async () => {
   const fixture = makeObserverFixture();
   const dataDir = makeDataDir();

--- a/tests/observer-sql-publish.test.mjs
+++ b/tests/observer-sql-publish.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { gunzipSync } from 'node:zlib';
 import { startObserverServer } from '../src/observer-server.mjs';
@@ -97,6 +97,7 @@ test('[req:SQL-INCR-5] forced reconciliation rebuilds operational rows despite a
       captureLevel: 'full-transcript',
       now: '2026-08-20T12:00:00Z',
     });
+    for (const file of Object.values(baseline.nextState.files)) file.revision = 7;
     writeFileSync(join(fixture.vaultBase, '.brain', 'observer-sql-state.json'), `${JSON.stringify(baseline.nextState, null, 2)}\n`);
     const posted = [];
     const result = await publishObserverSql({
@@ -108,7 +109,7 @@ test('[req:SQL-INCR-5] forced reconciliation rebuilds operational rows despite a
       forceFull: true,
       now: '2026-08-20T12:01:00Z',
       fetchImpl: async (url, init = {}) => {
-        if (!init.method) return { ok: true, status: 200, json: async () => ({ documents: [] }) };
+        if (!init.method) return { ok: false, status: 503, json: async () => ({}) };
         const body = JSON.parse(gunzipSync(init.body).toString('utf8'));
         posted.push(...body.events);
         return { ok: true, status: 201, json: async () => ({ accepted: body.events.length }) };
@@ -119,6 +120,9 @@ test('[req:SQL-INCR-5] forced reconciliation rebuilds operational rows despite a
     assert.ok(posted.some((event) => event.kind === 'usage.rollup'));
     assert.ok(posted.some((event) => event.kind === 'llm_call'));
     assert.ok(posted.some((event) => event.kind === 'transcript.upsert' && event.payload.coverage === 'complete'));
+    assert.ok(posted.filter((event) => event.kind === 'document.upsert').every((event) => event.payload.revision === 7));
+    const persisted = JSON.parse(readFileSync(join(fixture.vaultBase, '.brain', 'observer-sql-state.json'), 'utf8'));
+    assert.ok(Object.values(persisted.files).every((file) => file.revision === 7));
   } finally { fixture.cleanup(); }
 });
 

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -84,6 +84,14 @@ test('extractReleaseNotes: throws when the version is absent', () => {
 test('[sensor:release-tests] current release notes are extractable and match the package', () => {
   const release = extractReleaseNotes(CHANGELOG, PACKAGE.version);
   assert.equal(release.date, '2026-08-20');
+  assert.match(release.notes, /Coalescência sem perda/i);
+  assert.match(release.notes, /Reconciliação realmente integral/i);
+  assert.match(release.notes, /Leases compatíveis com o transporte/i);
+  assert.doesNotMatch(release.notes, /019f[0-9a-f-]+/i);
+});
+
+test('[sensor:release-tests] 0.75.0 Observer consolidation notes remain extractable', () => {
+  const release = extractReleaseNotes(CHANGELOG, '0.75.0');
   assert.match(release.notes, /Identidades SQL escopadas por projeto/i);
   assert.match(release.notes, /Ingest atômico por evento/i);
   assert.match(release.notes, /Reconciliação explícita/i);


### PR DESCRIPTION
## Resumo

Hotfix 0.75.1 para os apontamentos publicados após o merge do PR #65:

- preserva cada chamada, agente, rollup e transcript pela identidade específica da entidade
- força `observer reconcile --url` e `observer memory import` a reconstruírem toda a projeção sem confiar no cursor local
- estende as leases além do timeout máximo de transporte e impede que um proprietário remova o lock de outro
- inclui notas de release e bump para 0.75.1

## Validação

- suíte integral local: 1.549 testes, 1.548 aprovados e 1 skip esperado
- suíte dirigida: 59/59
- cobertura de regressão para os três comentários do review
- `node --check` e `git diff --check`
- árvore remota idêntica à árvore local validada