### PR TITLE
fix: align release provenance after project sync (0.85.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to **wendkeep** are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.85.1] — 2026-08-25
+
+### Fixed
+
+- **Proveniência da árvore publicada após o sync do próprio projeto.** O checkout de
+  desenvolvimento permanece sem depender do pacote `wendkeep` publicado, enquanto o bump patch
+  alinha `package.json`, lockfile, tag e automação de Release à árvore integrada pelo PR #109.
+
+### Changed
+
+- **Harness do repositório sincronizado com 0.85.0.** `AGENTS.md` e as skills gerenciadas passam
+  a refletir o contrato atual, incluindo o binding completo do Evidence Envelope no verdict; o
+  MCP do projeto usa o servidor nativo e o perfil persistente continua explicitamente `OFF`.
+
 ## [0.85.0] — 2026-08-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wendkeep",
-  "version": "0.85.0",
+  "version": "0.85.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wendkeep",
-      "version": "0.85.0",
+      "version": "0.85.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendkeep",
-  "version": "0.85.0",
+  "version": "0.85.1",
   "description": "Vault-first persistent memory for AI coding agents, with an optional profile-aware governance runtime: OFF, FLOW, GUIDE, GOVERN, or ASSURE. Local-first and agent-agnostic (Claude Code, Codex, Cursor…).",
   "type": "module",
   "workspaces": [

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -82,11 +82,11 @@ test('extractReleaseNotes: throws when the version is absent', () => {
 });
 
 test('[sensor:release-tests] current release notes are extractable and match the package', () => {
-  assert.equal(PACKAGE.version, '0.85.0');
+  assert.equal(PACKAGE.version, '0.85.1');
   const release = extractReleaseNotes(CHANGELOG, PACKAGE.version);
   assert.equal(release.date, '2026-08-25');
-  assert.match(release.notes, /Matriz versionada de capacidades dos hosts/i);
-  assert.match(release.notes, /requires_host_capabilities/i);
+  assert.match(release.notes, /Proveniência da árvore publicada após o sync do próprio projeto/i);
+  assert.match(release.notes, /perfil persistente continua explicitamente `OFF`/i);
   assert.doesNotMatch(release.notes, /019f[0-9a-f-]+/i);
 });
 


### PR DESCRIPTION
## Resumo

- corrige a proveniência de release após o sync do próprio checkout
- eleva a versão para 0.85.1 sem reintroduzir self-dependency
- registra no CHANGELOG o sync do harness 0.85.0 e mantém o perfil persistente OFF
- atualiza o teste das notas da versão corrente

## Validação

- npm run check
- node --test tests/release-provenance.test.mjs tests/release-changelog.test.mjs (65/65)
- npm test (2012 pass, 0 fail, 5 skip)
- node scripts/release-provenance.mjs --json