### PR TITLE
fix: scope deliveries by active context (0.76.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.76.5] — 2026-08-22
+
+### Added
+
+- **Delivery causal.** `delivery_id` passa a pertencer ao `active_contexts` da worktree/work session;
+  start, status, finish e abandon isolam deliveries concorrentes e rejeitam IDs de outro contexto.
+- **Hooks escopados.** `change-context` e `change-warn` só reconhecem a autorização de delivery do
+  chamador causal, sem herdar permissões de sessões irmãs.
+- **Compatibilidade conservadora.** `CURRENT_DELIVERY` vira projeção somente para um contexto
+  inequívoco; falha de bind remove o estado recém-criado sem publicar ponteiro parcial.
+
 ## [0.76.4] — 2026-08-22
 
 ### Added

--- a/README.en.md
+++ b/README.en.md
@@ -338,10 +338,15 @@ Work kind, profile, contract impact, and operational risk are independent dimens
 spec, or ADR. If delivery requires a code/config edit, it pauses and work returns to
 `implementation`:
 
+In multi-context Vaults, `active_contexts[].delivery_id` is authoritative and `--session <id>`
+selects the caller explicitly. `CURRENT_DELIVERY` is only a derived projection when there is one
+single, unambiguous context; hooks consult only the causal delivery, and an ID from another context
+fails with `WENDKEEP_DELIVERY_CONTEXT_MISMATCH`.
+
 ```bash
-npx wendkeep delivery start release-0-74-0 --allow git:merge --allow git:push --allow publish --source-change <slug> --source-commit <sha>
-npx wendkeep delivery status release-0-74-0
-npx wendkeep delivery finish release-0-74-0 --target main --ci-url <url> --version 0.74.0 --npm-integrity <sha512> --release-url <url>
+npx wendkeep delivery start release-0-74-0 --allow git:merge --allow git:push --allow publish --source-change <slug> --source-commit <sha> --session <id>
+npx wendkeep delivery status release-0-74-0 --session <id>
+npx wendkeep delivery finish release-0-74-0 --target main --ci-url <url> --version 0.74.0 --npm-integrity <sha512> --release-url <url> --session <id>
 ```
 
 If the harness does not record a lease, a small fix remains under the configured profile —

--- a/README.md
+++ b/README.md
@@ -335,10 +335,15 @@ Work kind, perfil, impacto de contrato e risco operacional são dimensões indep
 ADR. Se a entrega exigir alteração de código/config, ela pausa e o trabalho volta a
 `implementation`:
 
+Em Vaults multi-contexto, `active_contexts[].delivery_id` é a autoridade e `--session <id>` seleciona
+explicitamente o chamador. `CURRENT_DELIVERY` é somente uma projeção derivada quando há um único
+contexto inequívoco; hooks consultam apenas o delivery causal e um ID de outro contexto falha com
+`WENDKEEP_DELIVERY_CONTEXT_MISMATCH`.
+
 ```bash
-npx wendkeep delivery start release-0-74-0 --allow git:merge --allow git:push --allow publish --source-change <slug> --source-commit <sha>
-npx wendkeep delivery status release-0-74-0
-npx wendkeep delivery finish release-0-74-0 --target main --ci-url <url> --version 0.74.0 --npm-integrity <sha512> --release-url <url>
+npx wendkeep delivery start release-0-74-0 --allow git:merge --allow git:push --allow publish --source-change <slug> --source-commit <sha> --session <id>
+npx wendkeep delivery status release-0-74-0 --session <id>
+npx wendkeep delivery finish release-0-74-0 --target main --ci-url <url> --version 0.74.0 --npm-integrity <sha512> --release-url <url> --session <id>
 ```
 
 Se o harness não registrar a lease, uma correção pequena continua sob o perfil configurado — por

--- a/docs/en/commands/operating-profiles.md
+++ b/docs/en/commands/operating-profiles.md
@@ -57,10 +57,10 @@ npx wendkeep flow status [<id>]
 npx wendkeep flow show <id> [--session <id>]
 npx wendkeep flow finish <id> [--session <id>]
 npx wendkeep flow promote <id> [--change-slug <slug>] [--session <id>]
-npx wendkeep delivery start [id] --allow <capability> [--source-change <slug>] [--source-commit <sha>]
-npx wendkeep delivery status [id]
-npx wendkeep delivery finish [id] [--target <ref>] [--ci-url <url>] [--version <x.y.z>] [--npm-integrity <sha512>] [--release-url <url>]
-npx wendkeep delivery abandon [id] --reason <text>
+npx wendkeep delivery start [id] --allow <capability> [--source-change <slug>] [--source-commit <sha>] [--session <id>]
+npx wendkeep delivery status [id] [--session <id>]
+npx wendkeep delivery finish [id] [--target <ref>] [--ci-url <url>] [--version <x.y.z>] [--npm-integrity <sha512>] [--release-url <url>] [--session <id>]
+npx wendkeep delivery abandon [id] --reason <text> [--session <id>]
 ```
 
 Every FLOW subcommand also accepts `--project <path>`, `--vault <path>`, and `--json`. When
@@ -178,6 +178,15 @@ ownership to the native LLM harness.
   and for `publish` requires CI, version, npm integrity, and GitHub Release evidence. Receipts are
   append-only in `.brain/runtime/delivery-receipts.jsonl`. If code/config must change, delivery
   stops with `WENDKEEP_DELIVERY_IMPLEMENTATION_REQUIRED` and work returns to implementation.
+- In a multi-context Vault, `active_contexts[].delivery_id` is authoritative. `--session <id>`
+  selects the work session explicitly; without it, only one unambiguous active context for the
+  worktree may be used. Implicit status, finish, and abandon resolve that binding, not a global pointer.
+- `CURRENT_DELIVERY` is only a derived projection: it contains the ID for one single, unambiguous
+  active context with delivery and stays empty with zero or multiple contexts.
+  `WENDKEEP_DELIVERY_CONTEXT_MISMATCH` means the explicit ID belongs to another context; neither
+  context is mutated.
+- The `change-context` and `change-warn` hooks consult only the caller's causal delivery; one
+  session's authorization is neither injected into nor allowed to suppress warnings in another.
 - Exit `0` means a successful query or transition; exit `1` means a policy/red-sensor block; exit
   `2` means invalid profile, session, flow, or arguments, with no partial mutation.
 

--- a/docs/pt-BR/commands/operating-profiles.md
+++ b/docs/pt-BR/commands/operating-profiles.md
@@ -57,10 +57,10 @@ npx wendkeep flow status [<id>]
 npx wendkeep flow show <id> [--session <id>]
 npx wendkeep flow finish <id> [--session <id>]
 npx wendkeep flow promote <id> [--change-slug <slug>] [--session <id>]
-npx wendkeep delivery start [id] --allow <capability> [--source-change <slug>] [--source-commit <sha>]
-npx wendkeep delivery status [id]
-npx wendkeep delivery finish [id] [--target <ref>] [--ci-url <url>] [--version <x.y.z>] [--npm-integrity <sha512>] [--release-url <url>]
-npx wendkeep delivery abandon [id] --reason <texto>
+npx wendkeep delivery start [id] --allow <capability> [--source-change <slug>] [--source-commit <sha>] [--session <id>]
+npx wendkeep delivery status [id] [--session <id>]
+npx wendkeep delivery finish [id] [--target <ref>] [--ci-url <url>] [--version <x.y.z>] [--npm-integrity <sha512>] [--release-url <url>] [--session <id>]
+npx wendkeep delivery abandon [id] --reason <texto> [--session <id>]
 ```
 
 Todos os subcomandos FLOW também aceitam `--project <path>`, `--vault <path>` e `--json`.
@@ -177,6 +177,15 @@ harness nativo da LLM.
   para capability `publish`, exige CI, versão, integridade npm e GitHub Release. O receipt é
   append-only em `.brain/runtime/delivery-receipts.jsonl`. Se código/config precisar mudar, a
   delivery para com `WENDKEEP_DELIVERY_IMPLEMENTATION_REQUIRED` e o trabalho volta a implementation.
+- Em Vault multi-contexto, `active_contexts[].delivery_id` é a autoridade. `--session <id>` escolhe
+  explicitamente a work session; sem ela, somente um active context inequívoco da worktree pode ser
+  usado. Status, finish e abandon implícitos consultam esse binding, não um ponteiro global.
+- `CURRENT_DELIVERY` é somente uma projeção derivada: contém o ID quando existe um único contexto
+  ativo inequívoco com delivery e fica vazio com zero ou múltiplos contextos.
+  `WENDKEEP_DELIVERY_CONTEXT_MISMATCH` indica que o ID explícito pertence a outro contexto; nenhum
+  dos dois é mutado.
+- Os hooks `change-context` e `change-warn` consultam somente o delivery causal do chamador; a
+  autorização de uma sessão não é injetada nem suprime aviso em outra.
 - Exit `0` indica consulta ou transição concluída; exit `1` indica política/sensor vermelho; exit
   `2` indica perfil, sessão, flow ou argumentos inválidos, sem mutação parcial.
 

--- a/hooks/active-context-store.mjs
+++ b/hooks/active-context-store.mjs
@@ -6,8 +6,10 @@ import { mkdirVaultPath, writeVaultFileSync } from './vault-path-safety.mjs';
 
 export const ACTIVE_CONTEXTS_SCHEMA_VERSION = 1;
 const POINTER = '.brain/CURRENT_CHANGE.md';
+const DELIVERY_POINTER = '.brain/runtime/CURRENT_DELIVERY';
 const ID_PATTERN = /^[A-Za-z0-9._-]{1,160}$/;
 const SLUG_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,159}$/;
+const DELIVERY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{1,100}$/;
 
 function contextError(code, message) {
   const error = new Error(message);
@@ -84,6 +86,22 @@ export function projectLegacyActiveChange(vaultBase, registry = readSessionRegis
     { label: 'projeção legada CURRENT_CHANGE.md' },
   );
   return slug;
+}
+
+export function projectLegacyActiveDelivery(vaultBase, registry = readSessionRegistry(vaultBase)) {
+  const active = activeContexts(registry);
+  const id = active.length === 1 ? optionalText(active[0][1]?.delivery_id, 101) : '';
+  mkdirVaultPath(vaultBase, join(vaultBase, '.brain', 'runtime'), {
+    label: 'runtime da projeção legada de delivery',
+  });
+  writeVaultFileSync(
+    vaultBase,
+    join(vaultBase, DELIVERY_POINTER),
+    id ? `${id}\n` : '',
+    'utf8',
+    { label: 'projeção legada CURRENT_DELIVERY' },
+  );
+  return id;
 }
 
 export function resolveActiveContext(vaultBase, query = {}) {
@@ -174,6 +192,7 @@ export function mutateActiveContext(vaultBase, identity, updater, {
     return { key, context: structuredClone(next), registryRevision: registry.active_contexts_revision };
   });
   projectLegacyActiveChange(vaultBase);
+  projectLegacyActiveDelivery(vaultBase);
   return result;
 }
 
@@ -193,6 +212,26 @@ export function clearActiveContextChange(vaultBase, identity, options = {}) {
   return mutateActiveContext(vaultBase, identity, (context) => ({
     ...context,
     change_slug: '',
+    state: 'active',
+  }), options);
+}
+
+export function setActiveContextDelivery(vaultBase, identity, deliveryId, options = {}) {
+  const normalizedId = String(deliveryId || '').trim();
+  if (!DELIVERY_PATTERN.test(normalizedId)) {
+    throw contextError('WENDKEEP_ACTIVE_CONTEXT_DELIVERY_INVALID', 'delivery_id inválido ou ausente');
+  }
+  return mutateActiveContext(vaultBase, identity, (context) => ({
+    ...context,
+    delivery_id: normalizedId,
+    state: 'active',
+  }), options);
+}
+
+export function clearActiveContextDelivery(vaultBase, identity, options = {}) {
+  return mutateActiveContext(vaultBase, identity, (context) => ({
+    ...context,
+    delivery_id: '',
     state: 'active',
   }), options);
 }

--- a/hooks/change-context.mjs
+++ b/hooks/change-context.mjs
@@ -15,6 +15,7 @@ import {
   resolveHookOperatingProfile,
 } from './operating-profile-runtime.mjs';
 import { activeDelivery } from '../src/delivery.mjs';
+import { resolveCommandActiveContext } from '../src/active-context-runtime.mjs';
 
 // Conservador de propósito: verbos de tarefa comuns (pt+en) + tamanho mínimo. Falso-negativo
 // custa só o nudge; falso-positivo em pergunta curta viraria ruído.
@@ -26,11 +27,13 @@ export function looksLikeTask(prompt) {
 }
 
 // Retorna { context, hash? } quando há algo a injetar; null = silêncio.
-export function buildChangePing(vaultBase, sessionId, prompt = '', changeSlug = '', { profile = 'GOVERN' } = {}) {
+export function buildChangePing(vaultBase, sessionId, prompt = '', changeSlug = '', {
+  profile = 'GOVERN', context = null,
+} = {}) {
   const policy = hookProfilePolicy(profile);
   if (!policy.harness) return null;
   const sentinelId = profileSentinelId(sessionId, profile);
-  const delivery = activeDelivery(vaultBase);
+  const delivery = activeDelivery(vaultBase, { context });
   if (delivery) {
     const hash = `delivery:${delivery.id}`;
     if (readSentinel(vaultBase, 'ctx', sentinelId) === hash) return null;
@@ -68,10 +71,16 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     const vaultBase = runtime.vaultBase;
     const { identity, entry } = runtime;
     const sid = identity.state === 'resolved' ? identity.canonicalConversationId : (input.session_id || input.sessionId || '');
+    const commandContext = runtime.bindingError ? null : resolveCommandActiveContext({
+      vaultBase,
+      projectRoot: input.cwd || process.cwd(),
+      sessionId: sid,
+    });
     const ping = runtime.bindingError
       ? { context: profileRuntimeError(runtime.bindingError) }
       : buildChangePing(vaultBase, sid, input.prompt || '', entry?.change_slug || '', {
         profile: runtime.profile,
+        context: commandContext,
       });
     if (!ping) { writeHookOutput({}); }
     else writeHookOutput({ hookSpecificOutput: { hookEventName: 'UserPromptSubmit', additionalContext: ping.context } });

--- a/hooks/change-warn.mjs
+++ b/hooks/change-warn.mjs
@@ -13,6 +13,7 @@ import {
   resolveHookOperatingProfile,
 } from './operating-profile-runtime.mjs';
 import { activeDelivery } from '../src/delivery.mjs';
+import { resolveCommandActiveContext } from '../src/active-context-runtime.mjs';
 
 const CODE_EXT = /\.(ts|tsx|js|jsx|mjs|cjs|py|prisma|sql|go|rs|java|cs)$/i;
 
@@ -28,12 +29,13 @@ export function warnDecision(filePath, {
   cwd = '.',
   sessionId = '',
   profile = 'GOVERN',
+  context = null,
 } = {}) {
   const policy = hookProfilePolicy(profile);
   if (!policy.requiresChange) return null;
   if (!filePath || !isCodeFile(filePath)) return null;
-  if (activeChange(vaultBase)) return null;
-  if (activeDelivery(vaultBase)) return null;
+  if (activeChange(vaultBase, { context })) return null;
+  if (activeDelivery(vaultBase, { context })) return null;
   const abs = norm(isAbsolute(filePath) ? filePath : resolve(cwd, filePath));
   // Dentro do vault (NTFS é case-insensitive) ou em dirs de config de agente: não é código do projeto.
   if (abs.toLowerCase().startsWith(`${norm(resolve(vaultBase)).toLowerCase()}/`)) return null;
@@ -52,13 +54,20 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   try {
     const input = readHookInput();
     const runtime = resolveHookOperatingProfile({ input });
+    const sid = input.session_id || input.sessionId || '';
+    const commandContext = runtime.bindingError ? null : resolveCommandActiveContext({
+      vaultBase: runtime.vaultBase,
+      projectRoot: input.cwd || process.cwd(),
+      sessionId: sid,
+    });
     const warn = runtime.bindingError
       ? profileRuntimeError(runtime.bindingError)
       : warnDecision(input.tool_input?.file_path, {
         vaultBase: runtime.vaultBase,
         cwd: input.cwd || '.',
-        sessionId: input.session_id || input.sessionId || '',
+        sessionId: sid,
         profile: runtime.profile,
+        context: commandContext,
       });
     if (!warn) { writeHookOutput({}); }
     else writeHookOutput({ hookSpecificOutput: { hookEventName: 'PostToolUse', additionalContext: warn } });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.76.4",
+  "version": "0.76.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.76.4",
+      "version": "0.76.5",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.76.4",
+  "version": "0.76.5",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [

--- a/src/delivery.mjs
+++ b/src/delivery.mjs
@@ -1,11 +1,18 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { basename, join, resolve } from 'node:path';
 import {
   assertVaultPathSafe, mkdirVaultPath, writeVaultFileSync,
 } from '../hooks/vault-path-safety.mjs';
 import { resolveProjectVault } from './project-vault.mjs';
 import { createWorkRoute } from './work-kind.mjs';
+import {
+  activeContextKey,
+  clearActiveContextDelivery,
+  resolveActiveContext,
+  setActiveContextDelivery,
+} from '../hooks/active-context-store.mjs';
+import { resolveCommandActiveContext } from './active-context-runtime.mjs';
 
 export const DELIVERY_HELP = `wendkeep delivery <subcommand>
 
@@ -15,7 +22,7 @@ export const DELIVERY_HELP = `wendkeep delivery <subcommand>
               [--npm-integrity <sha512-...>] [--release-url <url>]
   abandon [id] --reason <text>
 
-Common options: --project <path> --vault <path> --json
+Common options: --project <path> --vault <path> --session <id> --json
 Delivery authorizes operational risk and creates an append-only receipt. It never creates a change,
 spec, or ADR. If code/config must change, abandon or pause delivery and resume an implementation.
 `;
@@ -26,7 +33,7 @@ export const DELIVERY_CAPABILITIES = Object.freeze([
 
 const VALUE_OPTIONS = new Set([
   '--project', '--vault', '--allow', '--source-change', '--source-commit', '--target',
-  '--ci-url', '--version', '--npm-integrity', '--release-url', '--reason',
+  '--ci-url', '--version', '--npm-integrity', '--release-url', '--reason', '--session',
 ]);
 
 function parseArgv(argv) {
@@ -95,11 +102,49 @@ function readPointer(vaultBase) {
   try { return safeId(readFileSync(pointer, 'utf8').trim()); } catch { return ''; }
 }
 
-export function activeDelivery(vaultBase) {
-  const id = readPointer(vaultBase);
+function deliveryContextError(message) {
+  const error = new Error(message);
+  error.code = 'WENDKEEP_DELIVERY_CONTEXT_MISMATCH';
+  return error;
+}
+
+function deliveryContextBusy(id) {
+  const error = new Error(`active context já possui delivery ativo: ${id}`);
+  error.code = 'WENDKEEP_DELIVERY_CONTEXT_BUSY';
+  return error;
+}
+
+function contextualBinding(vaultBase, context, expectedId = '') {
+  const binding = resolveActiveContext(vaultBase, context);
+  const id = String(binding.delivery_id || '').trim();
+  if (expectedId && id !== expectedId) {
+    throw deliveryContextError(`delivery ${expectedId} não pertence ao active context chamador`);
+  }
+  return { binding, id, key: activeContextKey(context) };
+}
+
+function assertStateContext(state, binding) {
+  if (!binding) return;
+  if (state.context_key !== binding.key) {
+    throw deliveryContextError(`delivery ${state.id} pertence a outro active context`);
+  }
+}
+
+export function activeDelivery(vaultBase, { context = null } = {}) {
+  let binding = null;
+  let id = readPointer(vaultBase);
+  if (context) {
+    try { binding = contextualBinding(vaultBase, context); }
+    catch (error) {
+      if (error?.code === 'WENDKEEP_ACTIVE_CONTEXT_NOT_FOUND') return null;
+      throw error;
+    }
+    id = binding.id;
+  }
   if (!id) return null;
   try {
     const state = readState(vaultBase, id);
+    assertStateContext(state, binding);
     return state.state === 'active' ? state : null;
   } catch {
     return null;
@@ -156,8 +201,12 @@ function context(parsed) {
   return { projectRoot, repoRoot, vaultBase: resolved.base };
 }
 
-function currentId(parsed, vaultBase) {
-  return safeId(parsed.positionals[1] || readPointer(vaultBase));
+function currentId(parsed, vaultBase, commandContext = null) {
+  const explicit = parsed.positionals[1];
+  if (explicit) return safeId(explicit);
+  return safeId(commandContext
+    ? activeDelivery(vaultBase, { context: commandContext })?.id
+    : readPointer(vaultBase));
 }
 
 function ensureClean(repoRoot) {
@@ -169,11 +218,30 @@ function ensureClean(repoRoot) {
   }
 }
 
-export function startDelivery({ vaultBase, repoRoot, id, capabilities, sourceChange = '', sourceCommit = '', now = new Date() }) {
+export function startDelivery({
+  vaultBase,
+  repoRoot,
+  id,
+  capabilities,
+  sourceChange = '',
+  sourceCommit = '',
+  context = null,
+  bindDelivery = setActiveContextDelivery,
+  removeState = rmSync,
+  now = new Date(),
+}) {
   ensureClean(repoRoot);
   const deliveryId = safeId(id || generatedId(now));
   const paths = deliveryPaths(vaultBase, deliveryId);
   if (existsSync(paths.state)) throw new Error(`delivery já existe: ${deliveryId}`);
+  if (context) {
+    try {
+      const current = contextualBinding(vaultBase, context);
+      if (current.id) throw deliveryContextBusy(current.id);
+    } catch (error) {
+      if (error?.code !== 'WENDKEEP_ACTIVE_CONTEXT_NOT_FOUND') throw error;
+    }
+  }
   const commit = sourceCommit || git(repoRoot, ['rev-parse', 'HEAD']);
   git(repoRoot, ['cat-file', '-e', `${commit}^{commit}`]);
   const requestedCapabilities = [...new Set((capabilities || []).map((item) => String(item).trim()).filter(Boolean))];
@@ -195,16 +263,29 @@ export function startDelivery({ vaultBase, repoRoot, id, capabilities, sourceCha
     worktree: repoRoot,
     branch: git(repoRoot, ['branch', '--show-current'], true),
     source_commit: commit,
+    ...(context ? { context_key: activeContextKey(context) } : {}),
     started_at: now.toISOString(),
   };
   writeState(vaultBase, state);
-  setPointer(vaultBase, deliveryId);
+  if (context) {
+    try { bindDelivery(vaultBase, context, deliveryId); }
+    catch (error) {
+      try { removeState(paths.state, { force: true }); } catch { /* rollback best-effort */ }
+      throw error;
+    }
+  } else {
+    setPointer(vaultBase, deliveryId);
+  }
   return state;
 }
 
-export function finishDelivery({ vaultBase, repoRoot, id, target = 'HEAD', evidence = {}, now = new Date() }) {
+export function finishDelivery({
+  vaultBase, repoRoot, id, target = 'HEAD', evidence = {}, context = null, now = new Date(),
+}) {
   ensureClean(repoRoot);
   const state = readState(vaultBase, safeId(id));
+  const binding = context ? contextualBinding(vaultBase, context, state.id) : null;
+  assertStateContext(state, binding);
   if (state.state !== 'active') throw new Error(`delivery ${id} não está ativa`);
   const targetCommit = git(repoRoot, ['rev-parse', `${target}^{commit}`]);
   git(repoRoot, ['merge-base', '--is-ancestor', state.source_commit, targetCommit]);
@@ -228,29 +309,49 @@ export function finishDelivery({ vaultBase, repoRoot, id, target = 'HEAD', evide
     work_kind: 'delivery',
     source_change: state.route.source_change || '',
     source_commit: state.source_commit,
+    ...(state.context_key ? { context_key: state.context_key } : {}),
     target,
     target_commit: targetCommit,
     capabilities,
     evidence,
     finished_at: now.toISOString(),
   };
-  appendReceipt(vaultBase, receipt);
-  writeState(vaultBase, { ...state, state: 'completed', target, target_commit: targetCommit, finished_at: receipt.finished_at, receipt });
-  if (readPointer(vaultBase) === state.id) setPointer(vaultBase);
+  if (context) clearActiveContextDelivery(vaultBase, context, { expectedRevision: binding.binding.revision });
+  try {
+    appendReceipt(vaultBase, receipt);
+    writeState(vaultBase, { ...state, state: 'completed', target, target_commit: targetCommit, finished_at: receipt.finished_at, receipt });
+  } catch (error) {
+    if (context) {
+      try { setActiveContextDelivery(vaultBase, context, state.id); } catch { /* rollback best-effort */ }
+    }
+    throw error;
+  }
+  if (!context && readPointer(vaultBase) === state.id) setPointer(vaultBase);
   return receipt;
 }
 
-export function abandonDelivery({ vaultBase, id, reason, now = new Date() }) {
+export function abandonDelivery({ vaultBase, id, reason, context = null, now = new Date() }) {
   const state = readState(vaultBase, safeId(id));
+  const binding = context ? contextualBinding(vaultBase, context, state.id) : null;
+  assertStateContext(state, binding);
   if (state.state !== 'active') throw new Error(`delivery ${id} não está ativa`);
   if (!String(reason || '').trim()) throw new Error('delivery abandon requer --reason <text>');
   const receipt = {
     schema_version: 1, delivery_id: state.id, outcome: 'abandoned',
+    ...(state.context_key ? { context_key: state.context_key } : {}),
     reason: String(reason).trim(), abandoned_at: now.toISOString(),
   };
-  appendReceipt(vaultBase, receipt);
-  writeState(vaultBase, { ...state, state: 'abandoned', reason: receipt.reason, abandoned_at: receipt.abandoned_at });
-  if (readPointer(vaultBase) === state.id) setPointer(vaultBase);
+  if (context) clearActiveContextDelivery(vaultBase, context, { expectedRevision: binding.binding.revision });
+  try {
+    appendReceipt(vaultBase, receipt);
+    writeState(vaultBase, { ...state, state: 'abandoned', reason: receipt.reason, abandoned_at: receipt.abandoned_at });
+  } catch (error) {
+    if (context) {
+      try { setActiveContextDelivery(vaultBase, context, state.id); } catch { /* rollback best-effort */ }
+    }
+    throw error;
+  }
+  if (!context && readPointer(vaultBase) === state.id) setPointer(vaultBase);
   return receipt;
 }
 
@@ -263,23 +364,33 @@ export function runDelivery(argv = []) {
   try {
     const parsed = parseArgv(argv);
     const sub = parsed.positionals[0] || 'status';
-    const { repoRoot, vaultBase } = context(parsed);
+    const { projectRoot, repoRoot, vaultBase } = context(parsed);
+    const commandContext = resolveCommandActiveContext({
+      vaultBase,
+      projectRoot,
+      sessionId: parsed.value('--session') || process.env.CODEX_THREAD_ID || process.env.CLAUDE_SESSION_ID || '',
+    });
     if (sub === 'start') {
       const state = startDelivery({
         vaultBase, repoRoot, id: parsed.positionals[1], capabilities: parsed.all('--allow'),
         sourceChange: parsed.value('--source-change'), sourceCommit: parsed.value('--source-commit'),
+        context: commandContext,
       });
       emit(state, parsed.json);
       return 0;
     }
     if (sub === 'status') {
-      const state = readState(vaultBase, currentId(parsed, vaultBase));
+      const id = currentId(parsed, vaultBase, commandContext);
+      const binding = commandContext ? contextualBinding(vaultBase, commandContext, id) : null;
+      const state = readState(vaultBase, id);
+      assertStateContext(state, binding);
       emit(state, parsed.json);
       return 0;
     }
     if (sub === 'finish') {
       const receipt = finishDelivery({
-        vaultBase, repoRoot, id: currentId(parsed, vaultBase), target: parsed.value('--target') || 'HEAD',
+        vaultBase, repoRoot, id: currentId(parsed, vaultBase, commandContext), target: parsed.value('--target') || 'HEAD',
+        context: commandContext,
         evidence: {
           ci_url: parsed.value('--ci-url'), version: parsed.value('--version'),
           npm_integrity: parsed.value('--npm-integrity'), release_url: parsed.value('--release-url'),
@@ -290,14 +401,15 @@ export function runDelivery(argv = []) {
     }
     if (sub === 'abandon') {
       const receipt = abandonDelivery({
-        vaultBase, id: currentId(parsed, vaultBase), reason: parsed.value('--reason'),
+        vaultBase, id: currentId(parsed, vaultBase, commandContext), reason: parsed.value('--reason'),
+        context: commandContext,
       });
       emit(receipt, parsed.json);
       return 0;
     }
     throw new Error(`subcomando desconhecido: ${sub}`);
   } catch (error) {
-    process.stderr.write(`wendkeep delivery: ${error.message}\n`);
+    process.stderr.write(`wendkeep delivery: ${error.code ? `${error.code}: ` : ''}${error.message}\n`);
     return 2;
   }
 }

--- a/tests/active-context-delivery-cli.test.mjs
+++ b/tests/active-context-delivery-cli.test.mjs
@@ -1,0 +1,134 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { bindProjectVault } from '../src/project-vault.mjs';
+import { writeSessionRegistry } from '../hooks/obsidian-common.mjs';
+import { captureProjectScope, scopeForRegistry } from '../hooks/project-scope.mjs';
+import { discoverWorktreeRepository, ensureWorktreeMetadata } from '../packages/vault/src/worktree-metadata.mjs';
+
+const BIN = join(process.cwd(), 'bin', 'wendkeep.mjs');
+
+function git(cwd, args) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8', windowsHide: true });
+  assert.equal(result.status, 0, result.stderr || result.error?.message);
+}
+
+function fixture() {
+  const parent = mkdtempSync(join(tmpdir(), 'wk-active-context-delivery-cli-'));
+  const project = join(parent, 'project');
+  git(parent, ['init', project]);
+  git(project, ['config', 'user.email', 'delivery@example.invalid']);
+  git(project, ['config', 'user.name', 'Delivery CLI Test']);
+  git(project, ['branch', '-M', 'main']);
+  git(project, ['remote', 'add', 'origin', 'https://example.com/acme/delivery-cli.git']);
+  writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'fixture', version: '1.0.0' }));
+  git(project, ['add', 'package.json']);
+  git(project, ['commit', '-m', 'fixture']);
+
+  const vault = join(parent, 'vault');
+  const binding = bindProjectVault({ projectRoot: project, vaultPath: vault });
+  ensureWorktreeMetadata({
+    repository: discoverWorktreeRepository({ startDir: project }),
+    projectId: binding.projectId,
+    vaultPath: vault,
+  });
+  git(project, ['add', '-A']);
+  git(project, ['commit', '--allow-empty', '-m', 'bind vault']);
+  const scope = (sessionId) => scopeForRegistry(captureProjectScope({
+    input: { cwd: project }, projectRoot: project, projectId: binding.projectId,
+    provider: 'claude', sessionId,
+  }));
+  writeSessionRegistry(vault, {
+    version: 2,
+    sessions: {
+      'session-a': { status: 'active', provider: 'claude', work_session_id: 'work-a', project_scope: scope('session-a') },
+      'session-b': { status: 'active', provider: 'claude', work_session_id: 'work-b', project_scope: scope('session-b') },
+    },
+  });
+  return { parent, project, vault };
+}
+
+function runHook(f, name, input) {
+  return spawnSync(process.execPath, [join(process.cwd(), 'hooks', `${name}.mjs`)], {
+    cwd: f.project,
+    input: JSON.stringify({ ...input, cwd: f.project, obsidian_vault_path: f.vault }),
+    encoding: 'utf8',
+    windowsHide: true,
+    env: {
+      ...process.env,
+      CLAUDECODE: '1',
+      CODEX_THREAD_ID: '',
+      CLAUDE_SESSION_ID: '',
+    },
+  });
+}
+
+function run(f, args) {
+  return spawnSync(process.execPath, [
+    BIN, 'delivery', ...args, '--project', f.project, '--vault', f.vault,
+  ], {
+    cwd: f.project,
+    encoding: 'utf8',
+    windowsHide: true,
+    env: { ...process.env, CODEX_THREAD_ID: '', CLAUDE_SESSION_ID: '' },
+  });
+}
+
+test('[req:ACTX-14] [req:ACTX-17] delivery CLI isolates implicit status and explicit lifecycle by session', () => {
+  const f = fixture();
+  try {
+    const startA = run(f, ['start', 'delivery-a', '--allow', 'git:push', '--session', 'session-a']);
+    assert.equal(startA.status, 0, startA.stderr);
+    const startB = run(f, ['start', 'delivery-b', '--allow', 'git:push', '--session', 'session-b']);
+    assert.equal(startB.status, 0, startB.stderr);
+
+    const statusA = run(f, ['status', '--session', 'session-a', '--json']);
+    assert.equal(statusA.status, 0, statusA.stderr);
+    assert.equal(JSON.parse(statusA.stdout).id, 'delivery-a');
+
+    const crossContext = run(f, ['status', 'delivery-a', '--session', 'session-b']);
+    assert.equal(crossContext.status, 2);
+    assert.match(crossContext.stderr, /WENDKEEP_DELIVERY_CONTEXT_MISMATCH/);
+
+    const abandonA = run(f, ['abandon', 'delivery-a', '--reason', 'done elsewhere', '--session', 'session-a']);
+    assert.equal(abandonA.status, 0, abandonA.stderr);
+    const statusB = run(f, ['status', '--session', 'session-b', '--json']);
+    assert.equal(statusB.status, 0, statusB.stderr);
+    assert.equal(JSON.parse(statusB.stdout).id, 'delivery-b');
+  } finally { rmSync(f.parent, { recursive: true, force: true }); }
+});
+
+test('[req:ACTX-16] executable hooks resolve and propagate the causal delivery context', () => {
+  const f = fixture();
+  try {
+    const startB = run(f, ['start', 'delivery-b', '--allow', 'git:push', '--session', 'session-b']);
+    assert.equal(startB.status, 0, startB.stderr);
+
+    const contextA = runHook(f, 'change-context', { session_id: 'session-a', prompt: 'oi' });
+    assert.equal(contextA.status, 0, contextA.stderr);
+    assert.equal(JSON.parse(contextA.stdout).hookSpecificOutput?.additionalContext ?? '', '');
+
+    const contextB = runHook(f, 'change-context', { session_id: 'session-b', prompt: 'oi' });
+    assert.equal(contextB.status, 0, contextB.stderr);
+    assert.match(
+      JSON.parse(contextB.stdout).hookSpecificOutput.additionalContext,
+      /<active_delivery>Delivery delivery-b ativa/,
+    );
+
+    const warnA = runHook(f, 'change-warn', {
+      session_id: 'session-a', tool_input: { file_path: 'src/a.mjs' },
+    });
+    assert.equal(warnA.status, 0, warnA.stderr);
+    assert.match(JSON.parse(warnA.stdout).hookSpecificOutput.additionalContext, /<change_warn>/);
+
+    const warnB = runHook(f, 'change-warn', {
+      session_id: 'session-b', tool_input: { file_path: 'src/b.mjs' },
+    });
+    assert.equal(warnB.status, 0, warnB.stderr);
+    assert.equal(JSON.parse(warnB.stdout).hookSpecificOutput?.additionalContext ?? '', '');
+  } finally { rmSync(f.parent, { recursive: true, force: true }); }
+});

--- a/tests/active-context-delivery.test.mjs
+++ b/tests/active-context-delivery.test.mjs
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { readSessionRegistry, writeSessionRegistry } from '../hooks/obsidian-common.mjs';
+import {
+  clearActiveContextDelivery,
+  projectLegacyActiveDelivery,
+  resolveActiveContext,
+  setActiveContextDelivery,
+} from '../hooks/active-context-store.mjs';
+
+function fixture() {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-active-context-delivery-'));
+  mkdirSync(join(vault, '.brain', 'runtime'), { recursive: true });
+  writeSessionRegistry(vault, { version: 2, sessions: {} });
+  return {
+    vault,
+    registry: join(vault, '.brain', 'SESSION_REGISTRY.json'),
+    pointer: join(vault, '.brain', 'runtime', 'CURRENT_DELIVERY'),
+  };
+}
+
+function identity(worktreeId, workSessionId) {
+  return {
+    projectId: 'project-1',
+    repositoryId: 'repository-1',
+    worktreeId,
+    workSessionId,
+    branch: `wk/${worktreeId}`,
+    headSha: 'a'.repeat(40),
+  };
+}
+
+test('[req:ACTX-14] delivery bindings are isolated and clear preserves the sibling', () => {
+  const f = fixture();
+  try {
+    const a = identity('worktree-a', 'work-a');
+    const b = identity('worktree-b', 'work-b');
+    setActiveContextDelivery(f.vault, a, 'release-a');
+    setActiveContextDelivery(f.vault, b, 'release-b');
+
+    assert.equal(resolveActiveContext(f.vault, a).delivery_id, 'release-a');
+    assert.equal(resolveActiveContext(f.vault, b).delivery_id, 'release-b');
+    assert.equal(readFileSync(f.pointer, 'utf8'), '');
+
+    clearActiveContextDelivery(f.vault, a);
+    assert.equal(resolveActiveContext(f.vault, a).delivery_id, '');
+    assert.equal(resolveActiveContext(f.vault, b).delivery_id, 'release-b');
+  } finally { rmSync(f.vault, { recursive: true, force: true }); }
+});
+
+test('[req:ACTX-15] legacy delivery projection is empty for zero or multiple active contexts', () => {
+  const f = fixture();
+  try {
+    writeFileSync(f.pointer, 'stale-delivery\n', 'utf8');
+    assert.equal(projectLegacyActiveDelivery(f.vault), '');
+    assert.equal(readFileSync(f.pointer, 'utf8'), '');
+
+    setActiveContextDelivery(f.vault, identity('worktree-a', 'work-a'), 'release-a');
+    assert.equal(readFileSync(f.pointer, 'utf8'), 'release-a\n');
+
+    setActiveContextDelivery(f.vault, identity('worktree-b', 'work-b'), 'release-b');
+    assert.equal(readFileSync(f.pointer, 'utf8'), '');
+  } finally { rmSync(f.vault, { recursive: true, force: true }); }
+});
+
+test('[req:ACTX-15] failed context persistence publishes no delivery projection', () => {
+  const f = fixture();
+  try {
+    writeFileSync(f.pointer, 'previous-delivery\n', 'utf8');
+    const beforeRegistry = readFileSync(f.registry);
+    const beforePointer = readFileSync(f.pointer);
+    let staged = false;
+
+    assert.throws(
+      () => setActiveContextDelivery(f.vault, identity('worktree-a', 'work-a'), 'release-a', {
+        mutateRegistry: (vaultBase, mutator) => {
+          const candidate = readSessionRegistry(vaultBase);
+          mutator(candidate);
+          staged = true;
+          throw new Error('simulated registry persistence failure');
+        },
+      }),
+      /simulated registry persistence failure/,
+    );
+    assert.equal(staged, true);
+    assert.deepEqual(readFileSync(f.registry), beforeRegistry);
+    assert.deepEqual(readFileSync(f.pointer), beforePointer);
+  } finally { rmSync(f.vault, { recursive: true, force: true }); }
+});

--- a/tests/delivery.test.mjs
+++ b/tests/delivery.test.mjs
@@ -7,10 +7,15 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  abandonDelivery, finishDelivery, startDelivery,
+  abandonDelivery, activeDelivery, finishDelivery, startDelivery,
 } from '../src/delivery.mjs';
 import { buildChangePing } from '../hooks/change-context.mjs';
 import { warnDecision } from '../hooks/change-warn.mjs';
+import {
+  clearActiveContextDelivery,
+  resolveActiveContext,
+  setActiveContextDelivery,
+} from '../hooks/active-context-store.mjs';
 
 function git(cwd, args) {
   return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
@@ -29,6 +34,17 @@ function fixture() {
   const commit = git(repo, ['rev-parse', 'HEAD']);
   git(repo, ['tag', '-a', 'v1.2.3', '-m', 'v1.2.3']);
   return { repo, vault, commit };
+}
+
+function identity(worktreeId, workSessionId) {
+  return {
+    projectId: 'project-delivery',
+    repositoryId: 'repository-delivery',
+    worktreeId,
+    workSessionId,
+    branch: `wk/${worktreeId}`,
+    headSha: 'a'.repeat(40),
+  };
 }
 
 test('delivery registra autorização e receipt sem criar change/spec/ADR', () => {
@@ -122,6 +138,156 @@ test('delivery rejeita capabilities desconhecidas e exige prova da tag autorizad
       vaultBase: vault, repoRoot: repo, id: state.id, evidence: { version: '1.2.3' },
     });
     assert.equal(receipt.outcome, 'completed');
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:ACTX-14] [req:ACTX-17] lifecycle resolves and clears only the owning active context', () => {
+  const { repo, vault } = fixture();
+  try {
+    const a = identity('worktree-a', 'work-a');
+    const b = identity('worktree-b', 'work-b');
+    const first = startDelivery({
+      vaultBase: vault, repoRoot: repo, id: 'delivery-a', capabilities: ['git:push'], context: a,
+    });
+    const second = startDelivery({
+      vaultBase: vault, repoRoot: repo, id: 'delivery-b', capabilities: ['git:push'], context: b,
+    });
+    const secondPath = join(vault, '.brain', 'runtime', 'deliveries', 'delivery-b.json');
+    const secondBefore = readFileSync(secondPath);
+
+    assert.equal(activeDelivery(vault, { context: a }).id, first.id);
+    assert.equal(activeDelivery(vault, { context: b }).id, second.id);
+    assert.throws(
+      () => finishDelivery({ vaultBase: vault, repoRoot: repo, id: first.id, context: b }),
+      (error) => error?.code === 'WENDKEEP_DELIVERY_CONTEXT_MISMATCH',
+    );
+
+    const receipt = finishDelivery({
+      vaultBase: vault, repoRoot: repo, id: first.id, context: a, target: 'HEAD',
+    });
+    assert.equal(receipt.outcome, 'completed');
+    assert.equal(receipt.context_key, first.context_key);
+    assert.equal(activeDelivery(vault, { context: a }), null);
+    assert.equal(activeDelivery(vault, { context: b }).id, second.id);
+    assert.equal(resolveActiveContext(vault, a).delivery_id, '');
+    assert.equal(resolveActiveContext(vault, b).delivery_id, second.id);
+    assert.deepEqual(readFileSync(secondPath), secondBefore);
+
+    const abandoned = abandonDelivery({
+      vaultBase: vault, id: second.id, context: b, reason: 'context-specific stop',
+    });
+    assert.equal(abandoned.outcome, 'abandoned');
+    assert.equal(activeDelivery(vault, { context: b }), null);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:ACTX-17] abandon records its context and preserves an active sibling byte-for-byte', () => {
+  const { repo, vault } = fixture();
+  try {
+    const a = identity('worktree-a', 'work-a');
+    const b = identity('worktree-b', 'work-b');
+    const first = startDelivery({
+      vaultBase: vault, repoRoot: repo, id: 'abandon-a', capabilities: ['git:push'], context: a,
+    });
+    const second = startDelivery({
+      vaultBase: vault, repoRoot: repo, id: 'keep-b', capabilities: ['git:push'], context: b,
+    });
+    const siblingPath = join(vault, '.brain', 'runtime', 'deliveries', 'keep-b.json');
+    const siblingBefore = readFileSync(siblingPath);
+
+    const receipt = abandonDelivery({
+      vaultBase: vault, id: first.id, context: a, reason: 'context-specific stop',
+    });
+
+    assert.equal(receipt.outcome, 'abandoned');
+    assert.equal(receipt.context_key, first.context_key);
+    assert.equal(activeDelivery(vault, { context: a }), null);
+    assert.equal(activeDelivery(vault, { context: b }).id, second.id);
+    assert.equal(resolveActiveContext(vault, b).delivery_id, second.id);
+    assert.deepEqual(readFileSync(siblingPath), siblingBefore);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:ACTX-14] one context cannot replace an active delivery silently', () => {
+  const { repo, vault } = fixture();
+  try {
+    const context = identity('worktree-a', 'work-a');
+    startDelivery({
+      vaultBase: vault, repoRoot: repo, id: 'delivery-a', capabilities: ['git:push'], context,
+    });
+    const secondPath = join(vault, '.brain', 'runtime', 'deliveries', 'delivery-a-2.json');
+    assert.throws(
+      () => startDelivery({
+        vaultBase: vault, repoRoot: repo, id: 'delivery-a-2', capabilities: ['git:push'], context,
+      }),
+      (error) => error?.code === 'WENDKEEP_DELIVERY_CONTEXT_BUSY',
+    );
+    assert.equal(existsSync(secondPath), false);
+    assert.equal(activeDelivery(vault, { context }).id, 'delivery-a');
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:ACTX-15] start removes its new state when contextual bind fails', () => {
+  const { repo, vault } = fixture();
+  try {
+    const statePath = join(vault, '.brain', 'runtime', 'deliveries', 'bind-fails.json');
+    assert.throws(
+      () => startDelivery({
+        vaultBase: vault,
+        repoRoot: repo,
+        id: 'bind-fails',
+        capabilities: ['git:push'],
+        context: identity('worktree-a', 'work-a'),
+        bindDelivery: () => { throw new Error('simulated context bind failure'); },
+      }),
+      /simulated context bind failure/,
+    );
+    assert.equal(existsSync(statePath), false);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:ACTX-16] hooks observe delivery only in the caller active context', () => {
+  const { repo, vault } = fixture();
+  try {
+    const a = identity('worktree-a', 'work-a');
+    const b = identity('worktree-b', 'work-b');
+    assert.match(warnDecision('src/pre-context.mjs', {
+      vaultBase: vault, cwd: repo, sessionId: 'session-before-context', profile: 'ASSURE', context: a,
+    }), /change_warn/);
+    setActiveContextDelivery(vault, a, 'temporary-a');
+    clearActiveContextDelivery(vault, a);
+    startDelivery({
+      vaultBase: vault, repoRoot: repo, id: 'delivery-b', capabilities: ['git:push'], context: b,
+    });
+
+    assert.equal(buildChangePing(vault, 'session-a', 'publique a versão', '', {
+      profile: 'ASSURE', context: a,
+    }), null);
+    assert.match(buildChangePing(vault, 'session-b', 'publique a versão', '', {
+      profile: 'ASSURE', context: b,
+    }).context, /Delivery delivery-b ativa/);
+
+    assert.match(warnDecision('src/release.mjs', {
+      vaultBase: vault, cwd: repo, sessionId: 'session-a', profile: 'ASSURE', context: a,
+    }), /change_warn/);
+    assert.equal(warnDecision('src/release.mjs', {
+      vaultBase: vault, cwd: repo, sessionId: 'session-b', profile: 'ASSURE', context: b,
+    }), null);
   } finally {
     rmSync(repo, { recursive: true, force: true });
     rmSync(vault, { recursive: true, force: true });

--- a/tests/docs-bilingual.test.mjs
+++ b/tests/docs-bilingual.test.mjs
@@ -571,3 +571,32 @@ test('[req:ACTX-12] [req:ACTX-13] DOC-16: registry multi-contexto e migração c
     assert.match(docs.guide, docs.ambiguity, `${locale}: ambiguidade causal ausente`);
   }
 });
+
+test('[req:ACTX-15] [req:ACTX-16] DOC-17: delivery causal e projeção legada são bilíngues', () => {
+  const cases = {
+    pt: {
+      guide: readFileSync(join(GUIDE_DIR.pt, 'operating-profiles.md'), 'utf8'),
+      readme: readFileSync(join(ROOT, 'README.md'), 'utf8'),
+      projection: /CURRENT_DELIVERY[\s\S]*(?:projeção|derivad)[\s\S]*(?:único|inequívoc)/i,
+      mismatch: /WENDKEEP_DELIVERY_CONTEXT_MISMATCH[\s\S]*(?:outro|diferente)[\s\S]*contexto/i,
+      hooks: /(?:hooks?|change-context|change-warn)[\s\S]*(?:delivery|autoriza)[\s\S]*(?:causal|chamador)/i,
+    },
+    en: {
+      guide: readFileSync(join(GUIDE_DIR.en, 'operating-profiles.md'), 'utf8'),
+      readme: readFileSync(join(ROOT, 'README.en.md'), 'utf8'),
+      projection: /CURRENT_DELIVERY[\s\S]*(?:projection|derived)[\s\S]*(?:single|unambiguous)/i,
+      mismatch: /WENDKEEP_DELIVERY_CONTEXT_MISMATCH[\s\S]*(?:other|different)[\s\S]*context/i,
+      hooks: /(?:hooks?|change-context|change-warn)[\s\S]*(?:delivery|authoriz)[\s\S]*(?:causal|caller)/i,
+    },
+  };
+  for (const [locale, docs] of Object.entries(cases)) {
+    for (const text of [docs.guide, docs.readme]) {
+      assert.match(text, /active_contexts/i, `${locale}: registry contextual ausente`);
+      assert.match(text, /delivery_id/i, `${locale}: binding delivery_id ausente`);
+      assert.match(text, /--session <id>/i, `${locale}: seleção causal explícita ausente`);
+    }
+    assert.match(docs.guide, docs.projection, `${locale}: projeção CURRENT_DELIVERY ausente`);
+    assert.match(docs.guide, docs.mismatch, `${locale}: erro cross-context ausente`);
+    assert.match(docs.guide, docs.hooks, `${locale}: contrato causal dos hooks ausente`);
+  }
+});

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -84,9 +84,15 @@ test('extractReleaseNotes: throws when the version is absent', () => {
 test('[sensor:release-tests] current release notes are extractable and match the package', () => {
   const release = extractReleaseNotes(CHANGELOG, PACKAGE.version);
   assert.equal(release.date, '2026-08-22');
+  assert.match(release.notes, /Delivery causal/i);
+  assert.match(release.notes, /CURRENT_DELIVERY.*projeção/i);
+  assert.doesNotMatch(release.notes, /019f[0-9a-f-]+/i);
+});
+
+test('[sensor:release-tests] 0.76.4 active-context registry notes remain extractable', () => {
+  const release = extractReleaseNotes(CHANGELOG, '0.76.4');
   assert.match(release.notes, /Registry multi-contexto/i);
   assert.match(release.notes, /CURRENT_CHANGE.*projeção/i);
-  assert.doesNotMatch(release.notes, /019f[0-9a-f-]+/i);
 });
 
 test('[sensor:release-tests] 0.76.3 recovery notes remain extractable', () => {

--- a/wendkeep.sensors.json
+++ b/wendkeep.sensors.json
@@ -576,6 +576,14 @@
       "severity": "critical",
       "type": "command",
       "command": "node --test tests/active-context-store.test.mjs tests/active-context-runtime.test.mjs tests/active-context-change-cli.test.mjs tests/change-core.test.mjs tests/change-cli.test.mjs"
+    },
+    {
+      "id": "active-context-delivery",
+      "name": "active-context-delivery",
+      "description": "Validates contextual delivery bindings, CLI lifecycle, hooks, rollback and legacy projection",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test tests/active-context-delivery.test.mjs tests/active-context-delivery-cli.test.mjs tests/delivery.test.mjs"
     }
   ]
 }


### PR DESCRIPTION
## Resumo

- vincula deliveries ao active context causal em vez de usar um ponteiro global
- mantém `CURRENT_DELIVERY` somente como projeção legada segura (vazia com zero ou múltiplos contextos)
- faz `change-context` e `change-warn` resolverem o delivery do chamador
- preserva deliveries irmãos em finish/abandon e registra `context_key` no receipt
- atualiza documentação bilíngue, sensor, CHANGELOG e versão 0.76.5

## Verificação

- `npm run check`
- `npm test` (exit 0)
- `wendkeep verify` (5/5 sensores)
- `wendkeep verify --deep`
- revisão independente: ACTX-14..17 cobertos, 13/13 focais, `ok:true`
- `npm pack --dry-run --json` (wendkeep@0.76.5, 192 arquivos)

## CHANGELOG

`0.76.5` impede que deliveries simultâneos em contextos causais irmãos se sobrescrevam ou sejam ocultados, preservando compatibilidade pelo ponteiro legado somente quando inequívoco.
