### PR TITLE
test: fix Linux symlink oracle for worktree manager

### DIFF
--- a/tests/worktree-cli.test.mjs
+++ b/tests/worktree-cli.test.mjs
@@ -193,13 +193,14 @@ test('[req:WT-1] root por junction para fora do repositório falha antes de cria
     writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
     git(fixture.main, ['add', '.wendkeep.json']);
     git(fixture.main, ['commit', '-m', 'configure linked worktree root']);
+    const statusBefore = git(fixture.main, ['status', '--short']);
 
     assert.throws(
       () => createManagedWorktree({ startDir: fixture.main, slug: 'escape', open: 'none' }),
       (error) => error?.code === 'WENDKEEP_WORKTREE_PATH_SYMLINK_ESCAPE',
     );
     assert.equal(existsSync(join(outside, 'escape')), false);
-    assert.equal(git(fixture.main, ['status', '--short']), '');
+    assert.equal(git(fixture.main, ['status', '--short']), statusBefore);
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Resumo

- captura o status Git preexistente antes de validar o escape por symlink
- compara o estado posterior com esse baseline em Windows e Linux
- mantém produção, contrato, versão e CHANGELOG inalterados

## Validação

- Node 24 Linux (Docker): 16/16
- sensor worktree-manager: 49/49
- npm test: 1.599 testes, 0 falhas