### PR TITLE
docs: planejar WendKeep 1.0 Project Memory Control Plane

### DIFF
--- a/docs/plans/2026-08-21-wendkeep-control-plane-1-0/phase-01-worktrees-and-active-context.md
+++ b/docs/plans/2026-08-21-wendkeep-control-plane-1-0/phase-01-worktrees-and-active-context.md
@@ -1,0 +1,187 @@
+# Fase 01 — Worktrees, active context e limpeza pós-merge
+
+**Issues:** #70, #71, #72  
+**Prioridade:** P0  
+**Gate da fase:** duas worktrees concorrentes operam no mesmo Vault sem trocar contexto, e uma worktree merged pode ser removida com segurança.
+
+## 1. Objetivo
+
+Construir a fundação operacional multi-worktree do WendKeep. Esta fase precede evidence v2 porque a prova precisa conhecer primeiro qual repository/worktree/session está sendo validado.
+
+## 2. Ordem de execução
+
+1. #70 — worktree manager e binding compartilhado;
+2. #71 — active context escopado;
+3. #72 — cleanup pós-merge.
+
+Cada issue é um PR independente.
+
+## 3. Capability #70 — gerenciador nativo
+
+### Comandos
+
+```text
+wendkeep worktree create <slug> [--base <ref>] [--branch <name>] [--open vscode|none]
+wendkeep worktree list [--json]
+wendkeep worktree status [<slug>] [--json]
+wendkeep worktree open <slug> [--editor vscode]
+```
+
+### Defaults
+
+```text
+root   = .worktrees
+branch = wk/<slug>
+base   = default branch
+```
+
+### Decisões
+
+- localizar common dir com Git, não por suposição de path;
+- derivar worktree identity do linked git dir + repository identity;
+- manter binding do Vault em metadata privada/runtime;
+- não editar `.wendkeep.json` na linked worktree;
+- ignorar `.worktrees/` em Git, scans e indexadores;
+- usar execução de argumentos sem shell interpolation;
+- abertura do VS Code é opcional e injetável em testes.
+
+### Gate
+
+```text
+principal root ─┐
+                ├─ resolve mesmo project_id + Vault
+linked worktree ┘
+```
+
+## 4. Capability #71 — active context
+
+### Chave causal
+
+```text
+project_id + repository_id + worktree_id + work_session_id
+```
+
+### Campos essenciais
+
+```text
+branch
+change_slug
+task_id
+delivery_id
+head_sha
+lease_id
+state
+updated_at
+revision
+```
+
+### Resolução
+
+1. contexto causal da sessão;
+2. único contexto ativo da worktree;
+3. ambiguidade explícita;
+4. nunca fallback para outra worktree.
+
+`CURRENT_CHANGE.md` deixa de ser autoridade e permanece temporariamente como projeção legada apenas quando existe um único contexto inequívoco.
+
+### Gate
+
+Teste de concorrência:
+
+```text
+WT-A / Codex  → change auth
+WT-B / Claude → change observer
+
+intercalar prompt, verify, stop, resume e status
+resultado: nenhum evento/gate usa a change da outra worktree
+```
+
+## 5. Capability #72 — cleanup seguro
+
+### Comandos
+
+```text
+wendkeep worktree finish <slug> --pr <number|url>
+wendkeep worktree cleanup --merged --dry-run|--apply
+wendkeep worktree remove <slug> --reason <text>
+wendkeep worktree prune --dry-run|--apply
+```
+
+### Preflight obrigatório
+
+- PR `MERGED`, não somente `CLOSED`;
+- worktree clean, inclusive untracked;
+- nenhuma sessão ativa;
+- nenhuma delivery ativa;
+- nenhum outbox/handoff pendente;
+- active context encerrável;
+- branch/path pertencem ao registry esperado.
+
+### Efeitos
+
+1. receipt de cleanup;
+2. close/archive do contexto operacional;
+3. remove linked worktree;
+4. delete branch local;
+5. delete remoto somente autorizado;
+6. prune Git metadata;
+7. memória histórica permanece.
+
+## 6. Segurança
+
+- path containment e symlink/hardlink checks reaproveitam Vault path safety quando aplicável;
+- slug/branch possuem grammar documentada;
+- worktree path nunca pode escapar de `worktrees.root`;
+- `--force` exige confirmação humana e motivo;
+- falha de consulta do merge produz `unproven`;
+- cleanup é idempotente e possui recovery after partial failure.
+
+## 7. VS Code
+
+### Antes de #70
+
+```powershell
+New-Item -ItemType Directory -Force .worktrees | Out-Null
+git switch main
+git pull --ff-only
+git worktree add ".worktrees/<slug>" -b "wk/<slug>" main
+code -n ".worktrees/<slug>"
+```
+
+### Depois de #70
+
+```powershell
+node ./bin/wendkeep.mjs worktree create <slug> --open vscode
+```
+
+### Depois do merge e #72
+
+```powershell
+node ./bin/wendkeep.mjs worktree finish <slug> --pr <PR>
+```
+
+## 8. Testes de fase
+
+- Windows e Linux;
+- paths com espaço e Unicode;
+- linked worktree dentro de `.worktrees/`;
+- mesma branch já checked out;
+- duas criações concorrentes;
+- dois active contexts;
+- duas sessões na mesma worktree;
+- detached HEAD;
+- PR merge/squash/rebase;
+- worktree dirty/untracked;
+- crash antes/depois de remove;
+- handles abertos no Windows;
+- migration do ponteiro global.
+
+## 9. Definition of Done
+
+- `.worktrees/` é o padrão gerenciado;
+- linked worktree usa o mesmo Vault sem branch dirty;
+- context routing é inequívoco;
+- hooks e CLI respeitam a worktree chamadora;
+- cleanup não remove trabalho não provado;
+- após merge, pasta, branch local e metadata deixam de existir;
+- histórico, receipts e decisões continuam consultáveis.

--- a/docs/plans/2026-08-21-wendkeep-control-plane-1-0/phase-02-evidence-and-contracts.md
+++ b/docs/plans/2026-08-21-wendkeep-control-plane-1-0/phase-02-evidence-and-contracts.md
@@ -1,0 +1,231 @@
+# Fase 02 — Evidence Envelope, contracts, TDD e commit provenance
+
+**Issues:** #73, #74, #75, #76, #40  
+**Prioridade:** P0/P1  
+**Pré-requisito:** Fase 01  
+**Gate da fase:** archive, commit e delivery só usam prova ligada ao código exato; task/handoff são avaliáveis por máquina.
+
+## 1. Objetivo
+
+Eliminar a diferença entre “foi registrado que passou” e “há prova de que este estado exato do código passou”. Em seguida, transformar tasks e handoffs em contratos derivados da autoria, sem duplicar specs.
+
+## 2. Ordem de execução
+
+1. #73 — Evidence Envelope v2;
+2. #74 — freshness/provenance gates;
+3. #75 — task/handoff contracts;
+4. #76 — TDD attestation;
+5. #40 — commit universal baseado em provas válidas.
+
+## 3. Evidence Envelope v2
+
+### Identidade mínima
+
+```text
+project_id
+repository_id
+worktree_id
+work_session_id
+change_slug
+branch
+```
+
+### Snapshot validado
+
+```text
+base_sha
+head_sha
+index_tree_sha
+worktree_digest
+dirty
+tasks_sha256
+effective_spec_sha256
+sensor_config_sha256
+wendkeep_version
+platform
+started_at
+finished_at
+```
+
+### Regras
+
+- HEAD inicial e final devem ser iguais;
+- digest deve incluir staged/unstaged/untracked conforme política documentada;
+- hashes usam SHA-256 canônico;
+- evidence v1 vira `legacy-unbound`;
+- writes são atômicos e protegidos por path-safety;
+- sensor registra comando efetivo, exit code, duration, output digest e tail sanitizado.
+
+## 4. Freshness/provenance gate
+
+Estados de prova:
+
+```text
+verified
+reported
+legacy-unbound
+stale
+conflict
+unproven
+```
+
+### Comparações locais
+
+- repository/worktree;
+- HEAD/index/worktree digest;
+- tasks/spec/sensor config;
+- verdict envelope ID;
+- active context.
+
+### Comparações externas opcionais
+
+- CI run → SHA;
+- tag → SHA;
+- package version;
+- npm integrity;
+- GitHub Release/tag/body.
+
+Falha de rede não promove `reported` a `verified`.
+
+## 5. Task Contract
+
+Derivado de:
+
+- task ID/texto;
+- requirement IDs;
+- acceptance criteria;
+- sensors;
+- artifacts;
+- dependencies;
+- active context.
+
+Campos essenciais:
+
+```text
+status
+inputs
+expected_outputs
+acceptance_criteria
+required_sensors
+required_artifacts
+dependencies
+owner/lease
+evidence_envelope_id
+```
+
+Uma checkbox `[x]` é apenas sinal autoral; conclusão depende da avaliação do contrato.
+
+## 6. Artifact gates
+
+Tipos mínimos:
+
+```text
+name
+path
+glob
+file-count
+```
+
+Regras:
+
+- filesystem scan bounded;
+- ignore Git/node_modules/dist/worktrees;
+- timeout;
+- paths repo-relative;
+- artifact registrado é preferível;
+- `fromFilesystem` é explícito, nunca implícito para conteúdo sensível.
+
+## 7. Handoff Contract
+
+Transporta:
+
+- origem/destino;
+- active context/task;
+- artifacts;
+- evidence refs;
+- decisions;
+- next actions;
+- blockers/risks;
+- HEAD/tasks/spec hashes;
+- host capability coverage.
+
+Heurísticas de resumo servem somente para legacy migration com autoridade `reported`.
+
+## 8. TDD attestation
+
+Ciclo registrado:
+
+```text
+requirement/task
+  ├─ RED: snapshot + command + expected failure digest
+  └─ GREEN: successor snapshot + command + green digest
+```
+
+Política:
+
+- FLOW: opcional;
+- GUIDE: recomendado;
+- GOVERN: obrigatório quando task declara TDD;
+- ASSURE: obrigatório para comportamento testável ou waiver humano.
+
+RED por import/typo/configuração não satisfaz a prova.
+
+## 9. Commit universal
+
+`wk-commit` consome apenas:
+
+- change/ADR;
+- task contracts concluídos;
+- Evidence Envelope fresco;
+- verdict correspondente;
+- staged diff;
+- identidade real dos agentes.
+
+Pipeline:
+
+```text
+wk-commit gera
+→ prepare-commit-msg estrutura
+→ commit-msg valida
+→ CI valida bypass
+```
+
+Nenhum receipt stale/unproven pode aparecer como evidência no corpo.
+
+## 10. Fluxo VS Code
+
+```powershell
+node ./bin/wendkeep.mjs worktree create evidence-envelope-v2 --open vscode
+```
+
+Depois de cada PR:
+
+```powershell
+node ./bin/wendkeep.mjs worktree finish <slug> --pr <PR>
+```
+
+## 11. Testes de fase
+
+- source alterado depois do verify;
+- amend/rebase;
+- staged/unstaged/untracked;
+- evidence de outra worktree;
+- sensor config alterada;
+- artifact ausente;
+- task marcada sem gate;
+- handoff stale;
+- RED já verde;
+- RED por erro de infraestrutura;
+- tag/npm/release divergentes;
+- receipts truncados;
+- bypass de commit hook.
+
+## 12. Definition of Done
+
+- qualquer prova identifica o estado exato testado;
+- archive recusa mudança pós-verify;
+- task e handoff são machine-checkable;
+- E→V respeita gates;
+- TDD pode ser auditado quando exigido;
+- commit e delivery não inventam resultados;
+- tudo permanece local-first e reparável.

--- a/docs/plans/2026-08-21-wendkeep-control-plane-1-0/phase-03-portability-mcp-and-hosts.md
+++ b/docs/plans/2026-08-21-wendkeep-control-plane-1-0/phase-03-portability-mcp-and-hosts.md
@@ -1,0 +1,235 @@
+# Fase 03 — Portabilidade, MCP, sync e capabilities dos hosts
+
+**Issues:** #77, #78, #79, #80  
+**Prioridade:** P1  
+**Pré-requisito:** Fases 01 e 02  
+**Gate da fase:** um agente ou máquina diferente consegue retomar authored state por interfaces tipadas, e toda lacuna de captura do host é explícita.
+
+## 1. Objetivo
+
+Levar o WendKeep do cenário “mesmo computador e mesmo Vault” para um sistema portátil e interoperável sem transformar cloud em requisito nem expor runtime privado.
+
+## 2. Ordem recomendada
+
+A execução pode ocorrer parcialmente em paralelo:
+
+```text
+#77 MCP read-only ───────────────┐
+                                 ├→ #80 host capability matrix
+#78 authored/private → #79 sync ┘
+```
+
+Writes MCP dependem dos contracts/evidence da Fase 02.
+
+## 3. MCP nativo
+
+### Princípio
+
+O MCP deve expor operações semânticas do WendKeep, não apenas leitura arbitrária do Vault.
+
+### Read-only inicial
+
+```text
+project_status
+context_status
+memory_recall
+memory_conflicts
+change_list/show/status
+spec_effective
+task_show/evaluate
+handoff_current
+evidence_latest
+observer_query
+```
+
+### Writes posteriores
+
+```text
+memory_assert
+checkpoint_create
+context_select
+task_claim/release/complete
+handoff_publish
+```
+
+Writes carregam actor, session, active context, lease e capability. Operações destrutivas permanecem fora da superfície padrão.
+
+### Runtime
+
+- Core tools: Node >=18;
+- Observer SQL tools: capability opcional Node >=22.13;
+- stdio como transporte inicial;
+- schemas e error codes versionados;
+- paginação, byte budgets, timeout e cancellation;
+- nenhuma dependência `@latest` no caminho principal.
+
+## 4. Authored state versus runtime privado
+
+### Authored/shared
+
+- CORE/invariantes compartilháveis;
+- specs/deltas;
+- ADRs/decisões normativas;
+- contracts sanitizados;
+- handoff compacto;
+- active-work;
+- hashes/references de evidência.
+
+### Private/generated
+
+- transcript/prompt/response;
+- token/cost detail;
+- absolute paths;
+- outboxes/locks;
+- traces completos;
+- local leases e secrets.
+
+A classificação deve ser formal e testável. Export default é safe-by-default.
+
+## 5. Snapshot `active-work`
+
+Campos mínimos:
+
+```text
+schema_version
+project_id
+repository_id
+change_slug
+task_id
+branch
+base_sha
+head_sha
+spec_sha256
+tasks_sha256
+status
+completed
+current_action
+next_actions
+blockers
+evidence_refs
+updated_at
+revision
+```
+
+O snapshot não contém path absoluto, transcript, secret ou session ID privado.
+
+### Regras de import
+
+- comparar revision/base hash;
+- conflito explícito;
+- não substituir estado local mais novo;
+- provenance de import/export;
+- round-trip determinístico;
+- opt-out de versionamento permitido.
+
+## 6. Sync local-first
+
+### Primitivas
+
+```text
+project_id
+record_key
+revision
+base_revision
+content_hash
+causal_parent_ids
+actor_id
+device_id
+lease_id
+observed_at
+operation
+```
+
+### Propriedades
+
+- compare-and-swap;
+- outbox/inbox idempotentes;
+- replay fora de ordem;
+- conflict sets;
+- leases com TTL/recovery;
+- offline-first;
+- backend substituível;
+- E2E para payload privado opt-in.
+
+### Anti-requisitos
+
+- nenhum last-write-wins automático;
+- nenhum backend obrigatório;
+- nenhum upload de transcript em plaintext por padrão.
+
+## 7. Capability matrix dos hosts
+
+Capabilities mínimas:
+
+```text
+session.start/resume/stop
+prompt.submit
+tool.pre/post
+edit.attribution
+plan.approved
+decision.capture
+task.completed
+subagent.start/stop
+transcript.read
+usage.read
+```
+
+Estados:
+
+```text
+native | adapted | polled | manual | unavailable
+```
+
+### Regras
+
+- manifest no início da sessão;
+- coverage persistida em session/handoff/evidence;
+- capability ausente não produz fato `verified`;
+- host desconhecido usa baseline MCP/CLI;
+- contract tests por versão;
+- adapter Pi deve existir ou deixar de ser declarado como integração implementada.
+
+## 8. VS Code e clientes
+
+Depois de #70:
+
+```powershell
+node ./bin/wendkeep.mjs worktree create native-mcp --open vscode
+node ./bin/wendkeep.mjs worktree create portable-active-work --open vscode
+```
+
+A integração VS Code futura deve gerar localmente:
+
+- task para `worktree create`;
+- task para `profile status`;
+- task para `change status`;
+- task para `verify`;
+- task para `worktree finish`;
+- configuração MCP nativa quando solicitada.
+
+Preferências pessoais permanecem locais; templates/versionamento ficam no pacote.
+
+## 9. Testes de fase
+
+- MCP handshake/tools/calls;
+- Core Node 18 e Observer 22.13;
+- pagination/timeout/cancel;
+- unauthorized write;
+- safe export/import em clone limpo;
+- secret/path fixtures;
+- CAS/conflicts/reorder/duplicate;
+- offline/reconnect;
+- lease takeover;
+- host capability ausente;
+- cross-provider resume;
+- package tarball consumer.
+
+## 10. Definition of Done
+
+- MCP é semântico, tipado e nativo;
+- authored state pode viajar sem runtime privado;
+- active-work permite retomada segura;
+- sync converge ou explicita conflito;
+- hosts declaram cobertura real;
+- VS Code consegue operar o fluxo sem comandos improvisados;
+- Keep Core continua local e funcional quando todas as extensões estão desligadas.

--- a/docs/plans/2026-08-21-wendkeep-control-plane-1-0/phase-04-security-scale-ecosystem-and-1-0.md
+++ b/docs/plans/2026-08-21-wendkeep-control-plane-1-0/phase-04-security-scale-ecosystem-and-1-0.md
@@ -1,0 +1,210 @@
+# Fase 04 — Segurança, escala, ecossistema e hardening para 1.0
+
+**Issues:** #81, #82, #83, #84  
+**Prioridade:** P2  
+**Pré-requisito:** Fases 01–03  
+**Gate da fase:** Observer e runtime são seguros/escopados, histórico escala incrementalmente, bridges não duplicam autoridade e releases 1.0 são migráveis/reproduzíveis.
+
+## 1. Objetivo
+
+Produtizar a base construída nas fases anteriores. Esta fase não introduz nova autoridade: reforça projeções, armazenamento, integrações e distribuição.
+
+## 2. Observer seguro
+
+### Captura por classe
+
+```text
+document_capture   = none | metadata | selected | full
+transcript_capture = none | metadata | messages | full
+prompt_capture     = none | redacted | full
+response_capture   = none | redacted | full
+usage_capture      = none | aggregate | calls
+```
+
+### Autorização
+
+```text
+roles  = viewer | auditor | publisher | admin
+scopes = project + capability + data class
+```
+
+Requisitos:
+
+- token expiry/rotation/revocation;
+- optional auth em loopback;
+- project isolation;
+- transcript/prompt scopes separados;
+- audit log de acesso sensível;
+- ingest/mutation sempre autenticados.
+
+### Retenção e proteção
+
+- TTL por classe;
+- purge idempotente com receipt;
+- índices derivados também removidos;
+- encryption at rest quando habilitada;
+- export seguro por padrão;
+- migrations de DB testadas.
+
+## 3. Ledger e recall incrementais
+
+### Memory ledger
+
+- segmentos imutáveis;
+- manifest/hash chain;
+- snapshots de projeção;
+- replay do tail;
+- compactação com dry-run/receipt;
+- repair a partir do ledger original.
+
+### Evidence recall
+
+- estado por `logical_path + content_hash`;
+- chunk upsert/delete incremental;
+- FTS local quando disponível;
+- fallback lexical sobre corpus completo;
+- embeddings opcionais/locais;
+- paginação e byte budgets.
+
+### Métricas
+
+- tempo de startup;
+- tempo de recall;
+- bytes lidos/escritos;
+- eventos replayed;
+- chunks atualizados;
+- tamanho de outbox/segments;
+- custo de full reconcile.
+
+## 4. Bridges do ecossistema
+
+### Matriz de autoridade
+
+```text
+Spec Kit    → autoria opcional de specs complexas
+WendKeep    → memory/context/contracts/evidence/governance
+Superpowers → execução/TDD/review
+CI          → prova final do commit
+```
+
+### Spec Kit adapter
+
+- detectar versão/artefatos;
+- preservar IDs/hashes;
+- importar/reference, não duplicar;
+- detectar drift;
+- mapping user story/requirement/change/task;
+- status/evidence como projeção opcional.
+
+### Superpowers adapter
+
+- dispatch package mínimo;
+- task contract e spec refs;
+- worktree via WendKeep;
+- ingest de ledger/review/commits como artifacts;
+- nenhuma reescrita silenciosa de escopo;
+- cleanup seguro pós-merge.
+
+Cada adapter é opcional e possui compatibility matrix.
+
+## 5. Arquitetura para 1.0
+
+Packages-alvo:
+
+```text
+@wendkeep/vault
+@wendkeep/harness
+@wendkeep/worktrees
+@wendkeep/observer
+@wendkeep/sync
+@wendkeep/integrations
+@wendkeep/mcp
+```
+
+Regras:
+
+- adapters irmãos não dependem entre si;
+- hooks contêm somente adaptação/orchestration;
+- effectful code nos composition roots;
+- Core Node >=18;
+- Observer SQL Node >=22.13;
+- schemas/migrations públicos;
+- legacy facades com deprecation timeline;
+- APIs 1.0 versionadas.
+
+## 6. Migrations
+
+Cobertura mínima:
+
+- Vault structure;
+- memory v2/segments/snapshots;
+- active contexts;
+- evidence v1→v2;
+- task/handoff contracts;
+- portable state;
+- Observer DB;
+- MCP configs/host manifests.
+
+Cada migration precisa de:
+
+- preflight;
+- dry-run quando possível;
+- staging/atomic publication;
+- rollback ou repair;
+- idempotência;
+- tests N-2/N-1 → atual;
+- receipt.
+
+## 7. CI e supply chain
+
+- Windows/Linux e macOS onde relevante;
+- Core 18/20; Full 22.13/24;
+- checks obrigatórios antes de merge/release;
+- Actions pinadas por SHA;
+- permissões mínimas por job;
+- dependency review/CodeQL quando aplicável;
+- SBOM/provenance do tarball;
+- package smoke em consumidor isolado;
+- migration tests;
+- coverage thresholds por package;
+- mutation nos kernels críticos;
+- tag/npm/Release no mesmo SHA e versão.
+
+## 8. VS Code
+
+```powershell
+node ./bin/wendkeep.mjs worktree create observer-security --open vscode
+node ./bin/wendkeep.mjs worktree create incremental-memory-recall --open vscode
+node ./bin/wendkeep.mjs worktree create ecosystem-bridges --open vscode
+node ./bin/wendkeep.mjs worktree create architecture-1-0 --open vscode
+```
+
+Cada implementação permanece separada. #84 não deve virar um rewrite que absorve #81–#83.
+
+## 9. Testes de fase
+
+- role/scope matrix;
+- retention/purge/encryption;
+- multi-project isolation;
+- 100k+ memory events;
+- corrupted snapshot/segment/index;
+- incremental document change;
+- FTS unavailable;
+- Spec Kit drift;
+- Superpowers dispatch/review;
+- dependency graph;
+- migrations N-2/N-1;
+- tarball consumer;
+- release provenance;
+- workflow permission assertions.
+
+## 10. Definition of Done
+
+- Observer pode ser usado remotamente com política explícita;
+- dados sensíveis têm captura/retention/access control;
+- histórico longo não degrada hooks linearmente;
+- bridges preservam autoridade única;
+- packages possuem fronteiras testadas;
+- upgrades preservam memória/evidence;
+- tarball publicado corresponde ao SHA testado;
+- release 1.0 possui compatibility/deprecation/support policy.

--- a/docs/plans/2026-08-21-wendkeep-control-plane-1-0/plan.md
+++ b/docs/plans/2026-08-21-wendkeep-control-plane-1-0/plan.md
@@ -1,0 +1,260 @@
+# WendKeep 1.0 — Project Memory Control Plane
+
+**Data:** 2026-08-21  
+**Épico:** #69  
+**Status:** planejado  
+**Estratégia:** PR incremental por capability; nenhum rewrite total
+
+## 1. Visão
+
+O WendKeep deve se tornar o plano de controle local-first de referência para desenvolvimento assistido por agentes. A proposta não é copiar integralmente Spec Kit, Superpowers, Dotcontext ou Medium Brain, mas absorver suas melhores propriedades sob uma arquitetura com uma única autoridade por conceito.
+
+O resultado esperado é um sistema no qual qualquer agente autorizado consiga responder, com evidência:
+
+- qual projeto, repositório, worktree, sessão, change e task estão ativos;
+- onde o trabalho realmente parou;
+- por que as decisões foram tomadas;
+- quais requisitos e critérios de aceite governam a implementação;
+- qual código exato foi testado;
+- quais gates ainda estão abertos;
+- qual operação externa foi autorizada;
+- qual entrega foi efetivamente observada;
+- como retomar sem reler a conversa anterior.
+
+## 2. Problemas que o programa fecha
+
+### 2.1 Contexto ativo global
+
+O ponteiro global de change/delivery não representa múltiplas worktrees. Uma sessão pode sobrescrever o contexto da outra.
+
+### 2.2 Evidência desligada do código
+
+Tasks e spec possuem fingerprints, mas a prova precisa identificar também repository, worktree, HEAD, index, working tree e configuração de sensores.
+
+### 2.3 Handoff parcialmente heurístico
+
+Resumo textual é útil para humanos, mas não substitui task/handoff contract tipado.
+
+### 2.4 Portabilidade incompleta
+
+O Vault local é rico, porém um clone novo não recebe authored state e active work automaticamente; versionar runtime integral exporia dados privados.
+
+### 2.5 MCP genérico
+
+Ler arquivos do Vault não equivale a operar as invariantes semânticas do WendKeep.
+
+### 2.6 Paridade aparente entre hosts
+
+Claude, Codex, Pi e clientes MCP não oferecem os mesmos eventos. Cobertura ausente deve ser declarada, não inferida.
+
+### 2.7 Observer e escala
+
+O read model precisa de políticas de captura, RBAC, retenção, purge e processamento incremental para uso prolongado/remoto.
+
+## 3. Princípios arquiteturais
+
+1. **Keep Core sempre disponível.** Memória, identidade, sessão, decisões, handoff e persistência não dependem de cloud.
+2. **Uma autoridade por conceito.** Autoria, runtime, evidência, autorização, delivery e projeções têm papéis distintos.
+3. **Projeções são reconstruíveis.** Observer, índices e dashboards nunca substituem authored state ou event ledger.
+4. **Sem last-write-wins silencioso.** Concorrência produz CAS success ou conflito explícito.
+5. **Done é derivado.** Checkbox isolada não conclui task com gate aberto.
+6. **Prova identifica o objeto provado.** Todo receipt aponta para código, configuração, ator e instante.
+7. **Governança proporcional.** Work kind, contract impact, profile e operation risk continuam independentes.
+8. **Adapters finos.** Host-specific code não entra no kernel.
+9. **Privacidade por padrão.** Metadata e hashes antes de conteúdo completo.
+10. **Migração antes de breaking change.** A evolução para 1.0 preserva Vaults e receipts existentes ou oferece repair determinístico.
+
+## 4. Matriz de autoridade
+
+| Conceito | Autoridade | Projeções/consumidores |
+|---|---|---|
+| Invariantes do projeto | CORE/constituição escolhida | agents, MCP, Observer |
+| Spec e requisitos | authored spec/WendKeep ou adapter Spec Kit | task contracts, verify |
+| Change | authored change WendKeep | active context, Observer |
+| Task | `tarefas.md` + IDs estáveis | task contract derivado |
+| Contexto ativo | registry por repository/worktree/session | hooks, CLI, MCP |
+| Memória | event ledger + reducer | SHARED_MEMORY, recall |
+| Evidência | Evidence Envelope + sensors/verdict | archive, commit, delivery |
+| Autorização | profile/lease/delivery capability | adapters operacionais |
+| Entrega | efeito observado + receipt | Observer, release report |
+| Observabilidade | Observer SQL | dashboard e consultas |
+
+## 5. Ondas de implementação
+
+### Onda 1 — Fundamento multi-worktree
+
+| Issue | Capability | Gate de saída |
+|---|---|---|
+| #70 | `wendkeep worktree` em `.worktrees/` + VS Code | duas linked worktrees resolvem o mesmo Vault |
+| #71 | active context escopado | duas changes concorrentes não se contaminam |
+| #72 | cleanup pós-merge | worktree merged some sem perder histórico |
+
+### Onda 2 — Integridade de prova
+
+| Issue | Capability | Gate de saída |
+|---|---|---|
+| #73 | Evidence Envelope v2 | mudança de código torna prova stale |
+| #74 | freshness/provenance gates | archive/delivery recusam prova divergente |
+| #75 | task/handoff contracts | E→V depende de gates machine-checkable |
+| #76 | attestation TDD | Red e Green pertencem à mesma linha causal |
+| #40 | commit universal | mensagem deriva somente de prova fresca |
+
+### Onda 3 — Portabilidade e interfaces
+
+| Issue | Capability | Gate de saída |
+|---|---|---|
+| #77 | MCP nativo | agentes consultam semântica sem filesystem arbitrário |
+| #78 | authored/private + `active-work` | clone limpo sabe o que retomar sem expor runtime |
+| #79 | sync CAS/leases | duas máquinas convergem ou explicitam conflito |
+| #80 | host capability matrix | coverage/degradação são observáveis |
+
+### Onda 4 — Segurança, escala e ecossistema
+
+| Issue | Capability | Gate de saída |
+|---|---|---|
+| #81 | Observer security/privacy | captura e acesso obedecem política e scopes |
+| #82 | snapshots/index incremental | retomada não reprocessa todo o histórico |
+| #83 | bridges Spec Kit/Superpowers | IDs/autoridades permanecem únicos |
+| #84 | arquitetura/CI/migrations 1.0 | pacote reproduzível, migrável e protegido |
+
+## 6. Grafo crítico
+
+```text
+#70 → #71 → #72
+          └→ #73 → #74 → #40
+                     └→ #75 → #76
+                         ├→ #77
+                         └→ #78 → #79
+#71 + #75 + #77 → #80
+#78 + #79 + #80 → #81
+#73 + #78 → #82
+#75 + #76 + #77 + #78 → #83
+#70–#83 + #40 → #84
+```
+
+O grafo representa dependências de contrato. Cada issue continua sendo um PR pequeno e integrável.
+
+## 7. Lifecycle padrão de worktree
+
+### Layout
+
+```text
+<repo>/
+├── .git/
+├── .worktrees/
+│   ├── active-context/
+│   └── evidence-envelope-v2/
+├── .WendKeep-vault/
+└── código da worktree principal
+```
+
+### Criação manual até #70
+
+```powershell
+New-Item -ItemType Directory -Force .worktrees | Out-Null
+git switch main
+git pull --ff-only
+git worktree add ".worktrees/<slug>" -b "wk/<slug>" main
+code -n ".worktrees/<slug>"
+```
+
+### Criação futura
+
+```powershell
+node ./bin/wendkeep.mjs worktree create <slug> --open vscode
+```
+
+### Fechamento futuro
+
+```powershell
+node ./bin/wendkeep.mjs worktree finish <slug> --pr <numero-ou-url>
+```
+
+O fechamento só pode continuar quando:
+
+- PR está realmente merged;
+- worktree está limpa;
+- não há sessão/delivery/outbox pendente;
+- active context foi encerrado;
+- receipt foi publicado.
+
+Depois:
+
+- `git worktree remove`;
+- branch local removida;
+- branch remota apenas com autorização;
+- `git worktree prune`;
+- memória histórica preservada.
+
+## 8. Fluxo de execução no VS Code
+
+Para cada issue:
+
+1. abrir a issue e copiar slug/dependências;
+2. criar a worktree dedicada;
+3. abrir nova janela do VS Code;
+4. executar `profile status` e routing gate;
+5. criar a change no perfil adequado;
+6. implementar tarefas TDD pequenas;
+7. executar sensores, verify e verdict;
+8. archive somente com evidence fresca;
+9. push e PR;
+10. após merge, cleanup da worktree.
+
+O arquivo `vscode-execution.md` deste diretório contém prompts e comandos prontos.
+
+## 9. Estratégia de rollout
+
+### Compatibilidade
+
+- artefatos existentes são classificados como legacy;
+- nenhuma migração inventa identidade causal;
+- projeções legadas continuam apenas enquanto inequívocas;
+- deprecation é documentada antes de remoção.
+
+### Profiles
+
+- worktree/context/evidence pertencem ao Keep Core ou à infraestrutura comum;
+- FLOW não deve receber cerimônia de GOVERN;
+- GUIDE usa contratos compactos;
+- GOVERN exige prova e review;
+- ASSURE acrescenta confirmação/handoff/authorization.
+
+### Releases
+
+Cada capability que altera comportamento observável atualiza:
+
+- README PT/EN;
+- guia de comando PT/EN;
+- CHANGELOG e versão quando aplicável;
+- schemas/migrations;
+- tarball smoke;
+- receipts de release.
+
+## 10. Métricas de sucesso
+
+- zero contaminação em testes multi-worktree;
+- zero archive aceito após alteração de código pós-verify;
+- tempo de retomada incremental estável em Vaults grandes;
+- 100% das tools MCP com schema e error code documentados;
+- capability coverage explícita em todos os hosts suportados;
+- nenhum secret em exports/snapshots padrão;
+- cleanup idempotente e sem pastas órfãs;
+- migrations N-2/N-1 testadas antes de 1.0;
+- tarball publicado corresponde ao SHA testado.
+
+## 11. Definition of Done
+
+O programa termina quando:
+
+- contexto ativo é correto por worktree/session;
+- evidência prova o código exato;
+- task e handoff são contratos estruturados;
+- um clone novo pode retomar authored state com segurança;
+- MCP nativo opera as invariantes do WendKeep;
+- hosts declaram coverage real;
+- sync preserva conflitos em vez de escondê-los;
+- Observer possui controles de produção;
+- ledger/recall escalam incrementalmente;
+- bridges externas não criam autoridades concorrentes;
+- arquitetura, migrations, CI e supply chain estão prontas para 1.0.

--- a/docs/plans/2026-08-21-wendkeep-control-plane-1-0/vscode-execution.md
+++ b/docs/plans/2026-08-21-wendkeep-control-plane-1-0/vscode-execution.md
@@ -1,0 +1,250 @@
+# Execução do programa no VS Code
+
+Este guia permite executar as issues #70–#84 em worktrees isoladas. Até #70/#72 existirem, use os comandos manuais seguros abaixo. Depois, substitua-os pelos comandos nativos do WendKeep.
+
+## 1. Pré-requisitos
+
+Na worktree principal:
+
+```powershell
+git switch main
+git pull --ff-only
+node --version
+npm ci --ignore-scripts
+node ./bin/wendkeep.mjs doctor --project .
+```
+
+Confirme também:
+
+```powershell
+gh auth status
+code --version
+git worktree list
+```
+
+## 2. Slugs recomendados
+
+| Issue | Slug/worktree | Branch |
+|---|---|---|
+| #70 | `worktree-manager` | `wk/worktree-manager` |
+| #71 | `active-context` | `wk/active-context` |
+| #72 | `worktree-cleanup` | `wk/worktree-cleanup` |
+| #73 | `evidence-envelope-v2` | `wk/evidence-envelope-v2` |
+| #74 | `provenance-gates` | `wk/provenance-gates` |
+| #75 | `typed-contracts` | `wk/typed-contracts` |
+| #76 | `tdd-attestation` | `wk/tdd-attestation` |
+| #40 | `universal-commit` | `wk/universal-commit` |
+| #77 | `native-mcp` | `wk/native-mcp` |
+| #78 | `portable-active-work` | `wk/portable-active-work` |
+| #79 | `sync-protocol` | `wk/sync-protocol` |
+| #80 | `host-capability-matrix` | `wk/host-capability-matrix` |
+| #81 | `observer-security` | `wk/observer-security` |
+| #82 | `incremental-memory-recall` | `wk/incremental-memory-recall` |
+| #83 | `ecosystem-bridges` | `wk/ecosystem-bridges` |
+| #84 | `architecture-1-0` | `wk/architecture-1-0` |
+
+Não comece uma issue antes das dependências declaradas em seu corpo.
+
+## 3. Criar uma worktree agora
+
+Exemplo para #70:
+
+```powershell
+$Slug = "worktree-manager"
+$Branch = "wk/$Slug"
+
+New-Item -ItemType Directory -Force .worktrees | Out-Null
+git switch main
+git pull --ff-only
+git worktree add ".worktrees/$Slug" -b $Branch main
+code -n ".worktrees/$Slug"
+```
+
+No terminal da nova janela:
+
+```powershell
+git status --short --branch
+npm ci --ignore-scripts
+node ./bin/wendkeep.mjs sync --project . --yes
+node ./bin/wendkeep.mjs profile status --project .
+```
+
+Para o próprio checkout do WendKeep, continue usando `node ./bin/wendkeep.mjs`; não reinstale `wendkeep` como devDependency.
+
+## 4. Criar uma worktree depois de #70
+
+```powershell
+node ./bin/wendkeep.mjs worktree create <slug> --open vscode
+```
+
+Exemplo:
+
+```powershell
+node ./bin/wendkeep.mjs worktree create active-context --open vscode
+```
+
+## 5. Prompt-base para o agente no VS Code
+
+Cole o texto abaixo no Codex/Claude da janela da worktree, substituindo a issue:
+
+```text
+Implemente integralmente a issue #NN do repositório rogersialves/wendkeep.
+
+Use o AGENTS.md do repositório como regra obrigatória. Trabalhe somente nesta worktree e nesta branch. Leia a issue, o épico #69 e os documentos em docs/plans/2026-08-21-wendkeep-control-plane-1-0/.
+
+Antes de editar:
+1. execute o routing gate do WendKeep;
+2. classifique work kind, contract impact e operation risk separadamente;
+3. crie/use a change adequada;
+4. transforme os critérios da issue em requisitos e tarefas TDD pequenas.
+
+Durante a implementação:
+- preserve as fronteiras de packages;
+- não altere o Vault ou runtime de outra worktree;
+- escreva testes Red → Green por comportamento;
+- mantenha documentação PT-BR/EN alinhada quando houver comportamento observável;
+- não faça merge, publish ou cleanup destrutivo.
+
+Antes de concluir:
+- execute os sensores relevantes;
+- execute verify e verify --deep;
+- faça revisão independente;
+- archive a change somente com gates válidos;
+- prepare CHANGELOG/versionamento se a issue alterar o pacote;
+- faça push da branch e abra um PR com resumo, testes, riscos e referência à issue.
+
+Pare somente diante de operação destrutiva/externa, risco de segurança ou ambiguidade que torne todas as alternativas um palpite.
+```
+
+## 6. Checklist de cada PR
+
+```text
+[ ] dependências da issue estão merged
+[ ] branch/worktree corretas
+[ ] routing gate registrado
+[ ] change/spec/tasks coerentes
+[ ] testes Red → Green
+[ ] sensores verdes
+[ ] verify/deep verdict
+[ ] docs PT/EN quando aplicável
+[ ] CHANGELOG/version quando aplicável
+[ ] nenhum runtime/Vault privado no diff
+[ ] PR aberto; sem self-merge
+```
+
+## 7. Limpeza manual segura depois do merge
+
+Até #72 existir, use este processo. Ele trata squash/rebase corretamente porque consulta o estado real do PR antes de forçar a remoção da branch local.
+
+### PowerShell
+
+```powershell
+$Slug = "worktree-manager"
+$Branch = "wk/$Slug"
+$Pr = 123
+$Path = ".worktrees/$Slug"
+
+$info = gh pr view $Pr --json state,mergedAt,headRefName,baseRefName | ConvertFrom-Json
+if ($info.state -ne "MERGED" -or -not $info.mergedAt) {
+  throw "PR #$Pr não está comprovadamente merged."
+}
+if ($info.headRefName -ne $Branch) {
+  throw "PR #$Pr pertence a $($info.headRefName), não a $Branch."
+}
+
+$dirty = git -C $Path status --porcelain
+if ($dirty) {
+  throw "Worktree possui mudanças locais; cleanup bloqueado.`n$dirty"
+}
+
+git worktree remove $Path
+
+# Em squash/rebase, -d pode recusar porque a branch tip não é ancestral de main.
+# Como o PR foi comprovado MERGED acima, a exclusão local pode ser forçada conscientemente.
+git branch -D $Branch
+
+git fetch --prune
+git worktree prune
+git worktree list
+```
+
+A branch remota só deve ser removida quando você desejar e houver autorização de delivery:
+
+```powershell
+git push origin --delete $Branch
+```
+
+### POSIX
+
+```bash
+slug="worktree-manager"
+branch="wk/$slug"
+pr="123"
+path=".worktrees/$slug"
+
+state="$(gh pr view "$pr" --json state --jq .state)"
+merged_at="$(gh pr view "$pr" --json mergedAt --jq .mergedAt)"
+head="$(gh pr view "$pr" --json headRefName --jq .headRefName)"
+
+[ "$state" = "MERGED" ] && [ -n "$merged_at" ] || {
+  echo "PR #$pr não está comprovadamente merged" >&2
+  exit 1
+}
+[ "$head" = "$branch" ] || {
+  echo "PR pertence a $head, não a $branch" >&2
+  exit 1
+}
+[ -z "$(git -C "$path" status --porcelain)" ] || {
+  echo "worktree dirty; cleanup bloqueado" >&2
+  exit 1
+}
+
+git worktree remove "$path"
+git branch -D "$branch"
+git fetch --prune
+git worktree prune
+git worktree list
+```
+
+## 8. Limpeza depois de #72
+
+```powershell
+node ./bin/wendkeep.mjs worktree finish <slug> --pr <numero-ou-url>
+```
+
+Para varrer resíduos comprovadamente merged:
+
+```powershell
+node ./bin/wendkeep.mjs worktree cleanup --merged --dry-run
+node ./bin/wendkeep.mjs worktree cleanup --merged --apply
+```
+
+## 9. Duas issues em paralelo
+
+Somente quando as dependências permitirem:
+
+```powershell
+node ./bin/wendkeep.mjs worktree create native-mcp --open vscode
+node ./bin/wendkeep.mjs worktree create portable-active-work --open vscode
+```
+
+Cada janela possui branch, active context, task e evidence próprios. Não use uma worktree para duas issues independentes.
+
+## 10. Recuperação de resíduos
+
+Inspecione antes de remover:
+
+```powershell
+git worktree list --porcelain
+git branch --list "wk/*"
+git status --short
+```
+
+Depois de confirmar que uma pasta não contém trabalho:
+
+```powershell
+git worktree prune --dry-run
+git worktree prune
+```
+
+Nunca apague manualmente `.git/worktrees/*` como primeira ação. Use o comando Git/WendKeep e preserve receipts/contexto histórico.

--- a/docs/plans/2026-08-21-wendkeep-control-plane-1-0/vscode-tasks.template.jsonc
+++ b/docs/plans/2026-08-21-wendkeep-control-plane-1-0/vscode-tasks.template.jsonc
@@ -1,0 +1,114 @@
+{
+  // Copie este arquivo para .vscode/tasks.json na sua máquina.
+  // .vscode/ permanece local/ignorado no repositório WendKeep.
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "WendKeep: Bootstrap worktree",
+      "type": "shell",
+      "command": "mkdir -p \"${workspaceFolder}/.worktrees\" && git -C \"${workspaceFolder}\" worktree add \".worktrees/${input:slug}\" -b \"wk/${input:slug}\" main",
+      "windows": {
+        "command": "powershell -NoProfile -ExecutionPolicy Bypass -Command \"New-Item -ItemType Directory -Force '${workspaceFolder}/.worktrees' | Out-Null; git -C '${workspaceFolder}' worktree add '.worktrees/${input:slug}' -b 'wk/${input:slug}' main; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }\""
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "WendKeep: Open worktree in new VS Code window",
+      "type": "process",
+      "command": "code",
+      "args": [
+        "-n",
+        "${workspaceFolder}/.worktrees/${input:slug}"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "WendKeep: Bootstrap + open worktree",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "WendKeep: Bootstrap worktree",
+        "WendKeep: Open worktree in new VS Code window"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "WendKeep: List worktrees",
+      "type": "process",
+      "command": "git",
+      "args": [
+        "-C",
+        "${workspaceFolder}",
+        "worktree",
+        "list",
+        "--porcelain"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "WendKeep: Doctor",
+      "type": "process",
+      "command": "node",
+      "args": [
+        "${workspaceFolder}/bin/wendkeep.mjs",
+        "doctor",
+        "--project",
+        "${workspaceFolder}"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "WendKeep: Native create worktree (after #70)",
+      "type": "process",
+      "command": "node",
+      "args": [
+        "${workspaceFolder}/bin/wendkeep.mjs",
+        "worktree",
+        "create",
+        "${input:slug}",
+        "--open",
+        "vscode"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "WendKeep: Native cleanup merged worktree (after #72)",
+      "type": "process",
+      "command": "node",
+      "args": [
+        "${workspaceFolder}/bin/wendkeep.mjs",
+        "worktree",
+        "finish",
+        "${input:slug}",
+        "--pr",
+        "${input:pr}"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "WendKeep: Preview cleanup of all merged worktrees (after #72)",
+      "type": "process",
+      "command": "node",
+      "args": [
+        "${workspaceFolder}/bin/wendkeep.mjs",
+        "worktree",
+        "cleanup",
+        "--merged",
+        "--dry-run"
+      ],
+      "problemMatcher": []
+    }
+  ],
+  "inputs": [
+    {
+      "id": "slug",
+      "type": "promptString",
+      "description": "Slug da issue/worktree, sem wk/",
+      "default": "worktree-manager"
+    },
+    {
+      "id": "pr",
+      "type": "promptString",
+      "description": "Número ou URL do PR comprovadamente merged"
+    }
+  ]
+}


### PR DESCRIPTION
## Objetivo

Versiona o programa de evolução do WendKeep para um Project Memory Control Plane 1.0, derivado da inspeção do repositório e da comparação com Spec Kit, Superpowers, Dotcontext e Medium Brain.

Tracks #69.

## Conteúdo

- plano-mestre e matriz de autoridade;
- grafo de dependências das issues #70–#84 e #40;
- Fase 01: worktrees em `.worktrees/`, active context e cleanup pós-merge;
- Fase 02: Evidence Envelope, provenance gates, contracts, TDD e commit;
- Fase 03: MCP nativo, authored/private, active-work, sync e host capabilities;
- Fase 04: Observer security, escala, bridges e hardening 1.0;
- guia executável para VS Code;
- template local de `tasks.json` para bootstrap e futuros comandos nativos.

## Decisões principais

- worktrees ficam em `<repo>/.worktrees/<slug>`;
- cada issue usa uma worktree/branch/PR próprios;
- cleanup só ocorre após merge comprovado e worktree limpa;
- worktrees compartilham o mesmo Vault sem editar o binding versionado;
- active context é escopado por repository/worktree/work session;
- evidência precisa identificar o código exato;
- adapters de Spec Kit/Superpowers não podem criar autoridade paralela;
- Observer e sync permanecem opcionais em relação ao Keep Core.

## Validação

- revisão estática dos documentos e comandos;
- comparação da branch: 7 arquivos novos, sem alterações em código/runtime;
- links e dependências correspondem às issues criadas no épico #69.

## Riscos

- este PR define arquitetura e ordem; não implementa ainda os comandos `wendkeep worktree`;
- o template VS Code marca explicitamente quais tasks só funcionarão após #70/#72;
- a limpeza manual documentada consulta `gh pr view` para não confundir squash/rebase com branch não merged.

## Próximo passo após merge

Começar por #70 em `wk/worktree-manager`, seguido por #71 e #72.
