### PR TITLE
fix: scope task leases by active context (0.76.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.76.6] — 2026-08-22
+
+### Fixed
+
+- **Task lease causal.** `operating_profile_task` passa a pertencer ao `active_contexts` da
+  worktree/work session; rotas temporárias irmãs não se sobrescrevem nem ampliam autorização.
+- **CLI e hooks escopados.** `profile route/status`, os hooks de operating profile e o consumo no
+  Stop resolvem a lease do chamador e preservam o sibling byte a byte por revision/CAS.
+- **Fallback legado fail-closed.** Vault sem registry contextual conserva a lease na sessão;
+  depois da inicialização, uma lease global não é copiada nem aplicada sem identidade provada.
+
 ## [0.76.5] — 2026-08-22
 
 ### Added

--- a/README.en.md
+++ b/README.en.md
@@ -343,6 +343,11 @@ selects the caller explicitly. `CURRENT_DELIVERY` is only a derived projection w
 single, unambiguous context; hooks consult only the causal delivery, and an ID from another context
 fails with `WENDKEEP_DELIVERY_CONTEXT_MISMATCH`.
 
+`operating_profile_task` belongs to the causal work session's active context. `profile route` and
+`profile status --session <id>`, hooks, and Stop read/consume only that lease; a temporary route
+never crosses into a sibling. Legacy session fallback exists only without `active_contexts`;
+an initialized registry never copies a global authorization without proven identity.
+
 ```bash
 npx wendkeep delivery start release-0-74-0 --allow git:merge --allow git:push --allow publish --source-change <slug> --source-commit <sha> --session <id>
 npx wendkeep delivery status release-0-74-0 --session <id>

--- a/README.md
+++ b/README.md
@@ -340,6 +340,11 @@ explicitamente o chamador. `CURRENT_DELIVERY` é somente uma projeção derivada
 contexto inequívoco; hooks consultam apenas o delivery causal e um ID de outro contexto falha com
 `WENDKEEP_DELIVERY_CONTEXT_MISMATCH`.
 
+`operating_profile_task` pertence ao active context da work session causal. `profile route` e
+`profile status --session <id>`, hooks e Stop leem/consomem somente essa lease; uma rota temporária
+não atravessa para o sibling. O fallback legado na sessão existe apenas sem `active_contexts`;
+registry inicializado nunca copia uma autorização global sem identidade provada.
+
 ```bash
 npx wendkeep delivery start release-0-74-0 --allow git:merge --allow git:push --allow publish --source-change <slug> --source-commit <sha> --session <id>
 npx wendkeep delivery status release-0-74-0 --session <id>

--- a/docs/en/commands/operating-profiles.md
+++ b/docs/en/commands/operating-profiles.md
@@ -130,6 +130,12 @@ ownership to the native LLM harness.
   session identity.
 - `profile route` requires `--session` and `--reason`, accepts only the four adaptive profiles,
   and records lease id, reason, turn/sequence, and timestamp without touching persistent profiles.
+- `operating_profile_task` belongs to the causal session/work session's active context. `profile route`
+  creates and `profile status --session <id>` reads only that lease; hooks use the same caller
+  context and an accepted Stop consumes it by `lease_id` with revision/CAS without changing a sibling.
+- Legacy fallback of the lease in the session exists only without `active_contexts`. With an
+  initialized registry, a global lease absent from the context is neither copied nor applied;
+  missing, ambiguous, or stale context fails closed without a partial mutation.
 - `.wendkeep.json` stays on `schemaVersion: 1`; the additive field is, for example,
   `"harness": { "profile": "GOVERN" }`. A legacy binding without it also resolves to `GOVERN`.
 - A corrupt binding never means `OFF`. When the payload or legacy integration identifies one

--- a/docs/pt-BR/commands/operating-profiles.md
+++ b/docs/pt-BR/commands/operating-profiles.md
@@ -131,6 +131,12 @@ harness nativo da LLM.
   projeto; com `--session`, grava override, origem e timestamp sem trocar a identidade da sessão.
 - `profile route` exige `--session` e `--reason`, aceita somente os quatro perfis adaptativos e
   grava `lease_id`, motivo, turno/sequência e timestamp sem tocar no perfil persistente.
+- `operating_profile_task` pertence ao active context da work session/sessão causal. `profile route`
+  cria e `profile status --session <id>` consulta somente essa lease; os hooks usam o mesmo contexto
+  do chamador e o Stop aceito consome por `lease_id` com revision/CAS, sem alterar o sibling.
+- O fallback legado de lease na sessão existe apenas sem `active_contexts`. Com o registry
+  inicializado, uma lease global ausente do contexto não é copiada nem aplicada; contexto
+  ausente, ambíguo ou stale falha fechado sem mutação parcial.
 - `.wendkeep.json` continua em `schemaVersion: 1`; o campo aditivo usa, por exemplo,
   `"harness": { "profile": "GOVERN" }`. Binding legado sem o campo também resolve `GOVERN`.
 - Binding corrompido nunca equivale a `OFF`. Quando o payload ou a integração legada identifica

--- a/hooks/active-context-store.mjs
+++ b/hooks/active-context-store.mjs
@@ -139,6 +139,7 @@ export function mutateActiveContext(vaultBase, identity, updater, {
   expectedRevision,
   now = new Date().toISOString(),
   mutateRegistry = mutateSessionRegistry,
+  projectLegacy = true,
 } = {}) {
   const normalized = normalizeIdentity(identity);
   const key = activeContextKey(normalized);
@@ -191,8 +192,10 @@ export function mutateActiveContext(vaultBase, identity, updater, {
     registry.active_contexts = { ...contexts, [key]: next };
     return { key, context: structuredClone(next), registryRevision: registry.active_contexts_revision };
   });
-  projectLegacyActiveChange(vaultBase);
-  projectLegacyActiveDelivery(vaultBase);
+  if (projectLegacy) {
+    projectLegacyActiveChange(vaultBase);
+    projectLegacyActiveDelivery(vaultBase);
+  }
   return result;
 }
 

--- a/hooks/change-nag.mjs
+++ b/hooks/change-nag.mjs
@@ -15,11 +15,11 @@ import {
 } from './operating-profile-runtime.mjs';
 import { consumeSessionTaskOperatingProfile } from './operating-profile-task-store.mjs';
 
-export function nagDecision(input, vaultBase, { profile = 'GOVERN' } = {}) {
+export function nagDecision(input, vaultBase, { profile = 'GOVERN', context = null } = {}) {
   if (input && input.stop_hook_active) return null; // anti-loop: sempre primeiro
   const policy = hookProfilePolicy(profile);
   if (!policy.harness) return null;
-  const gate = quickGateState(vaultBase);
+  const gate = quickGateState(vaultBase, { context });
   if (!gate || !gate.openTasks) return null;
   const sid = input?.session_id || input?.sessionId || '';
   const sentinelId = profileSentinelId(sid, profile);
@@ -39,12 +39,16 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       ? null
       : runtime.bindingError
         ? { decision: 'block', reason: profileRuntimeError(runtime.bindingError) }
-        : nagDecision(input, runtime.vaultBase, { profile: runtime.profile });
+        : nagDecision(input, runtime.vaultBase, {
+          profile: runtime.profile,
+          context: runtime.activeContext,
+        });
     if (!decision && runtime.taskLease?.state === 'active') {
       consumeSessionTaskOperatingProfile(
         runtime.vaultBase,
         runtime.identity?.canonicalConversationId || input?.session_id || input?.sessionId || '',
         runtime.taskLease.lease_id,
+        { context: runtime.activeContext },
       );
     }
     writeHookOutput(decision || {});

--- a/hooks/operating-profile-runtime.mjs
+++ b/hooks/operating-profile-runtime.mjs
@@ -11,6 +11,8 @@ import {
 import { findProjectBinding, resolveProjectVault } from '../src/project-vault.mjs';
 import { readSessionRegistry } from './obsidian-common.mjs';
 import { resolveSessionIdentity } from './session-identity.mjs';
+import { resolveCommandActiveContext } from '../src/active-context-runtime.mjs';
+import { sessionTaskOperatingProfile } from './operating-profile-task-store.mjs';
 
 function bindingDiagnostic(error, configPath = '') {
   return {
@@ -152,9 +154,26 @@ export function resolveHookOperatingProfile({
   const entry = identity.state === 'resolved'
     ? readSessionRegistry(vaultResolution.base).sessions?.[identity.canonicalConversationId] || null
     : null;
+  let activeContext = null;
+  let contextError = null;
+  if (!bindingError && identity.state === 'resolved') {
+    try {
+      activeContext = resolveCommandActiveContext({
+        vaultBase: vaultResolution.base,
+        projectRoot: input?.cwd || vaultResolution.projectRoot || process.cwd(),
+        sessionId: identity.canonicalConversationId,
+      });
+    } catch (error) {
+      contextError = bindingDiagnostic(error);
+    }
+  }
   const base = sessionOverride(entry) || project;
   const taskLease = evaluateTaskOperatingProfileLease(
-    entry?.operating_profile_task,
+    contextError ? null : sessionTaskOperatingProfile(
+      vaultResolution.base,
+      identity.canonicalConversationId || '',
+      { context: activeContext },
+    ),
     taskLeaseContext(entry, input, identity.canonicalConversationId || ''),
   );
   const selected = taskLease.state === 'active'
@@ -176,6 +195,8 @@ export function resolveHookOperatingProfile({
     baseProfile: base.profile,
     baseSource: base.source,
     taskLease,
+    activeContext,
+    ...(contextError ? { contextError } : {}),
     resolution: vaultResolution,
     ...(bindingError ? { bindingError } : {}),
   };

--- a/hooks/operating-profile-task-store.mjs
+++ b/hooks/operating-profile-task-store.mjs
@@ -3,7 +3,8 @@ import { randomUUID } from 'node:crypto';
 import {
   createTaskOperatingProfileLease,
 } from '../src/operating-profile.mjs';
-import { mutateSessionRegistry } from './obsidian-common.mjs';
+import { mutateSessionRegistry, readSessionRegistry } from './obsidian-common.mjs';
+import { mutateActiveContext, resolveActiveContext } from './active-context-store.mjs';
 
 function isoTimestamp(now) {
   if (typeof now === 'string') return now;
@@ -17,33 +18,93 @@ function missingSessionError(sessionId) {
   return error;
 }
 
+function activeContextRequiredError() {
+  const error = new Error('active context causal é obrigatório quando o registry contextual está inicializado');
+  error.code = 'WENDKEEP_ACTIVE_CONTEXT_REQUIRED';
+  return error;
+}
+
+function hasActiveContextRegistry(registry) {
+  return Boolean(registry && (
+    Object.hasOwn(registry, 'active_contexts')
+    || Object.hasOwn(registry, 'active_contexts_schema')
+    || Object.hasOwn(registry, 'active_contexts_revision')
+  ));
+}
+
+function leaseFromSession(current, profile, { reason, leaseId, issuedAt, sessionId }) {
+  const turnId = typeof current.last_prompt_turn_id === 'string'
+    ? current.last_prompt_turn_id.trim()
+    : '';
+  const hasRegisteredTurn = Boolean(
+    turnId
+    && current.turn_sequences
+    && Object.hasOwn(current.turn_sequences, turnId)
+    && current.turn_sequences[turnId] === current.last_turn_sequence
+  );
+  return createTaskOperatingProfileLease({
+    profile,
+    reason,
+    sessionId,
+    turnId,
+    turnSequence: hasRegisteredTurn ? current.last_turn_sequence : undefined,
+    leaseId,
+    issuedAt,
+  });
+}
+
+export function sessionTaskOperatingProfile(vaultBase, sessionId, { context = null } = {}) {
+  if (context) {
+    try { return resolveActiveContext(vaultBase, context).operating_profile_task || null; }
+    catch (error) {
+      if (error?.code === 'WENDKEEP_ACTIVE_CONTEXT_NOT_FOUND') {
+        const registry = readSessionRegistry(vaultBase);
+        if (hasActiveContextRegistry(registry)) return null;
+        return registry.sessions?.[sessionId]?.operating_profile_task || null;
+      }
+      throw error;
+    }
+  }
+  const registry = readSessionRegistry(vaultBase);
+  if (hasActiveContextRegistry(registry)) return null;
+  return registry.sessions?.[sessionId]?.operating_profile_task || null;
+}
+
 export function setSessionTaskOperatingProfile(vaultBase, sessionId, profile, {
   reason,
   leaseId = randomUUID(),
   now,
+  context = null,
+  mutateContext = mutateActiveContext,
 } = {}) {
   const issuedAt = isoTimestamp(now);
+  if (context) {
+    let lease;
+    mutateContext(vaultBase, context, (active) => ({
+      ...active,
+      operating_profile_task: lease,
+      state: 'active',
+    }), {
+      now: issuedAt,
+      projectLegacy: false,
+      mutateRegistry: (base, mutator) => mutateSessionRegistry(base, (registry) => {
+        const sessions = registry.sessions || (registry.sessions = {});
+        if (!Object.hasOwn(sessions, sessionId)) throw missingSessionError(sessionId);
+        lease = leaseFromSession(sessions[sessionId], profile, {
+          reason, leaseId, issuedAt, sessionId,
+        });
+        return mutator(registry);
+      }),
+    });
+    return lease;
+  }
   return mutateSessionRegistry(vaultBase, (registry) => {
+    if (hasActiveContextRegistry(registry)) throw activeContextRequiredError();
     const sessions = registry.sessions || (registry.sessions = {});
     if (!Object.hasOwn(sessions, sessionId)) throw missingSessionError(sessionId);
     const current = sessions[sessionId];
-    const turnId = typeof current.last_prompt_turn_id === 'string'
-      ? current.last_prompt_turn_id.trim()
-      : '';
-    const hasRegisteredTurn = Boolean(
-      turnId
-      && current.turn_sequences
-      && Object.hasOwn(current.turn_sequences, turnId)
-      && current.turn_sequences[turnId] === current.last_turn_sequence
-    );
-    const lease = createTaskOperatingProfileLease({
-      profile,
-      reason,
-      sessionId,
-      turnId,
-      turnSequence: hasRegisteredTurn ? current.last_turn_sequence : undefined,
-      leaseId,
-      issuedAt,
+    const lease = leaseFromSession(current, profile, {
+      reason, leaseId, issuedAt, sessionId,
     });
     sessions[sessionId] = {
       ...current,
@@ -56,10 +117,53 @@ export function setSessionTaskOperatingProfile(vaultBase, sessionId, profile, {
 
 export function consumeSessionTaskOperatingProfile(vaultBase, sessionId, leaseId, {
   now,
+  context = null,
+  mutateContext = mutateActiveContext,
 } = {}) {
   if (!sessionId || !leaseId) return false;
   const consumedAt = isoTimestamp(now);
+  if (context) {
+    let current;
+    try { current = resolveActiveContext(vaultBase, context); }
+    catch (error) {
+      if (error?.code !== 'WENDKEEP_ACTIVE_CONTEXT_NOT_FOUND') throw error;
+      const registry = readSessionRegistry(vaultBase);
+      if (hasActiveContextRegistry(registry)) return false;
+      return consumeSessionTaskOperatingProfile(vaultBase, sessionId, leaseId, {
+        now: consumedAt,
+      });
+    }
+    const lease = current.operating_profile_task;
+    if (!lease || lease.state !== 'active' || lease.lease_id !== leaseId) return false;
+    let consumed = false;
+    try {
+      mutateContext(vaultBase, context, (active) => {
+        const activeLease = active.operating_profile_task;
+        if (!activeLease || activeLease.state !== 'active' || activeLease.lease_id !== leaseId) {
+          return active;
+        }
+        consumed = true;
+        return {
+          ...active,
+          operating_profile_task: {
+            ...activeLease,
+            state: 'consumed',
+            consumed_at: consumedAt,
+          },
+        };
+      }, {
+        expectedRevision: current.revision,
+        now: consumedAt,
+        projectLegacy: false,
+      });
+    } catch (error) {
+      if (error?.code === 'WENDKEEP_ACTIVE_CONTEXT_STALE') return false;
+      throw error;
+    }
+    return consumed;
+  }
   return mutateSessionRegistry(vaultBase, (registry) => {
+    if (hasActiveContextRegistry(registry)) throw activeContextRequiredError();
     const current = registry.sessions?.[sessionId];
     const lease = current?.operating_profile_task;
     if (!lease || lease.state !== 'active' || lease.lease_id !== leaseId) return false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.76.5",
+  "version": "0.76.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.76.5",
+      "version": "0.76.6",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.76.5",
+  "version": "0.76.6",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [

--- a/src/profile.mjs
+++ b/src/profile.mjs
@@ -8,7 +8,11 @@ import {
   resolveOperatingProfile,
   setOperatingProfile,
 } from './operating-profile.mjs';
-import { setSessionTaskOperatingProfile } from '../hooks/operating-profile-task-store.mjs';
+import {
+  sessionTaskOperatingProfile,
+  setSessionTaskOperatingProfile,
+} from '../hooks/operating-profile-task-store.mjs';
+import { resolveCommandActiveContext } from './active-context-runtime.mjs';
 import { resolve } from 'node:path';
 import { findProjectBinding, resolveProjectVault, updateProjectBinding } from './project-vault.mjs';
 
@@ -163,12 +167,13 @@ function sessionProfile(vaultBase, sessionId, projectResolved) {
   return sessionBaseProfile(sessions[sessionId], projectResolved);
 }
 
-function sessionProfileStatus(vaultBase, sessionId, projectResolved) {
+function sessionProfileStatus(vaultBase, sessionId, projectResolved, { context = null } = {}) {
   const sessions = readSessionRegistry(vaultBase).sessions || {};
   if (!Object.hasOwn(sessions, sessionId)) throw new Error(`sessão não encontrada: ${sessionId}`);
   const entry = sessions[sessionId];
   const base = sessionBaseProfile(entry, projectResolved);
-  const taskLease = evaluateTaskOperatingProfileLease(entry.operating_profile_task, {
+  const taskLease = evaluateTaskOperatingProfileLease(
+    sessionTaskOperatingProfile(vaultBase, sessionId, { context }), {
     sessionId,
     turnId: entry.last_prompt_turn_id || '',
     turnSequence: entry.last_turn_sequence,
@@ -181,6 +186,15 @@ function sessionProfileStatus(vaultBase, sessionId, projectResolved) {
     baseSource: base.source,
     taskLease,
   };
+}
+
+function commandActiveContext(state, sessionId) {
+  if (!sessionId || state.resolved.bindingError) return null;
+  return resolveCommandActiveContext({
+    vaultBase: state.vaultBase,
+    projectRoot: state.resolved.projectRoot || process.cwd(),
+    sessionId,
+  });
 }
 
 function sessionOutputPayload(effective, sessionId) {
@@ -213,8 +227,9 @@ export function runProfile(argv = []) {
   if (sub === 'status' || sub === 'show') {
     if (args.length > 1) return fail(`${sub} não aceita argumentos posicionais adicionais`);
     try {
+      const activeContext = sessionId ? commandActiveContext(state, sessionId) : null;
       const effective = sessionId
-        ? sessionProfileStatus(state.vaultBase, sessionId, projectResolved)
+        ? sessionProfileStatus(state.vaultBase, sessionId, projectResolved, { context: activeContext })
         : { profile: projectResolved.profile, source: projectResolved.source, scope: 'project' };
       output({
         ...(sessionId ? sessionOutputPayload(effective, sessionId) : {
@@ -235,11 +250,12 @@ export function runProfile(argv = []) {
     if (!reason) return fail('route requer --reason <text>');
     try {
       const base = sessionProfile(state.vaultBase, sessionId, projectResolved);
+      const activeContext = commandActiveContext(state, sessionId);
       const lease = setSessionTaskOperatingProfile(
         state.vaultBase,
         sessionId,
         args[1],
-        { reason },
+        { reason, context: activeContext },
       );
       output({
         profile: lease.profile,

--- a/tests/active-context-task-lease-cli.test.mjs
+++ b/tests/active-context-task-lease-cli.test.mjs
@@ -1,0 +1,194 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { bindProjectVault } from '../src/project-vault.mjs';
+import { resolveRuntimeActiveContext } from '../src/active-context-runtime.mjs';
+import { readSessionRegistry, writeSessionRegistry } from '../hooks/obsidian-common.mjs';
+import { captureProjectScope, scopeForRegistry } from '../hooks/project-scope.mjs';
+import {
+  activeContextKey,
+  mutateActiveContext,
+  setActiveContextChange,
+} from '../hooks/active-context-store.mjs';
+import { setSessionTaskOperatingProfile } from '../hooks/operating-profile-task-store.mjs';
+import { discoverWorktreeRepository, ensureWorktreeMetadata } from '../packages/vault/src/worktree-metadata.mjs';
+
+const BIN = join(process.cwd(), 'bin', 'wendkeep.mjs');
+
+function git(cwd, args) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8', windowsHide: true });
+  assert.equal(result.status, 0, result.stderr || result.error?.message);
+}
+
+function fixture({ initializeContexts = true } = {}) {
+  const parent = mkdtempSync(join(tmpdir(), 'wk-active-context-task-lease-cli-'));
+  const project = join(parent, 'project');
+  git(parent, ['init', project]);
+  git(project, ['config', 'user.email', 'task-lease@example.invalid']);
+  git(project, ['config', 'user.name', 'Task Lease CLI Test']);
+  git(project, ['branch', '-M', 'main']);
+  git(project, ['remote', 'add', 'origin', 'https://example.com/acme/task-lease-cli.git']);
+  writeFileSync(join(project, 'package.json'), JSON.stringify({ name: 'fixture', version: '1.0.0' }));
+  git(project, ['add', 'package.json']);
+  git(project, ['commit', '-m', 'fixture']);
+
+  const vault = join(parent, 'vault');
+  const binding = bindProjectVault({
+    projectRoot: project,
+    vaultPath: vault,
+    configPatch: { harness: { profile: 'OFF' } },
+  });
+  ensureWorktreeMetadata({
+    repository: discoverWorktreeRepository({ startDir: project }),
+    projectId: binding.projectId,
+    vaultPath: vault,
+  });
+  git(project, ['add', '-A']);
+  git(project, ['commit', '--allow-empty', '-m', 'bind vault']);
+  const scope = (sessionId) => scopeForRegistry(captureProjectScope({
+    input: { cwd: project }, projectRoot: project, projectId: binding.projectId,
+    provider: 'claude', sessionId,
+  }));
+  writeSessionRegistry(vault, {
+    version: 2,
+    sessions: {
+      'session-a': {
+        status: 'active', provider: 'claude', work_session_id: 'work-a', project_scope: scope('session-a'),
+        last_prompt_turn_id: 'turn-a', last_turn_sequence: 1, turn_sequences: { 'turn-a': 1 },
+      },
+      'session-b': {
+        status: 'active', provider: 'claude', work_session_id: 'work-b', project_scope: scope('session-b'),
+        last_prompt_turn_id: 'turn-b', last_turn_sequence: 1, turn_sequences: { 'turn-b': 1 },
+      },
+    },
+  });
+  const a = resolveRuntimeActiveContext({ vaultBase: vault, projectRoot: project, sessionId: 'session-a' });
+  const b = resolveRuntimeActiveContext({ vaultBase: vault, projectRoot: project, sessionId: 'session-b' });
+  if (initializeContexts) {
+    mutateActiveContext(vault, a, (context) => context);
+    mutateActiveContext(vault, b, (context) => context);
+  }
+  return { parent, project, vault, a, b };
+}
+
+function runProfile(f, args) {
+  return spawnSync(process.execPath, [
+    BIN, 'profile', ...args, '--project', f.project, '--vault', f.vault,
+  ], {
+    cwd: f.project,
+    encoding: 'utf8',
+    windowsHide: true,
+    env: { ...process.env, CODEX_THREAD_ID: '', CLAUDE_SESSION_ID: '' },
+  });
+}
+
+function runHook(f, name, input) {
+  return spawnSync(process.execPath, [join(process.cwd(), 'hooks', `${name}.mjs`)], {
+    cwd: f.project,
+    input: JSON.stringify({ ...input, cwd: f.project, obsidian_vault_path: f.vault }),
+    encoding: 'utf8',
+    windowsHide: true,
+    env: {
+      ...process.env,
+      CLAUDECODE: '1',
+      CODEX_THREAD_ID: '',
+      CLAUDE_SESSION_ID: '',
+    },
+  });
+}
+
+test('[req:ACTX-19] [req:ACTX-20] profile CLI and executable hooks isolate and consume task leases by causal context', () => {
+  const f = fixture();
+  try {
+    const routeA = runProfile(f, [
+      'route', 'FLOW', '--session', 'session-a', '--reason', 'bounded A', '--json',
+    ]);
+    assert.equal(routeA.status, 0, routeA.stderr);
+    const routeB = runProfile(f, [
+      'route', 'GOVERN', '--session', 'session-b', '--reason', 'governed B', '--json',
+    ]);
+    assert.equal(routeB.status, 0, routeB.stderr);
+
+    const statusA = runProfile(f, ['status', '--session', 'session-a', '--json']);
+    const statusB = runProfile(f, ['status', '--session', 'session-b', '--json']);
+    assert.equal(statusA.status, 0, statusA.stderr);
+    assert.equal(statusB.status, 0, statusB.stderr);
+    assert.equal(JSON.parse(statusA.stdout).profile, 'FLOW');
+    assert.equal(JSON.parse(statusB.stdout).profile, 'GOVERN');
+
+    const warnA = runHook(f, 'change-warn', {
+      session_id: 'session-a', turn_id: 'turn-a', turn_sequence: 1,
+      tool_input: { file_path: 'src/a.mjs' },
+    });
+    const warnB = runHook(f, 'change-warn', {
+      session_id: 'session-b', turn_id: 'turn-b', turn_sequence: 1,
+      tool_input: { file_path: 'src/b.mjs' },
+    });
+    assert.equal(warnA.status, 0, warnA.stderr);
+    assert.equal(warnB.status, 0, warnB.stderr);
+    assert.equal(JSON.parse(warnA.stdout).hookSpecificOutput?.additionalContext ?? '', '');
+    assert.match(JSON.parse(warnB.stdout).hookSpecificOutput.additionalContext, /<change_warn>/);
+
+    const changeDir = join(f.vault, '08-Mudanças', 'task-stop-open');
+    mkdirSync(changeDir, { recursive: true });
+    writeFileSync(join(changeDir, 'proposta.md'), '# proposta\n');
+    writeFileSync(join(changeDir, 'design.md'), '# design\n');
+    writeFileSync(join(changeDir, 'tarefas.md'), '- [ ] 1.1 tarefa contextual\n');
+    setActiveContextChange(f.vault, f.a, 'task-stop-open', { projectLegacy: false });
+
+    let registry = readSessionRegistry(f.vault);
+    const keyA = activeContextKey(f.a);
+    const keyB = activeContextKey(f.b);
+    const siblingBefore = JSON.stringify(registry.active_contexts[keyB]);
+    const blockedA = runHook(f, 'change-nag', {
+      session_id: 'session-a', turn_id: 'turn-a', turn_sequence: 1,
+    });
+    assert.equal(blockedA.status, 0, blockedA.stderr);
+    assert.equal(JSON.parse(blockedA.stdout).decision, 'block');
+    registry = readSessionRegistry(f.vault);
+    assert.equal(registry.active_contexts[keyA].operating_profile_task.state, 'active');
+    assert.equal(JSON.stringify(registry.active_contexts[keyB]), siblingBefore);
+
+    const retryA = runHook(f, 'change-nag', {
+      session_id: 'session-a', turn_id: 'turn-a', turn_sequence: 1,
+      stop_hook_active: true,
+    });
+    assert.equal(retryA.status, 0, retryA.stderr);
+    assert.deepEqual(JSON.parse(retryA.stdout), {});
+    registry = readSessionRegistry(f.vault);
+    assert.equal(registry.active_contexts[keyA].operating_profile_task.state, 'consumed');
+    assert.equal(registry.active_contexts[keyB].operating_profile_task.state, 'active');
+    assert.equal(JSON.stringify(registry.active_contexts[keyB]), siblingBefore);
+    assert.equal(registry.sessions['session-a'].operating_profile_task, undefined);
+    assert.equal(registry.sessions['session-b'].operating_profile_task, undefined);
+  } finally { rmSync(f.parent, { recursive: true, force: true }); }
+});
+
+test('[req:ACTX-21] profile status preserves the session lease before contextual registry initialization', () => {
+  const f = fixture({ initializeContexts: false });
+  try {
+    setSessionTaskOperatingProfile(f.vault, 'session-a', 'FLOW', {
+      reason: 'legacy pre-migration lease', leaseId: 'legacy-cli-lease',
+      now: '2026-08-22T08:00:00.000Z',
+    });
+
+    const status = runProfile(f, ['status', '--session', 'session-a', '--json']);
+    assert.equal(status.status, 0, status.stderr);
+    const payload = JSON.parse(status.stdout);
+    assert.equal(payload.profile, 'FLOW');
+    assert.equal(payload.task_lease.state, 'active');
+    assert.equal(payload.task_lease.lease_id, 'legacy-cli-lease');
+
+    const stop = runHook(f, 'change-nag', {
+      session_id: 'session-a', turn_id: 'turn-a', turn_sequence: 1,
+    });
+    assert.equal(stop.status, 0, stop.stderr);
+    assert.deepEqual(JSON.parse(stop.stdout), {});
+    const registry = readSessionRegistry(f.vault);
+    assert.equal(registry.sessions['session-a'].operating_profile_task.state, 'consumed');
+  } finally { rmSync(f.parent, { recursive: true, force: true }); }
+});

--- a/tests/docs-bilingual.test.mjs
+++ b/tests/docs-bilingual.test.mjs
@@ -600,3 +600,31 @@ test('[req:ACTX-15] [req:ACTX-16] DOC-17: delivery causal e projeção legada s�
     assert.match(docs.guide, docs.hooks, `${locale}: contrato causal dos hooks ausente`);
   }
 });
+
+test('[req:ACTX-19] [req:ACTX-21] DOC-18: task lease causal e fallback legado são bilíngues', () => {
+  const cases = {
+    pt: {
+      guide: readFileSync(join(GUIDE_DIR.pt, 'operating-profiles.md'), 'utf8'),
+      readme: readFileSync(join(ROOT, 'README.md'), 'utf8'),
+      authority: /operating_profile_task[\s\S]*active context[\s\S]*(?:work session|sessão causal)/i,
+      lifecycle: /profile route[\s\S]*status[\s\S]*(?:hooks?|Stop)[\s\S]*(?:causal|chamador)/i,
+      fallback: /(?:fallback|compatibilidade) legado[\s\S]*(?:sem|ausente)[\s\S]*active_contexts/i,
+    },
+    en: {
+      guide: readFileSync(join(GUIDE_DIR.en, 'operating-profiles.md'), 'utf8'),
+      readme: readFileSync(join(ROOT, 'README.en.md'), 'utf8'),
+      authority: /operating_profile_task[\s\S]*active context[\s\S]*(?:work session|causal session)/i,
+      lifecycle: /profile route[\s\S]*status[\s\S]*(?:hooks?|Stop)[\s\S]*(?:causal|caller)/i,
+      fallback: /legacy (?:fallback|compatibility)[\s\S]*(?:without|absent)[\s\S]*active_contexts/i,
+    },
+  };
+  for (const [locale, docs] of Object.entries(cases)) {
+    for (const text of [docs.guide, docs.readme]) {
+      assert.match(text, /operating_profile_task/i, `${locale}: campo da lease contextual ausente`);
+      assert.match(text, /--session <id>/i, `${locale}: seleção causal ausente`);
+    }
+    assert.match(docs.guide, docs.authority, `${locale}: autoridade contextual da lease ausente`);
+    assert.match(docs.guide, docs.lifecycle, `${locale}: lifecycle causal da lease ausente`);
+    assert.match(docs.guide, docs.fallback, `${locale}: limite do fallback legado ausente`);
+  }
+});

--- a/tests/operating-profile-task-store.test.mjs
+++ b/tests/operating-profile-task-store.test.mjs
@@ -7,8 +7,13 @@ import { join } from 'node:path';
 import { readSessionRegistry } from '../hooks/obsidian-common.mjs';
 import {
   consumeSessionTaskOperatingProfile,
+  sessionTaskOperatingProfile,
   setSessionTaskOperatingProfile,
 } from '../hooks/operating-profile-task-store.mjs';
+import {
+  activeContextKey,
+  mutateActiveContext,
+} from '../hooks/active-context-store.mjs';
 
 function fixture() {
   const vault = mkdtempSync(join(tmpdir(), 'wk-task-profile-store-'));
@@ -28,10 +33,157 @@ function fixture() {
         last_turn_sequence: 5,
         turn_sequences: { 'turn-5': 5 },
       },
+      'session-2': {
+        status: 'active',
+        provider: 'codex',
+        session_file: 'session.md',
+        operating_profile: 'OFF',
+        operating_profile_source: 'explicit-cli',
+        last_prompt_turn_id: 'turn-7',
+        last_turn_sequence: 7,
+        turn_sequences: { 'turn-7': 7 },
+      },
     },
   }, null, 2)}\n`, 'utf8');
   return { vault, note };
 }
+
+function identity(worktreeId, workSessionId) {
+  return {
+    projectId: 'project-task-lease',
+    repositoryId: 'repository-task-lease',
+    worktreeId,
+    workSessionId,
+    branch: `wk/${worktreeId}`,
+    headSha: 'a'.repeat(40),
+  };
+}
+
+test('[req:ACTX-18] [req:ACTX-20] contextual leases replace and consume only their owning active context', () => {
+  const f = fixture();
+  try {
+    const a = identity('worktree-a', 'work-a');
+    const b = identity('worktree-a', 'work-b');
+    mutateActiveContext(f.vault, a, (context) => context);
+    mutateActiveContext(f.vault, b, (context) => context);
+
+    const firstA = setSessionTaskOperatingProfile(f.vault, 'session-1', 'FLOW', {
+      context: a, reason: 'route A', leaseId: 'lease-a-1', now: '2026-08-22T08:00:00.000Z',
+    });
+    const leaseB = setSessionTaskOperatingProfile(f.vault, 'session-2', 'GOVERN', {
+      context: b, reason: 'route B', leaseId: 'lease-b', now: '2026-08-22T08:01:00.000Z',
+    });
+    let registry = readSessionRegistry(f.vault);
+    const keyA = activeContextKey(a);
+    const keyB = activeContextKey(b);
+    assert.equal(registry.sessions['session-1'].operating_profile_task, undefined);
+    assert.equal(registry.sessions['session-2'].operating_profile_task, undefined);
+    assert.deepEqual(registry.active_contexts[keyA].operating_profile_task, firstA);
+    assert.deepEqual(registry.active_contexts[keyB].operating_profile_task, leaseB);
+    const siblingBefore = JSON.stringify(registry.active_contexts[keyB]);
+
+    const secondA = setSessionTaskOperatingProfile(f.vault, 'session-1', 'ASSURE', {
+      context: a, reason: 'route A escalated', leaseId: 'lease-a-2', now: '2026-08-22T08:02:00.000Z',
+    });
+    registry = readSessionRegistry(f.vault);
+    assert.equal(registry.active_contexts[keyA].operating_profile_task.lease_id, secondA.lease_id);
+    assert.equal(JSON.stringify(registry.active_contexts[keyB]), siblingBefore);
+
+    assert.equal(consumeSessionTaskOperatingProfile(
+      f.vault, 'session-1', firstA.lease_id, { context: a, now: '2026-08-22T08:03:00.000Z' },
+    ), false);
+    assert.equal(consumeSessionTaskOperatingProfile(
+      f.vault, 'session-1', secondA.lease_id, { context: a, now: '2026-08-22T08:04:00.000Z' },
+    ), true);
+    registry = readSessionRegistry(f.vault);
+    assert.equal(registry.active_contexts[keyA].operating_profile_task.state, 'consumed');
+    assert.equal(registry.active_contexts[keyB].operating_profile_task.state, 'active');
+    assert.equal(JSON.stringify(registry.active_contexts[keyB]), siblingBefore);
+  } finally { rmSync(f.vault, { recursive: true, force: true }); }
+});
+
+test('[req:ACTX-21] failed contextual persistence preserves the registry byte-for-byte', () => {
+  const f = fixture();
+  try {
+    const context = identity('worktree-a', 'work-a');
+    mutateActiveContext(f.vault, context, (current) => current);
+    const registryPath = join(f.vault, '.brain', 'SESSION_REGISTRY.json');
+    const before = readFileSync(registryPath);
+    assert.throws(
+      () => setSessionTaskOperatingProfile(f.vault, 'session-1', 'FLOW', {
+        reason: 'missing causal context', leaseId: 'lease-global', now: '2026-08-22T08:00:00.000Z',
+      }),
+      (error) => error?.code === 'WENDKEEP_ACTIVE_CONTEXT_REQUIRED',
+    );
+    assert.deepEqual(readFileSync(registryPath), before);
+    assert.throws(
+      () => setSessionTaskOperatingProfile(f.vault, 'session-1', 'FLOW', {
+        context,
+        reason: 'must rollback',
+        leaseId: 'lease-fails',
+        now: '2026-08-22T08:00:00.000Z',
+        mutateContext: () => { throw new Error('simulated contextual persistence failure'); },
+      }),
+      /simulated contextual persistence failure/,
+    );
+    assert.deepEqual(readFileSync(registryPath), before);
+  } finally { rmSync(f.vault, { recursive: true, force: true }); }
+});
+
+test('[req:ACTX-21] an initialized contextual registry never applies a legacy session lease', () => {
+  const f = fixture();
+  try {
+    const legacy = setSessionTaskOperatingProfile(f.vault, 'session-1', 'FLOW', {
+      reason: 'legacy request', leaseId: 'legacy-lease', now: '2026-08-22T08:00:00.000Z',
+    });
+    assert.deepEqual(sessionTaskOperatingProfile(f.vault, 'session-1'), legacy);
+    const context = identity('worktree-a', 'work-a');
+    mutateActiveContext(f.vault, context, (current) => current);
+
+    assert.equal(sessionTaskOperatingProfile(f.vault, 'session-1'), null);
+    assert.equal(sessionTaskOperatingProfile(f.vault, 'session-1', { context }), null);
+    const registry = readSessionRegistry(f.vault);
+    assert.deepEqual(registry.sessions['session-1'].operating_profile_task, legacy);
+    assert.equal(registry.active_contexts[activeContextKey(context)].operating_profile_task, undefined);
+  } finally { rmSync(f.vault, { recursive: true, force: true }); }
+});
+
+test('[req:ACTX-21] an explicitly empty contextual registry disables legacy task leases', () => {
+  const f = fixture();
+  try {
+    const registryPath = join(f.vault, '.brain', 'SESSION_REGISTRY.json');
+    const registry = readSessionRegistry(f.vault);
+    registry.active_contexts_schema = 1;
+    registry.active_contexts_revision = 0;
+    registry.active_contexts = {};
+    writeFileSync(registryPath, `${JSON.stringify(registry, null, 2)}\n`, 'utf8');
+    const before = readFileSync(registryPath);
+
+    assert.equal(sessionTaskOperatingProfile(f.vault, 'session-1'), null);
+    assert.throws(
+      () => setSessionTaskOperatingProfile(f.vault, 'session-1', 'FLOW', {
+        reason: 'must not revive global fallback', leaseId: 'legacy-after-contexts',
+        now: '2026-08-22T08:00:00.000Z',
+      }),
+      (error) => error?.code === 'WENDKEEP_ACTIVE_CONTEXT_REQUIRED',
+    );
+    assert.deepEqual(readFileSync(registryPath), before);
+  } finally { rmSync(f.vault, { recursive: true, force: true }); }
+});
+
+test('[req:ACTX-19] a proven caller without a context record ignores a sibling and its legacy lease', () => {
+  const f = fixture();
+  try {
+    setSessionTaskOperatingProfile(f.vault, 'session-1', 'FLOW', {
+      reason: 'legacy request', leaseId: 'legacy-lease', now: '2026-08-22T08:00:00.000Z',
+    });
+    const caller = identity('worktree-a', 'work-a');
+    const sibling = identity('worktree-a', 'work-b');
+    mutateActiveContext(f.vault, sibling, (current) => current);
+
+    assert.equal(sessionTaskOperatingProfile(f.vault, 'session-1', { context: caller }), null);
+  } finally { rmSync(f.vault, { recursive: true, force: true }); }
+});
 
 test('[req:OP-11] store cria lease no prompt atual sem alterar perfil persistente, identidade ou nota', () => {
   const f = fixture();

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -82,11 +82,18 @@ test('extractReleaseNotes: throws when the version is absent', () => {
 });
 
 test('[sensor:release-tests] current release notes are extractable and match the package', () => {
+  assert.equal(PACKAGE.version, '0.76.6');
   const release = extractReleaseNotes(CHANGELOG, PACKAGE.version);
   assert.equal(release.date, '2026-08-22');
+  assert.match(release.notes, /Task lease causal/i);
+  assert.match(release.notes, /operating_profile_task.*active_contexts/i);
+  assert.doesNotMatch(release.notes, /019f[0-9a-f-]+/i);
+});
+
+test('[sensor:release-tests] 0.76.5 delivery notes remain extractable', () => {
+  const release = extractReleaseNotes(CHANGELOG, '0.76.5');
   assert.match(release.notes, /Delivery causal/i);
   assert.match(release.notes, /CURRENT_DELIVERY.*projeção/i);
-  assert.doesNotMatch(release.notes, /019f[0-9a-f-]+/i);
 });
 
 test('[sensor:release-tests] 0.76.4 active-context registry notes remain extractable', () => {

--- a/wendkeep.sensors.json
+++ b/wendkeep.sensors.json
@@ -584,6 +584,14 @@
       "severity": "critical",
       "type": "command",
       "command": "node --test tests/active-context-delivery.test.mjs tests/active-context-delivery-cli.test.mjs tests/delivery.test.mjs"
+    },
+    {
+      "id": "active-context-task-lease",
+      "name": "active-context-task-lease",
+      "description": "Validates contextual task-lease authority, CLI/hooks/Stop isolation, CAS and legacy fallback",
+      "severity": "critical",
+      "type": "command",
+      "command": "node --test tests/operating-profile-task-store.test.mjs tests/active-context-task-lease-cli.test.mjs tests/profile-cli.test.mjs tests/operating-profile-hooks.test.mjs"
     }
   ]
 }


### PR DESCRIPTION
## Resumo

- move operating_profile_task para o active context causal da work session
- isola profile route/status e hooks entre siblings, com consumo revisionado por lease_id
- preserva compatibilidade pré-migração apenas quando nenhum campo/schema active_contexts existe
- faz change-nag avaliar a change contextual e mantém fallback fail-closed após inicialização

## Changelog

### Fixed

- Task lease causal: rotas temporárias irmãs não se sobrescrevem nem ampliam autorização.
- CLI e hooks escopados: profile route/status e Stop preservam siblings byte a byte por revision/CAS.
- Fallback legado fail-closed: vault legado mantém leitura/consumo na sessão; registry inicializado nunca copia autorização global.

## Verificação

- npm run check
- npm test -- --test-reporter=dot
- wendkeep verify: 5/5
- wendkeep verify --deep: 5/5
- wk-verify independente: ok true, ACTX-18..ACTX-21, 38/38 focais
- npm pack --dry-run: wendkeep@0.76.6, 192 arquivos

Relacionada a #71.