### PR TITLE
fix: share operating profile across worktrees (0.80.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.80.2] — 2026-08-24
+
+### Fixed
+
+- **Perfil persistente em worktrees vinculadas.** `profile use` e `profile status` agora leem e
+  escrevem o binding canônico da worktree principal quando o Vault é resolvido pelo registry Git
+  compartilhado, sem alterar o `.wendkeep.json` versionado da worktree vinculada. A identidade de
+  caminho também normaliza aliases Windows 8.3, impedindo que uma seleção humana `OFF` volte
+  imediatamente ao fallback `GOVERN`; README e guia de perfis foram atualizados em PT-BR/EN.
+
 ## [0.80.1] — 2026-08-24
 
 ### Fixed

--- a/README.en.md
+++ b/README.en.md
@@ -161,6 +161,9 @@ paths are also supported. Hooks search upward from the agent's `cwd`, so nested 
 the nearest binding. The vault carries the same identity in `.brain/PROJECT.json`; a mismatch
 is rejected before any session is written. If no binding exists, hooks fail closed and never
 create the historical `~/wendkeep-vault` fallback.
+In linked worktrees, `profile use` and `profile status` resolve the main worktree's canonical
+binding through the shared Git registry; the persistent selection applies project-wide without
+rewriting the current worktree's versioned `.wendkeep.json`.
 
 `OBSIDIAN_VAULT_PATH` remains only as legacy/manual CLI compatibility. It is not used to
 route automatic Codex or Claude hooks and a project-local binding overrides an inherited

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ relativos, como `.NutriGymBrain`, partem da raiz do projeto; caminhos absolutos 
 aceitos. Os hooks procuram o vínculo mais próximo subindo a partir do `cwd`. O vault guarda a
 mesma identidade em `.brain/PROJECT.json`, e uma divergência bloqueia a escrita. Sem vínculo,
 os hooks falham de modo seguro e nunca criam o antigo fallback `~/wendkeep-vault`.
+Em worktrees vinculadas, `profile use` e `profile status` resolvem o binding canônico da worktree
+principal pelo registry Git compartilhado; a seleção persistente vale para todo o projeto sem
+reescrever o `.wendkeep.json` versionado da worktree atual.
 
 `OBSIDIAN_VAULT_PATH` permanece somente como compatibilidade legada para comandos manuais.
 Ele não roteia hooks automáticos do Codex ou Claude, e o vínculo local prevalece sobre uma

--- a/docs/en/commands/operating-profiles.md
+++ b/docs/en/commands/operating-profiles.md
@@ -138,6 +138,10 @@ ownership to the native LLM harness.
   missing, ambiguous, or stale context fails closed without a partial mutation.
 - `.wendkeep.json` stays on `schemaVersion: 1`; the additive field is, for example,
   `"harness": { "profile": "GOVERN" }`. A legacy binding without it also resolves to `GOVERN`.
+- In a linked worktree, `profile use` and `profile status` use the main worktree's canonical
+  binding discovered through the shared Git registry. The selection is persisted once for the
+  project and the linked worktree's versioned `.wendkeep.json` remains unchanged, including on
+  Windows when long paths and 8.3 aliases identify the same Vault.
 - A corrupt binding never means `OFF`. When the payload or legacy integration identifies one
   unambiguous Vault, Keep Core remains active under `GOVERN` and the hook exposes a diagnostic;
   mutation guards fail closed until the binding is repaired. Invalid local configuration, a

--- a/docs/pt-BR/commands/operating-profiles.md
+++ b/docs/pt-BR/commands/operating-profiles.md
@@ -139,6 +139,10 @@ harness nativo da LLM.
   ausente, ambíguo ou stale falha fechado sem mutação parcial.
 - `.wendkeep.json` continua em `schemaVersion: 1`; o campo aditivo usa, por exemplo,
   `"harness": { "profile": "GOVERN" }`. Binding legado sem o campo também resolve `GOVERN`.
+- Em worktree vinculada, `profile use` e `profile status` usam o binding canônico da worktree
+  principal descoberto pelo registry Git compartilhado. A seleção é persistida uma vez para o
+  projeto e o `.wendkeep.json` versionado da worktree vinculada permanece intacto, inclusive no
+  Windows quando caminhos longos e aliases 8.3 identificam o mesmo Vault.
 - Binding corrompido nunca equivale a `OFF`. Quando o payload ou a integração legada identifica
   um Vault inequívoco, o Keep Core continua ativo sob `GOVERN` e o hook expõe um diagnóstico;
   guards de mutação falham fechados até o binding ser reparado. Configuração local inválida,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.80.1",
+  "version": "0.80.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.80.1",
+      "version": "0.80.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.80.1",
+  "version": "0.80.2",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [

--- a/src/profile.mjs
+++ b/src/profile.mjs
@@ -13,6 +13,7 @@ import {
   setSessionTaskOperatingProfile,
 } from '../hooks/operating-profile-task-store.mjs';
 import { resolveCommandActiveContext } from './active-context-runtime.mjs';
+import { realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { findProjectBinding, resolveProjectVault, updateProjectBinding } from './project-vault.mjs';
 
@@ -77,7 +78,11 @@ function validateArgv(argv) {
 }
 
 function canonicalPath(value) {
-  const path = resolve(value).replaceAll('\\', '/');
+  const absolute = resolve(value);
+  let canonical = absolute;
+  try { canonical = realpathSync.native(absolute); }
+  catch { /* Preserve comparison support for valid paths that do not exist yet. */ }
+  const path = canonical.replaceAll('\\', '/');
   return process.platform === 'win32' ? path.toLowerCase() : path;
 }
 
@@ -114,8 +119,16 @@ function context(argv) {
   catch (error) {
     if (!explicitVault) throw error;
   }
-  const matchingBinding = binding && canonicalPath(binding.base) === canonicalPath(resolved.base) ? binding : null;
-  const projectConfig = resolved.config || matchingBinding?.config || {};
+  let canonicalBinding = null;
+  if (resolved.source === 'worktree-registry' && resolved.projectRoot) {
+    canonicalBinding = findProjectBinding(resolved.projectRoot);
+  }
+  const candidateBinding = canonicalBinding || binding;
+  const matchingBinding = candidateBinding
+    && canonicalPath(candidateBinding.base) === canonicalPath(resolved.base)
+    ? candidateBinding
+    : null;
+  const projectConfig = matchingBinding?.config || resolved.config || {};
   return {
     resolved: {
       ...resolved,

--- a/tests/profile-cli.test.mjs
+++ b/tests/profile-cli.test.mjs
@@ -6,8 +6,12 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { bindProjectVault } from '../src/project-vault.mjs';
+import { bindProjectVault, resolveProjectVault } from '../src/project-vault.mjs';
 import { setSessionOperatingProfile } from '../src/profile.mjs';
+import {
+  discoverWorktreeRepository,
+  ensureWorktreeMetadata,
+} from '../packages/vault/src/worktree-metadata.mjs';
 
 const BIN = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'wendkeep.mjs');
 
@@ -58,6 +62,37 @@ function run(project, ...args) {
   });
 }
 
+function git(cwd, ...args) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  assert.equal(result.status, 0, `git ${args.join(' ')}\n${result.stderr}`);
+  return result;
+}
+
+function linkedWorktreeFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'wk-profile-worktree-'));
+  const main = join(root, 'main');
+  const linked = join(root, 'linked');
+  const vault = join(main, '.WendKeep-vault');
+  mkdirSync(main, { recursive: true });
+  git(main, 'init', '-b', 'main');
+  git(main, 'config', 'user.email', 'tests@wendkeep.invalid');
+  git(main, 'config', 'user.name', 'WendKeep Tests');
+  writeFileSync(join(main, 'tracked.txt'), 'fixture\n');
+  git(main, 'add', 'tracked.txt');
+  git(main, 'commit', '-m', 'initial');
+  bindProjectVault({ projectRoot: main, vaultPath: vault });
+  git(main, 'add', '.wendkeep.json');
+  git(main, 'commit', '-m', 'bind project');
+  git(main, 'worktree', 'add', linked, '-b', 'wk/linked');
+  const repository = discoverWorktreeRepository({ startDir: main });
+  ensureWorktreeMetadata({
+    repository,
+    projectId: JSON.parse(readFileSync(join(main, '.wendkeep.json'), 'utf8')).projectId,
+    vaultPath: vault,
+  });
+  return { root, main, linked };
+}
+
 test('profile status defaults legacy bindings to GOVERN without rewriting them', () => {
   const f = fixture();
   try {
@@ -89,6 +124,26 @@ test('profile use persists explicit OFF at project scope and status reads it bac
     assert.equal(status.status, 0, status.stderr);
     assert.equal(JSON.parse(status.stdout).profile, 'OFF');
     assert.equal(JSON.parse(status.stdout).source, 'project-binding');
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('profile use from a linked worktree persists and reads the canonical project profile', () => {
+  const f = linkedWorktreeFixture();
+  try {
+    const linkedBindingBefore = readFileSync(join(f.linked, '.wendkeep.json'), 'utf8');
+    assert.equal(resolveProjectVault({ startDir: f.linked }).source, 'worktree-registry');
+    const changed = run(f.linked, 'use', 'OFF', '--json');
+    assert.equal(changed.status, 0, changed.stderr);
+    assert.equal(
+      JSON.parse(readFileSync(join(f.main, '.wendkeep.json'), 'utf8')).harness.profile,
+      'OFF',
+    );
+
+    const status = run(f.linked, 'status', '--json');
+    assert.equal(status.status, 0, status.stderr);
+    assert.equal(JSON.parse(status.stdout).profile, 'OFF', status.stderr);
+    assert.equal(JSON.parse(status.stdout).source, 'project-binding');
+    assert.equal(readFileSync(join(f.linked, '.wendkeep.json'), 'utf8'), linkedBindingBefore);
   } finally { rmSync(f.root, { recursive: true, force: true }); }
 });
 

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -82,11 +82,11 @@ test('extractReleaseNotes: throws when the version is absent', () => {
 });
 
 test('[sensor:release-tests] current release notes are extractable and match the package', () => {
-  assert.equal(PACKAGE.version, '0.80.1');
+  assert.equal(PACKAGE.version, '0.80.2');
   const release = extractReleaseNotes(CHANGELOG, PACKAGE.version);
   assert.equal(release.date, '2026-08-24');
-  assert.match(release.notes, /Bootstrap causal das sessões Codex/i);
-  assert.match(release.notes, /work_session_id/i);
+  assert.match(release.notes, /Perfil persistente em worktrees vinculadas/i);
+  assert.match(release.notes, /aliases Windows 8\.3/i);
   assert.doesNotMatch(release.notes, /019f[0-9a-f-]+/i);
 });
 


### PR DESCRIPTION
## Resumo
- resolve `profile use`/`profile status` pelo binding canônico da worktree principal quando o Vault vem do registry Git compartilhado
- normaliza caminhos reais no Windows, incluindo aliases 8.3, sem reescrever o `.wendkeep.json` da worktree vinculada
- atualiza README e guia de perfis em PT-BR/EN e prepara a versão 0.80.2

## Testes
- RED confirmado: worktree vinculada retornava GOVERN após `profile use OFF`
- `node --test tests/profile-cli.test.mjs`
- conjunto focado de profile/worktree/vault/docs/package/release
- suíte integral `node --test --test-concurrency=2 --test-reporter=dot` (exit 0)
- `npm run check`
- `git diff --check`

## CHANGELOG
- Perfil persistente em worktrees vinculadas agora usa o binding canônico compartilhado e reconhece aliases Windows 8.3.