### PR TITLE
chore: sync project harness to 0.85.0

### DIFF
--- a/.agents/skills/example-skill/.wendkeep-meta.json
+++ b/.agents/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.75.3",
+  "wendkeepVersion": "0.85.0",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.agents/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.agents/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.75.3",
+  "wendkeepVersion": "0.85.0",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.agents/skills/wk-debugging/.wendkeep-meta.json
+++ b/.agents/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.75.3",
+  "wendkeepVersion": "0.85.0",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.agents/skills/wk-planning/.wendkeep-meta.json
+++ b/.agents/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.75.3",
+  "wendkeepVersion": "0.85.0",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.agents/skills/wk-tdd/.wendkeep-meta.json
+++ b/.agents/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.75.3",
-  "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
+  "wendkeepVersion": "0.85.0",
+  "sourceHash": "ae02dafa66bdcb8092967602ce7aa524ddc3e357a292121b972e5e4739736d4c"
 }

--- a/.agents/skills/wk-verify/.wendkeep-meta.json
+++ b/.agents/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.75.3",
-  "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
+  "wendkeepVersion": "0.85.0",
+  "sourceHash": "e42a0d8feccc684620288b863334753df19730bd8b34ba62678bb0d411adae25"
 }

--- a/.agents/skills/wk-verify/SKILL.md
+++ b/.agents/skills/wk-verify/SKILL.md
@@ -26,7 +26,8 @@ nunca tivesse visto a implementação. Contexto fresco, read-only.
   (isolamento real). Nos outros, entre num contexto limpo e re-derive do spec, não da memória.
 - `ok: false` se algum requisito não tem cobertura que discrimina. Gap não é "quase lá" — é vermelho.
 - Não conserte aqui. Gap vira tarefa de correção na change; re-verifica depois.
-- O gate do `archive` **exige** `verdict.json` com `ok` cobrindo todo `[req:]`. Sem isso, não arquiva.
+- O gate do `archive` **exige** `verdict.json` com `ok` cobrindo todo `[req:]` e copiando
+  `evidenceEnvelopeId` + `evidenceBinding` de `verificacao.json`. Sem isso, não arquiva.
 
 ## Templates (nesta pasta)
 - `spec-reviewer-prompt.md` — cole ao spawnar o subagente verificador (read-only, autor≠verificador).

--- a/.agents/skills/wk-verify/spec-reviewer-prompt.md
+++ b/.agents/skills/wk-verify/spec-reviewer-prompt.md
@@ -19,5 +19,6 @@ Para cada `[req:ID]` da mudança:
 
 Grave `08-Mudanças/<slug>/verdict.json` no formato de `verdict-template.json`. `ok: false` se
 qualquer `[req:]` não tem cobertura que discrimina. Não conserte aqui — gap vira tarefa de
-correção. `tasksHash` e `effectiveSpecHash` vêm do pacote; alterações posteriores deixam o verdict stale.
+correção. `tasksHash`, `effectiveSpecHash`, `evidenceEnvelopeId` e `evidenceBinding` vêm do
+pacote; alterações posteriores deixam o verdict stale e o binding nunca deve ser reconstruído à mão.
 ---

--- a/.agents/skills/wk-verify/verdict-template.json
+++ b/.agents/skills/wk-verify/verdict-template.json
@@ -6,5 +6,7 @@
   ],
   "tasksHash": "<copie de verificacao.json — selo de frescor / copy from verificacao.json — freshness seal>",
   "effectiveSpecHash": "<copie de verificacao.json / copy from verificacao.json>",
+  "evidenceEnvelopeId": "<copie de verificacao.json / copy from verificacao.json>",
+  "evidenceBinding": "<copie o objeto de verificacao.json / copy the object from verificacao.json>",
   "notes": []
 }

--- a/.agents/skills/wk-workflow/.wendkeep-meta.json
+++ b/.agents/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.75.3",
+  "wendkeepVersion": "0.85.0",
   "sourceHash": "89c94dd2c27b980e38ec9637f8168872c3771d83bc867640d2dfb6038bc05519"
 }

--- a/.claude/skills/example-skill/.wendkeep-meta.json
+++ b/.claude/skills/example-skill/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.75.3",
+  "wendkeepVersion": "0.85.0",
   "sourceHash": "e7b979ba4560e68e65534b26d6bb5f550f14e8dd33d9524ad52ccd31d513b4cd"
 }

--- a/.claude/skills/wk-brainstorming/.wendkeep-meta.json
+++ b/.claude/skills/wk-brainstorming/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.75.3",
+  "wendkeepVersion": "0.85.0",
   "sourceHash": "e1482c1f6c0cd7a95c9b30d02e9ffabbb1105cf27c3f01962ae5de30ff58a49e"
 }

--- a/.claude/skills/wk-debugging/.wendkeep-meta.json
+++ b/.claude/skills/wk-debugging/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.75.3",
+  "wendkeepVersion": "0.85.0",
   "sourceHash": "d8e751eba0ef985002519027d0cf151079a344447b255429c4f7fe73ba93c249"
 }

--- a/.claude/skills/wk-planning/.wendkeep-meta.json
+++ b/.claude/skills/wk-planning/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.75.3",
+  "wendkeepVersion": "0.85.0",
   "sourceHash": "35baf0294c979dd73d4c69a9ea65a0fc4187a91e4f2faff2977dde772a6426ae"
 }

--- a/.claude/skills/wk-tdd/.wendkeep-meta.json
+++ b/.claude/skills/wk-tdd/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.75.3",
-  "sourceHash": "8ba106a7e5ef9e5def8cf87552d3233a1bfbbe4a5c231b982c3f1bacb38f2df8"
+  "wendkeepVersion": "0.85.0",
+  "sourceHash": "ae02dafa66bdcb8092967602ce7aa524ddc3e357a292121b972e5e4739736d4c"
 }

--- a/.claude/skills/wk-verify/.wendkeep-meta.json
+++ b/.claude/skills/wk-verify/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.75.3",
-  "sourceHash": "b696def5e6a3da5ea9709b2e794b90c688b797c9042ed5f1b3039f85ee3da813"
+  "wendkeepVersion": "0.85.0",
+  "sourceHash": "e42a0d8feccc684620288b863334753df19730bd8b34ba62678bb0d411adae25"
 }

--- a/.claude/skills/wk-verify/SKILL.md
+++ b/.claude/skills/wk-verify/SKILL.md
@@ -26,7 +26,8 @@ nunca tivesse visto a implementação. Contexto fresco, read-only.
   (isolamento real). Nos outros, entre num contexto limpo e re-derive do spec, não da memória.
 - `ok: false` se algum requisito não tem cobertura que discrimina. Gap não é "quase lá" — é vermelho.
 - Não conserte aqui. Gap vira tarefa de correção na change; re-verifica depois.
-- O gate do `archive` **exige** `verdict.json` com `ok` cobrindo todo `[req:]`. Sem isso, não arquiva.
+- O gate do `archive` **exige** `verdict.json` com `ok` cobrindo todo `[req:]` e copiando
+  `evidenceEnvelopeId` + `evidenceBinding` de `verificacao.json`. Sem isso, não arquiva.
 
 ## Templates (nesta pasta)
 - `spec-reviewer-prompt.md` — cole ao spawnar o subagente verificador (read-only, autor≠verificador).

--- a/.claude/skills/wk-verify/spec-reviewer-prompt.md
+++ b/.claude/skills/wk-verify/spec-reviewer-prompt.md
@@ -19,5 +19,6 @@ Para cada `[req:ID]` da mudança:
 
 Grave `08-Mudanças/<slug>/verdict.json` no formato de `verdict-template.json`. `ok: false` se
 qualquer `[req:]` não tem cobertura que discrimina. Não conserte aqui — gap vira tarefa de
-correção. `tasksHash` e `effectiveSpecHash` vêm do pacote; alterações posteriores deixam o verdict stale.
+correção. `tasksHash`, `effectiveSpecHash`, `evidenceEnvelopeId` e `evidenceBinding` vêm do
+pacote; alterações posteriores deixam o verdict stale e o binding nunca deve ser reconstruído à mão.
 ---

--- a/.claude/skills/wk-verify/verdict-template.json
+++ b/.claude/skills/wk-verify/verdict-template.json
@@ -6,5 +6,7 @@
   ],
   "tasksHash": "<copie de verificacao.json — selo de frescor / copy from verificacao.json — freshness seal>",
   "effectiveSpecHash": "<copie de verificacao.json / copy from verificacao.json>",
+  "evidenceEnvelopeId": "<copie de verificacao.json / copy from verificacao.json>",
+  "evidenceBinding": "<copie o objeto de verificacao.json / copy the object from verificacao.json>",
   "notes": []
 }

--- a/.claude/skills/wk-workflow/.wendkeep-meta.json
+++ b/.claude/skills/wk-workflow/.wendkeep-meta.json
@@ -1,4 +1,4 @@
 {
-  "wendkeepVersion": "0.75.3",
+  "wendkeepVersion": "0.85.0",
   "sourceHash": "89c94dd2c27b980e38ec9637f8168872c3771d83bc867640d2dfb6038bc05519"
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,8 +4,11 @@
       "type": "stdio",
       "command": "npx",
       "args": [
-        "-y",
-        "@bitbonsai/mcpvault@latest",
+        "--no-install",
+        "wendkeep",
+        "mcp",
+        "serve",
+        "--vault",
         "C:\\GitHub\\WendKeep\\.WendKeep-vault"
       ]
     }

--- a/.wendkeep.json
+++ b/.wendkeep.json
@@ -1,5 +1,10 @@
 {
   "schemaVersion": 1,
   "projectId": "8f116430-1dd7-4af3-a393-5e5786cfa24e",
-  "vault": ".WendKeep-vault"
+  "vault": ".WendKeep-vault",
+  "harness": {
+    "profile": "OFF",
+    "profileSource": "explicit-cli",
+    "profileUpdatedAt": "2026-08-25T01:21:02.332Z"
+  }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- wendkeep:skills:start -->
-<!-- wendkeep-version: 0.75.3; skills-sha256: 416206a455a3834f8d025f7a2827796b6a0e9c2b3f45cb45adb110a06cea0eee -->
+<!-- wendkeep-version: 0.85.0; skills-sha256: f1bd4bcb21c0f6f990855c1b64e51daa566e31e9fcb379c6a4b10c2cea0598a7 -->
 ## wendkeep — Keep Core & operating profiles
 
 This project uses the [wendkeep](https://github.com/rogersialves/wendkeep) harness. **Keep Core is always active**


### PR DESCRIPTION
## Resumo
- sincroniza AGENTS.md e skills gerenciadas para WendKeep 0.85.0
- troca o MCP legado pelo servidor nativo wendkeep-vault
- preserva o perfil persistente OFF no binding do projeto
- mantém o checkout de desenvolvimento sem depender do próprio pacote publicado

## Validação
- npm run check
- node --test tests/release-provenance.test.mjs (11/11)
- node --test --test-concurrency=1 tests/worktree-cleanup.test.mjs
- git diff --check

## Escopo
- sem bump de versão
- sem publicação NPM
- package.json e package-lock.json não fazem parte do PR