### PR TITLE
feat: adicionar FTS local com fallback lexical bounded (#82)

### DIFF
--- a/hooks/evidence-context.mjs
+++ b/hooks/evidence-context.mjs
@@ -2,7 +2,13 @@
 // UserPromptSubmit: bounded, read-only retrieval from the local evidence index.
 import { pathToFileURL } from 'node:url';
 import { readHookInput, readSessionRegistry, writeHookOutput } from './obsidian-common.mjs';
-import { loadEvidenceIndex, recallEvidence, renderEvidenceContext } from './evidence-recall.mjs';
+import {
+  EVIDENCE_SEARCH_MAX_CANDIDATES,
+  loadEvidenceIndex,
+  recallEvidence,
+  renderEvidenceContext,
+  searchEvidenceCandidates,
+} from './evidence-recall.mjs';
 import { sanitizeMemoryText } from './memory-schema.mjs';
 import { resolveHookOperatingProfile } from './operating-profile-runtime.mjs';
 import {
@@ -11,16 +17,44 @@ import {
 } from './active-context-handoff-evidence.mjs';
 import { isBootstrapPrompt } from '../packages/integrations/src/prompt-content.mjs';
 
+function scopedRows(rows, activeContext, registry) {
+  return scopeEvidenceRows(rows, { activeContext, registry });
+}
+
+function indexedScopedEvidence(vaultBase, query, topK, activeContext, registry) {
+  const initialLimit = Math.min(
+    EVIDENCE_SEARCH_MAX_CANDIDATES,
+    Math.max(512, Number(topK || 0) * 64),
+  );
+  const first = searchEvidenceCandidates(vaultBase, query, {
+    candidateLimit: initialLimit,
+  });
+  let scoped = scopedRows(first.rows, activeContext, registry);
+  if (scoped.length >= topK || !first.has_more
+      || initialLimit >= EVIDENCE_SEARCH_MAX_CANDIDATES) return scoped;
+  const expanded = searchEvidenceCandidates(vaultBase, query, {
+    candidateLimit: EVIDENCE_SEARCH_MAX_CANDIDATES,
+  });
+  scoped = scopedRows(expanded.rows, activeContext, registry);
+  return scoped;
+}
+
 export function buildPromptEvidenceContext(vaultBase, prompt, {
   topK = 3, maxBytes = 3072, rows = null, activeContext = null, registry = null,
 } = {}) {
   const query = sanitizeMemoryText(String(prompt || '')).trim();
   if (!query || isBootstrapPrompt(query)) return '';
-  const evidence = rows || loadEvidenceIndex(vaultBase);
-  const scoped = scopeEvidenceRows(evidence, {
-    activeContext,
-    registry: registry || readSessionRegistry(vaultBase),
-  });
+  const effectiveRegistry = registry || readSessionRegistry(vaultBase);
+  let scoped;
+  if (rows) {
+    scoped = scopedRows(rows, activeContext, effectiveRegistry);
+  } else {
+    try {
+      scoped = indexedScopedEvidence(vaultBase, query, topK, activeContext, effectiveRegistry);
+    } catch {
+      scoped = scopedRows(loadEvidenceIndex(vaultBase), activeContext, effectiveRegistry);
+    }
+  }
   if (!scoped.length) return '';
   return sanitizeMemoryText(renderEvidenceContext(
     recallEvidence(scoped, query, { topK }),

--- a/hooks/evidence-recall.mjs
+++ b/hooks/evidence-recall.mjs
@@ -1,5 +1,6 @@
 export * from '../packages/vault/src/evidence-recall.mjs';
 export * from '../packages/vault/src/evidence-recall-page.mjs';
+export * from '../packages/vault/src/evidence-search-index.mjs';
 export {
   EVIDENCE_INDEX_STATE_FILE,
   EVIDENCE_INDEX_STATE_VERSION,

--- a/hooks/evidence-recall.mjs
+++ b/hooks/evidence-recall.mjs
@@ -1,4 +1,5 @@
 export * from '../packages/vault/src/evidence-recall.mjs';
+export * from '../packages/vault/src/evidence-recall-page.mjs';
 export {
   EVIDENCE_INDEX_STATE_FILE,
   EVIDENCE_INDEX_STATE_VERSION,

--- a/packages/vault/src/evidence-recall-page.mjs
+++ b/packages/vault/src/evidence-recall-page.mjs
@@ -1,0 +1,381 @@
+import { createHash } from 'node:crypto';
+import { normalizeRecallText, recallEvidence } from './evidence-recall.mjs';
+
+export const EVIDENCE_RECALL_CURSOR_VERSION = 1;
+export const EVIDENCE_RECALL_DEFAULT_LIMIT = 5;
+export const EVIDENCE_RECALL_MAX_LIMIT = 100;
+export const EVIDENCE_RECALL_DEFAULT_MAX_BYTES = 64 * 1024;
+export const EVIDENCE_RECALL_MAX_BYTES = 16 * 1024 * 1024;
+
+const CURSOR_MAX_CHARS = 8 * 1024;
+const HASH_PATTERN = /^[0-9a-f]{64}$/;
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+const EXACT_FILTER_FIELDS = [
+  'authority',
+  'validity',
+  'entity_type',
+  'project_id',
+  'change_slug',
+  'session_id',
+  'work_session_id',
+  'logical_path',
+];
+const FILTER_FIELDS = new Set([...EXACT_FILTER_FIELDS, 'logical_path_prefix']);
+
+export class EvidenceRecallCursorError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'EvidenceRecallCursorError';
+    this.code = 'EVIDENCE_RECALL_CURSOR_INVALID';
+  }
+}
+
+export class EvidenceRecallBudgetError extends Error {
+  constructor(message, { requiredBytes = null, maxBytes = null } = {}) {
+    super(message);
+    this.name = 'EvidenceRecallBudgetError';
+    this.code = 'EVIDENCE_RECALL_BUDGET_TOO_SMALL';
+    this.required_bytes = requiredBytes;
+    this.max_bytes = maxBytes;
+  }
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map((item) => canonicalize(item));
+  if (!value || typeof value !== 'object') return value;
+  const out = {};
+  for (const key of Object.keys(value).sort()) {
+    if (value[key] !== undefined) out[key] = canonicalize(value[key]);
+  }
+  return out;
+}
+
+function stableJson(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+function compareText(left, right) {
+  const a = String(left ?? '');
+  const b = String(right ?? '');
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function sha256(value) {
+  return createHash('sha256').update(String(value ?? '')).digest('hex');
+}
+
+function normalizeStringSet(value, field) {
+  if (value === undefined || value === null || value === '') return [];
+  const values = Array.isArray(value) ? value : [value];
+  const normalized = [];
+  for (const item of values) {
+    if (typeof item !== 'string') {
+      throw new TypeError(`evidence recall filter ${field} must be a string or string array`);
+    }
+    const text = item.trim();
+    if (text) normalized.push(text);
+  }
+  return [...new Set(normalized)].sort(compareText);
+}
+
+export function normalizeEvidenceRecallFilters(filters = {}) {
+  if (filters === undefined || filters === null) return {};
+  if (typeof filters !== 'object' || Array.isArray(filters)) {
+    throw new TypeError('evidence recall filters must be an object');
+  }
+  for (const field of Object.keys(filters)) {
+    if (!FILTER_FIELDS.has(field)) {
+      throw new TypeError(`unsupported evidence recall filter: ${field}`);
+    }
+  }
+  const normalized = {};
+  for (const field of EXACT_FILTER_FIELDS) {
+    const values = normalizeStringSet(filters[field], field);
+    if (values.length) normalized[field] = values;
+  }
+  if (normalized.logical_path) {
+    normalized.logical_path = [...new Set(normalized.logical_path
+      .map((path) => path.replaceAll('\\', '/')))].sort(compareText);
+  }
+  const prefixes = [...new Set(
+    normalizeStringSet(filters.logical_path_prefix, 'logical_path_prefix')
+      .map((prefix) => prefix.replaceAll('\\', '/')),
+  )].sort(compareText);
+  if (prefixes.length) normalized.logical_path_prefix = prefixes;
+  return normalized;
+}
+
+export function filterEvidenceRecallRows(rows, filters = {}) {
+  const normalized = normalizeEvidenceRecallFilters(filters);
+  const docs = Array.isArray(rows) ? rows : [];
+  return docs.filter((row) => {
+    for (const field of EXACT_FILTER_FIELDS) {
+      const expected = normalized[field];
+      if (expected?.length && !expected.includes(String(row?.[field] ?? ''))) return false;
+    }
+    const prefixes = normalized.logical_path_prefix;
+    if (prefixes?.length) {
+      const path = String(row?.logical_path ?? '').replaceAll('\\', '/');
+      if (!prefixes.some((prefix) => path.startsWith(prefix))) return false;
+    }
+    return true;
+  });
+}
+
+function indexDescriptor(row) {
+  return {
+    index_version: row?.index_version ?? null,
+    project_id: String(row?.project_id ?? ''),
+    logical_path: String(row?.logical_path ?? ''),
+    title: String(row?.title ?? ''),
+    heading: String(row?.heading ?? ''),
+    change_slug: String(row?.change_slug ?? ''),
+    session_id: String(row?.session_id ?? ''),
+    work_session_id: String(row?.work_session_id ?? ''),
+    observed_at: String(row?.observed_at ?? ''),
+    chunk_id: String(row?.chunk_id ?? ''),
+    entity_type: String(row?.entity_type ?? ''),
+    authority: String(row?.authority ?? ''),
+    validity: String(row?.validity ?? ''),
+    ordinal: Number(row?.ordinal ?? 0),
+    content_hash: String(row?.content_hash ?? ''),
+  };
+}
+
+function canonicalRows(rows) {
+  return (Array.isArray(rows) ? rows : [])
+    .map((row) => ({ row, descriptor: stableJson(indexDescriptor(row)) }))
+    .sort((left, right) => compareText(left.row?.logical_path, right.row?.logical_path)
+      || Number(left.row?.ordinal ?? 0) - Number(right.row?.ordinal ?? 0)
+      || compareText(left.row?.chunk_id, right.row?.chunk_id)
+      || compareText(left.row?.content_hash, right.row?.content_hash)
+      || compareText(left.descriptor, right.descriptor))
+    .map(({ row }) => row);
+}
+
+function evidenceIndexHash(rows) {
+  return sha256(canonicalRows(rows).map((row) => stableJson(indexDescriptor(row))).join('\n'));
+}
+
+function evidenceRequestHash(query, filters) {
+  return sha256(stableJson({
+    query: normalizeRecallText(query),
+    filters,
+  }));
+}
+
+function invalidCursor(message) {
+  throw new EvidenceRecallCursorError(message);
+}
+
+function validateCursorPayload(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    invalidCursor('evidence recall cursor payload must be an object');
+  }
+  const keys = Object.keys(payload).sort();
+  const expectedKeys = ['as_of', 'index_hash', 'offset', 'request_hash', 'version'];
+  if (stableJson(keys) !== stableJson(expectedKeys)) {
+    invalidCursor('evidence recall cursor payload has unexpected fields');
+  }
+  if (payload.version !== EVIDENCE_RECALL_CURSOR_VERSION) {
+    invalidCursor('evidence recall cursor version is unsupported');
+  }
+  if (!HASH_PATTERN.test(String(payload.index_hash || ''))
+      || !HASH_PATTERN.test(String(payload.request_hash || ''))) {
+    invalidCursor('evidence recall cursor hashes are invalid');
+  }
+  if (!Number.isSafeInteger(payload.offset) || payload.offset < 0) {
+    invalidCursor('evidence recall cursor offset is invalid');
+  }
+  if (!Number.isSafeInteger(payload.as_of) || Number.isNaN(new Date(payload.as_of).getTime())) {
+    invalidCursor('evidence recall cursor as_of is invalid');
+  }
+  return payload;
+}
+
+function encodeCursor(payload) {
+  const envelope = {
+    payload,
+    checksum: sha256(stableJson(payload)),
+  };
+  return Buffer.from(stableJson(envelope), 'utf8').toString('base64url');
+}
+
+function decodeCursor(cursor) {
+  if (typeof cursor !== 'string' || !cursor || cursor.length > CURSOR_MAX_CHARS
+      || !BASE64URL_PATTERN.test(cursor)) {
+    invalidCursor('evidence recall cursor encoding is invalid');
+  }
+  let decoded = '';
+  try {
+    const bytes = Buffer.from(cursor, 'base64url');
+    if (bytes.toString('base64url') !== cursor) invalidCursor('evidence recall cursor encoding is not canonical');
+    decoded = bytes.toString('utf8');
+  } catch (error) {
+    if (error instanceof EvidenceRecallCursorError) throw error;
+    invalidCursor('evidence recall cursor encoding is invalid');
+  }
+  let envelope = null;
+  try {
+    envelope = JSON.parse(decoded);
+  } catch {
+    invalidCursor('evidence recall cursor JSON is invalid');
+  }
+  if (!envelope || typeof envelope !== 'object' || Array.isArray(envelope)
+      || stableJson(Object.keys(envelope).sort()) !== stableJson(['checksum', 'payload'])) {
+    invalidCursor('evidence recall cursor envelope is invalid');
+  }
+  const payload = validateCursorPayload(envelope.payload);
+  if (!HASH_PATTERN.test(String(envelope.checksum || ''))
+      || envelope.checksum !== sha256(stableJson(payload))) {
+    invalidCursor('evidence recall cursor checksum is invalid');
+  }
+  return payload;
+}
+
+function normalizeLimit(value) {
+  const limit = Number(value ?? EVIDENCE_RECALL_DEFAULT_LIMIT);
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > EVIDENCE_RECALL_MAX_LIMIT) {
+    throw new RangeError(`evidence recall limit must be an integer between 1 and ${EVIDENCE_RECALL_MAX_LIMIT}`);
+  }
+  return limit;
+}
+
+function normalizeMaxBytes(value) {
+  const maxBytes = Number(value ?? EVIDENCE_RECALL_DEFAULT_MAX_BYTES);
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 2 || maxBytes > EVIDENCE_RECALL_MAX_BYTES) {
+    throw new RangeError(`evidence recall maxBytes must be an integer between 2 and ${EVIDENCE_RECALL_MAX_BYTES}`);
+  }
+  return maxBytes;
+}
+
+function normalizeNow(value) {
+  const now = Number(value ?? Date.now());
+  if (!Number.isSafeInteger(now) || Number.isNaN(new Date(now).getTime())) {
+    throw new RangeError('evidence recall now must be a valid integer timestamp');
+  }
+  return now;
+}
+
+function compactResult(row) {
+  const { content, ...rest } = row || {};
+  return {
+    ...rest,
+    excerpt: String(rest.excerpt ?? ''),
+    content_bytes: Buffer.byteLength(String(content ?? ''), 'utf8'),
+    content_omitted: Object.prototype.hasOwnProperty.call(row || {}, 'content'),
+  };
+}
+
+function serializedBytes(results) {
+  return Buffer.byteLength(JSON.stringify(results), 'utf8');
+}
+
+function withTruncatedExcerpt(candidate, existing, maxBytes) {
+  const characters = Array.from(String(candidate.excerpt ?? ''));
+  if (!characters.length) return null;
+  const makeCandidate = (count) => ({
+    ...candidate,
+    excerpt: count > 0 ? `${characters.slice(0, count).join('')}…` : '',
+    excerpt_truncated: true,
+  });
+  const minimum = makeCandidate(0);
+  if (serializedBytes([...existing, minimum]) > maxBytes) return null;
+  let low = 0;
+  let high = characters.length - 1;
+  let best = minimum;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const current = makeCandidate(middle);
+    if (serializedBytes([...existing, current]) <= maxBytes) {
+      best = current;
+      low = middle + 1;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return best;
+}
+
+export function recallEvidencePage(rows, query, {
+  cursor = null,
+  filters = {},
+  limit: requestedLimit,
+  topK,
+  maxBytes: requestedMaxBytes,
+  now,
+} = {}) {
+  const limit = normalizeLimit(requestedLimit ?? topK);
+  const maxBytes = normalizeMaxBytes(requestedMaxBytes);
+  const normalizedFilters = normalizeEvidenceRecallFilters(filters);
+  const docs = canonicalRows(rows);
+  const indexHash = evidenceIndexHash(docs);
+  const requestHash = evidenceRequestHash(query, normalizedFilters);
+  const cursorPayload = cursor ? decodeCursor(cursor) : null;
+  if (cursorPayload?.index_hash !== undefined && cursorPayload.index_hash !== indexHash) {
+    invalidCursor('evidence recall cursor does not match the current index');
+  }
+  if (cursorPayload?.request_hash !== undefined && cursorPayload.request_hash !== requestHash) {
+    invalidCursor('evidence recall cursor does not match the current query and filters');
+  }
+  const asOf = cursorPayload ? cursorPayload.as_of : normalizeNow(now);
+  const offset = cursorPayload?.offset ?? 0;
+  const scoped = filterEvidenceRecallRows(docs, normalizedFilters);
+  const ranked = recallEvidence(scoped, query, {
+    topK: Math.max(1, scoped.length),
+    now: asOf,
+  });
+  if (offset > ranked.length) {
+    invalidCursor('evidence recall cursor offset exceeds the result set');
+  }
+
+  const results = [];
+  let position = offset;
+  while (position < ranked.length && results.length < limit) {
+    const candidate = compactResult(ranked[position]);
+    if (serializedBytes([...results, candidate]) <= maxBytes) {
+      results.push(candidate);
+      position += 1;
+      continue;
+    }
+    const truncated = withTruncatedExcerpt(candidate, results, maxBytes);
+    if (truncated) {
+      results.push(truncated);
+      position += 1;
+      continue;
+    }
+    if (!results.length) {
+      const requiredBytes = serializedBytes([{
+        ...candidate,
+        excerpt: '',
+        excerpt_truncated: true,
+      }]);
+      throw new EvidenceRecallBudgetError(
+        'evidence recall byte budget cannot fit the next result metadata',
+        { requiredBytes, maxBytes },
+      );
+    }
+    break;
+  }
+
+  const hasMore = position < ranked.length;
+  const nextCursor = hasMore ? encodeCursor({
+    version: EVIDENCE_RECALL_CURSOR_VERSION,
+    index_hash: indexHash,
+    request_hash: requestHash,
+    offset: position,
+    as_of: asOf,
+  }) : null;
+  return {
+    results,
+    next_cursor: nextCursor,
+    has_more: hasMore,
+    matched_count: ranked.length,
+    returned_count: results.length,
+    returned_bytes: serializedBytes(results),
+    offset,
+    limit,
+    max_bytes: maxBytes,
+    as_of: new Date(asOf).toISOString(),
+  };
+}

--- a/packages/vault/src/evidence-search-index.mjs
+++ b/packages/vault/src/evidence-search-index.mjs
@@ -34,6 +34,7 @@ const SHA256 = /^[a-f0-9]{64}$/;
 const ARTIFACT_PATH = /^evidence-search\/[A-Za-z0-9._-]+$/;
 const require = createRequire(import.meta.url);
 const lexicalCache = new Map();
+let sqliteCapability = null;
 
 function brainDir(vaultBase) {
   return join(vaultBase, '.brain');
@@ -331,8 +332,39 @@ function sqliteDatabaseSync() {
   }
 }
 
+function detectSqliteCapability() {
+  if (sqliteCapability) return sqliteCapability;
+  const DatabaseSync = sqliteDatabaseSync();
+  if (!DatabaseSync) {
+    sqliteCapability = {
+      available: false,
+      DatabaseSync: null,
+      reason: 'node-sqlite-unavailable',
+      error_code: 'EVIDENCE_SEARCH_SQLITE_UNAVAILABLE',
+    };
+    return sqliteCapability;
+  }
+
+  let db = null;
+  try {
+    db = new DatabaseSync(':memory:', { open: true });
+    db.exec('CREATE VIRTUAL TABLE evidence_fts_probe USING fts5(content)');
+    sqliteCapability = { available: true, DatabaseSync, reason: '', error_code: '' };
+  } catch {
+    sqliteCapability = {
+      available: false,
+      DatabaseSync,
+      reason: 'fts5-unavailable',
+      error_code: 'EVIDENCE_SEARCH_FTS5_UNAVAILABLE',
+    };
+  } finally {
+    try { db?.close(); } catch { /* capability probe is best effort */ }
+  }
+  return sqliteCapability;
+}
+
 export function evidenceSearchSqliteAvailable() {
-  return Boolean(sqliteDatabaseSync());
+  return detectSqliteCapability().available;
 }
 
 function cleanupSqliteCandidate(vaultBase, path) {
@@ -343,15 +375,18 @@ function cleanupSqliteCandidate(vaultBase, path) {
 }
 
 function buildSqliteArtifact(vaultBase, rows, indexHash, { required = false } = {}) {
-  const DatabaseSync = sqliteDatabaseSync();
-  if (!DatabaseSync) {
+  const capability = detectSqliteCapability();
+  if (!capability.available) {
     if (required) {
-      const error = new Error('node:sqlite is unavailable; evidence FTS requires Node.js 22.13+');
-      error.code = 'EVIDENCE_SEARCH_SQLITE_UNAVAILABLE';
+      const error = new Error(capability.reason === 'node-sqlite-unavailable'
+        ? 'node:sqlite is unavailable; evidence FTS requires a compatible Node.js runtime'
+        : 'the current node:sqlite build does not include FTS5; evidence search will use the lexical backend');
+      error.code = capability.error_code;
       throw error;
     }
-    return { artifact: null, written: false, reason: 'node-sqlite-unavailable' };
+    return { artifact: null, written: false, reason: capability.reason };
   }
+  const { DatabaseSync } = capability;
 
   const candidate = join(searchDir(vaultBase), `.fts-${indexHash.slice(0, 20)}-${randomUUID()}.tmp.sqlite`);
   assertVaultPathSafe(vaultBase, candidate, {

--- a/packages/vault/src/evidence-search-index.mjs
+++ b/packages/vault/src/evidence-search-index.mjs
@@ -1,0 +1,882 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { readFileSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+
+import {
+  EVIDENCE_INDEX_FILE,
+  loadEvidenceIndex,
+  recallEvidence,
+  recallTerms,
+} from './evidence-recall.mjs';
+import {
+  filterEvidenceRecallRows,
+  normalizeEvidenceRecallFilters,
+} from './evidence-recall-page.mjs';
+import { EVIDENCE_INDEX_STATE_FILE } from './evidence-index-store.mjs';
+import {
+  assertVaultPathSafe,
+  mkdirVaultPath,
+  renameVaultPath,
+  unlinkVaultFile,
+  writeVaultFileAtomic,
+} from './vault-path-safety.mjs';
+
+export const EVIDENCE_SEARCH_STATE_FILE = 'EVIDENCE_SEARCH_STATE.json';
+export const EVIDENCE_SEARCH_STATE_VERSION = 1;
+export const EVIDENCE_SEARCH_DEFAULT_CANDIDATES = 512;
+export const EVIDENCE_SEARCH_MAX_CANDIDATES = 4096;
+export const EVIDENCE_SEARCH_DEFAULT_POSTING_BUDGET = 65_536;
+export const EVIDENCE_SEARCH_MAX_POSTING_BUDGET = 1_048_576;
+
+const SEARCH_DIRECTORY = 'evidence-search';
+const SHA256 = /^[a-f0-9]{64}$/;
+const ARTIFACT_PATH = /^evidence-search\/[A-Za-z0-9._-]+$/;
+const require = createRequire(import.meta.url);
+const lexicalCache = new Map();
+
+function brainDir(vaultBase) {
+  return join(vaultBase, '.brain');
+}
+
+function searchDir(vaultBase) {
+  return join(brainDir(vaultBase), SEARCH_DIRECTORY);
+}
+
+function searchStatePath(vaultBase) {
+  return join(brainDir(vaultBase), EVIDENCE_SEARCH_STATE_FILE);
+}
+
+function evidenceIndexPath(vaultBase) {
+  return join(brainDir(vaultBase), EVIDENCE_INDEX_FILE);
+}
+
+function evidenceIndexStatePath(vaultBase) {
+  return join(brainDir(vaultBase), EVIDENCE_INDEX_STATE_FILE);
+}
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function compareText(left, right) {
+  const a = String(left ?? '');
+  const b = String(right ?? '');
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map((item) => canonicalize(item));
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(Object.keys(value).sort(compareText)
+    .filter((key) => value[key] !== undefined)
+    .map((key) => [key, canonicalize(value[key])]));
+}
+
+function stableJson(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+function bigintText(value, fallbackMs = 0) {
+  if (typeof value === 'bigint') return value.toString();
+  return BigInt(Math.max(0, Math.trunc(Number(fallbackMs || 0) * 1_000_000))).toString();
+}
+
+function safeFile(vaultBase, path, label, { allowMissing = true } = {}) {
+  return assertVaultPathSafe(vaultBase, path, {
+    allowMissing,
+    expectedType: 'file',
+    label,
+  });
+}
+
+function fileFingerprint(vaultBase, path, label) {
+  let checked = safeFile(vaultBase, path, label);
+  if (!checked.exists) return null;
+  checked = safeFile(vaultBase, checked.target, label, { allowMissing: false });
+  const stat = statSync(checked.target, { bigint: true });
+  if (!stat.isFile()) return null;
+  return {
+    size: stat.size.toString(),
+    mtime_ns: bigintText(stat.mtimeNs, stat.mtimeMs),
+    ctime_ns: bigintText(stat.ctimeNs, stat.ctimeMs),
+  };
+}
+
+function sameFingerprint(left, right) {
+  if (left === null || right === null) return left === right;
+  return Boolean(left && right)
+    && left.size === right.size
+    && left.mtime_ns === right.mtime_ns
+    && left.ctime_ns === right.ctime_ns;
+}
+
+function readSafeFile(vaultBase, path, label, encoding = 'utf8') {
+  let checked = safeFile(vaultBase, path, label);
+  if (!checked.exists) return null;
+  checked = safeFile(vaultBase, checked.target, label, { allowMissing: false });
+  return encoding === null ? readFileSync(checked.target) : readFileSync(checked.target, encoding);
+}
+
+function validFingerprint(value) {
+  return value === null || (Boolean(value && typeof value === 'object' && !Array.isArray(value))
+    && /^\d+$/.test(String(value.size || ''))
+    && /^\d+$/.test(String(value.mtime_ns || ''))
+    && /^\d+$/.test(String(value.ctime_ns || '')));
+}
+
+function validArtifact(value, kind) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+    && value.kind === kind
+    && ARTIFACT_PATH.test(String(value.path || ''))
+    && SHA256.test(String(value.hash || ''))
+    && validFingerprint(value.fingerprint)
+    && value.fingerprint !== null;
+}
+
+function parseState(raw) {
+  if (raw === null) return null;
+  try {
+    const state = JSON.parse(raw);
+    if (state?.schema_version !== EVIDENCE_SEARCH_STATE_VERSION
+        || !SHA256.test(String(state?.index_hash || ''))
+        || !Number.isSafeInteger(state?.row_count)
+        || state.row_count < 0
+        || !state?.source
+        || !validFingerprint(state.source.index)
+        || state.source.index === null
+        || !validFingerprint(state.source.state)
+        || !validArtifact(state.lexical, 'lexical')
+        || (state.sqlite !== null && !validArtifact(state.sqlite, 'sqlite'))) return null;
+    return state;
+  } catch {
+    return null;
+  }
+}
+
+export function loadEvidenceSearchState(vaultBase) {
+  const raw = readSafeFile(
+    vaultBase,
+    searchStatePath(vaultBase),
+    'estado do índice de busca de evidências',
+  );
+  return parseState(raw);
+}
+
+function currentSource(vaultBase) {
+  return {
+    index: fileFingerprint(vaultBase, evidenceIndexPath(vaultBase), 'autoridade JSONL da busca de evidências'),
+    state: fileFingerprint(vaultBase, evidenceIndexStatePath(vaultBase), 'estado incremental da busca de evidências'),
+  };
+}
+
+function artifactPath(vaultBase, artifact) {
+  return join(brainDir(vaultBase), artifact.path);
+}
+
+function artifactCurrent(vaultBase, artifact) {
+  try {
+    return sameFingerprint(
+      artifact.fingerprint,
+      fileFingerprint(vaultBase, artifactPath(vaultBase, artifact), `artefato ${artifact.kind} da busca`),
+    );
+  } catch {
+    return false;
+  }
+}
+
+function stateCurrent(vaultBase, state) {
+  if (!state) return false;
+  const source = currentSource(vaultBase);
+  return sameFingerprint(state.source.index, source.index)
+    && sameFingerprint(state.source.state, source.state)
+    && artifactCurrent(vaultBase, state.lexical)
+    && (state.sqlite === null || artifactCurrent(vaultBase, state.sqlite));
+}
+
+function validEvidenceRow(row) {
+  return Boolean(row && typeof row === 'object' && !Array.isArray(row))
+    && typeof row.chunk_id === 'string'
+    && row.chunk_id.length > 0
+    && typeof row.logical_path === 'string'
+    && Number.isSafeInteger(row.ordinal)
+    && row.ordinal >= 0
+    && typeof row.content === 'string'
+    && SHA256.test(String(row.content_hash || ''))
+    && sha256(row.content) === row.content_hash;
+}
+
+function canonicalRows(rows) {
+  if (!Array.isArray(rows)) throw new TypeError('evidence search rows must be an array');
+  if (!rows.every(validEvidenceRow)) throw new TypeError('evidence search rows contain an invalid chunk');
+  const sorted = [...rows].sort((left, right) => compareText(left.logical_path, right.logical_path)
+    || left.ordinal - right.ordinal
+    || compareText(left.chunk_id, right.chunk_id)
+    || compareText(left.content_hash, right.content_hash));
+  const ids = new Set();
+  for (const row of sorted) {
+    if (ids.has(row.chunk_id)) throw new TypeError(`duplicate evidence chunk id: ${row.chunk_id}`);
+    ids.add(row.chunk_id);
+  }
+  return sorted;
+}
+
+export function evidenceSearchIndexHash(rows) {
+  return sha256(canonicalRows(rows).map((row) => stableJson(row)).join('\n'));
+}
+
+function weightedTerms(row) {
+  const weights = new Map();
+  const add = (value, multiplier) => {
+    const counts = new Map();
+    for (const term of recallTerms(value)) {
+      counts.set(term, Math.min(32, (counts.get(term) || 0) + 1));
+    }
+    for (const [term, count] of counts) {
+      weights.set(term, (weights.get(term) || 0) + count * multiplier);
+    }
+  };
+  add(row.content, 1);
+  add(row.logical_path, 2);
+  add(row.heading, 3);
+  add(row.title, 4);
+  return weights;
+}
+
+function buildLexicalArtifact(rows, indexHash) {
+  const postings = new Map();
+  rows.forEach((row, rowIndex) => {
+    for (const [term, weight] of weightedTerms(row)) {
+      if (!postings.has(term)) postings.set(term, []);
+      postings.get(term).push([rowIndex, weight]);
+    }
+  });
+  const renderedPostings = {};
+  for (const term of [...postings.keys()].sort(compareText)) {
+    renderedPostings[term] = postings.get(term).sort((left, right) => right[1] - left[1]
+      || left[0] - right[0]);
+  }
+  return {
+    schema_version: EVIDENCE_SEARCH_STATE_VERSION,
+    index_hash: indexHash,
+    row_count: rows.length,
+    rows,
+    postings: renderedPostings,
+  };
+}
+
+function validateLexicalArtifact(value, expectedState = null) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)
+      || value.schema_version !== EVIDENCE_SEARCH_STATE_VERSION
+      || !SHA256.test(String(value.index_hash || ''))
+      || !Number.isSafeInteger(value.row_count)
+      || value.row_count < 0
+      || !Array.isArray(value.rows)
+      || value.rows.length !== value.row_count
+      || !value.rows.every(validEvidenceRow)
+      || !value.postings
+      || typeof value.postings !== 'object'
+      || Array.isArray(value.postings)) return false;
+  if (expectedState && (value.index_hash !== expectedState.index_hash
+      || value.row_count !== expectedState.row_count)) return false;
+  for (const [term, entries] of Object.entries(value.postings)) {
+    if (!term || !Array.isArray(entries)) return false;
+    for (const entry of entries) {
+      if (!Array.isArray(entry) || entry.length !== 2
+          || !Number.isSafeInteger(entry[0]) || entry[0] < 0 || entry[0] >= value.row_count
+          || !Number.isFinite(entry[1]) || entry[1] <= 0) return false;
+    }
+  }
+  return evidenceSearchIndexHash(value.rows) === value.index_hash;
+}
+
+function lexicalFileContent(artifact) {
+  return `${JSON.stringify(artifact)}\n`;
+}
+
+function writeContentAddressedText(vaultBase, prefix, indexHash, content) {
+  const contentHash = sha256(content);
+  const relativePath = `${SEARCH_DIRECTORY}/${prefix}-${indexHash.slice(0, 20)}-${contentHash.slice(0, 20)}.json`;
+  const path = join(brainDir(vaultBase), relativePath);
+  const current = readSafeFile(vaultBase, path, `artefato ${prefix} da busca`);
+  let written = false;
+  if (current === null) {
+    writeVaultFileAtomic(vaultBase, path, content, 'utf8', {
+      label: `artefato imutável ${prefix} da busca`,
+      scopeRoot: searchDir(vaultBase),
+    });
+    written = true;
+  } else if (sha256(current) !== contentHash || current !== content) {
+    const error = new Error(`content-addressed evidence search artifact diverges: ${relativePath}`);
+    error.code = 'EVIDENCE_SEARCH_ARTIFACT_DIVERGED';
+    throw error;
+  }
+  return {
+    artifact: {
+      kind: 'lexical',
+      path: relativePath,
+      hash: contentHash,
+      fingerprint: fileFingerprint(vaultBase, path, `artefato ${prefix} da busca`),
+    },
+    written,
+  };
+}
+
+function sqliteDatabaseSync() {
+  try {
+    const module = require('node:sqlite');
+    return typeof module?.DatabaseSync === 'function' ? module.DatabaseSync : null;
+  } catch {
+    return null;
+  }
+}
+
+export function evidenceSearchSqliteAvailable() {
+  return Boolean(sqliteDatabaseSync());
+}
+
+function cleanupSqliteCandidate(vaultBase, path) {
+  try { unlinkVaultFile(vaultBase, `${path}-journal`, { label: 'journal temporário FTS' }); } catch { /* best effort */ }
+  try { unlinkVaultFile(vaultBase, `${path}-wal`, { label: 'WAL temporário FTS' }); } catch { /* best effort */ }
+  try { unlinkVaultFile(vaultBase, `${path}-shm`, { label: 'SHM temporário FTS' }); } catch { /* best effort */ }
+  try { unlinkVaultFile(vaultBase, path, { label: 'SQLite temporário FTS' }); } catch { /* best effort */ }
+}
+
+function buildSqliteArtifact(vaultBase, rows, indexHash, { required = false } = {}) {
+  const DatabaseSync = sqliteDatabaseSync();
+  if (!DatabaseSync) {
+    if (required) {
+      const error = new Error('node:sqlite is unavailable; evidence FTS requires Node.js 22.13+');
+      error.code = 'EVIDENCE_SEARCH_SQLITE_UNAVAILABLE';
+      throw error;
+    }
+    return { artifact: null, written: false, reason: 'node-sqlite-unavailable' };
+  }
+
+  const candidate = join(searchDir(vaultBase), `.fts-${indexHash.slice(0, 20)}-${randomUUID()}.tmp.sqlite`);
+  assertVaultPathSafe(vaultBase, candidate, {
+    expectedType: 'file',
+    mustNotExist: true,
+    label: 'candidate SQLite FTS',
+  });
+  let db = null;
+  try {
+    db = new DatabaseSync(candidate, { open: true });
+    db.exec(`
+      PRAGMA journal_mode = OFF;
+      PRAGMA synchronous = OFF;
+      PRAGMA temp_store = MEMORY;
+      CREATE TABLE evidence_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      ) WITHOUT ROWID;
+      CREATE TABLE evidence_rows (
+        chunk_id TEXT PRIMARY KEY,
+        logical_path TEXT NOT NULL,
+        ordinal INTEGER NOT NULL,
+        authority TEXT NOT NULL,
+        validity TEXT NOT NULL,
+        entity_type TEXT NOT NULL,
+        project_id TEXT NOT NULL,
+        change_slug TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        work_session_id TEXT NOT NULL,
+        row_json TEXT NOT NULL
+      ) WITHOUT ROWID;
+      CREATE VIRTUAL TABLE evidence_fts USING fts5(
+        chunk_id UNINDEXED,
+        title,
+        heading,
+        logical_path,
+        content,
+        tokenize = 'unicode61 remove_diacritics 2'
+      );
+    `);
+    const insertMeta = db.prepare('INSERT INTO evidence_meta(key, value) VALUES (?, ?)');
+    const insertRow = db.prepare(`
+      INSERT INTO evidence_rows(
+        chunk_id, logical_path, ordinal, authority, validity, entity_type, project_id,
+        change_slug, session_id, work_session_id, row_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    const insertFts = db.prepare(`
+      INSERT INTO evidence_fts(chunk_id, title, heading, logical_path, content)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+    db.exec('BEGIN IMMEDIATE');
+    try {
+      insertMeta.run('schema_version', String(EVIDENCE_SEARCH_STATE_VERSION));
+      insertMeta.run('index_hash', indexHash);
+      insertMeta.run('row_count', String(rows.length));
+      for (const row of rows) {
+        insertRow.run(
+          row.chunk_id,
+          row.logical_path,
+          row.ordinal,
+          String(row.authority || ''),
+          String(row.validity || ''),
+          String(row.entity_type || ''),
+          String(row.project_id || ''),
+          String(row.change_slug || ''),
+          String(row.session_id || ''),
+          String(row.work_session_id || ''),
+          JSON.stringify(row),
+        );
+        insertFts.run(
+          row.chunk_id,
+          String(row.title || ''),
+          String(row.heading || ''),
+          row.logical_path,
+          row.content,
+        );
+      }
+      db.exec('COMMIT');
+    } catch (error) {
+      try { db.exec('ROLLBACK'); } catch { /* ignore */ }
+      throw error;
+    }
+    db.close();
+    db = null;
+
+    const checkedCandidate = safeFile(vaultBase, candidate, 'candidate SQLite FTS', { allowMissing: false });
+    const bytes = readFileSync(checkedCandidate.target);
+    const contentHash = sha256(bytes);
+    const relativePath = `${SEARCH_DIRECTORY}/fts-${indexHash.slice(0, 20)}-${contentHash.slice(0, 20)}.sqlite`;
+    const finalPath = join(brainDir(vaultBase), relativePath);
+    const existing = readSafeFile(vaultBase, finalPath, 'artefato SQLite FTS', null);
+    let written = false;
+    if (existing === null) {
+      try {
+        renameVaultPath(vaultBase, candidate, finalPath, {
+          sourceType: 'file',
+          label: 'publicação do SQLite FTS',
+        });
+        written = true;
+      } catch (error) {
+        const raced = readSafeFile(vaultBase, finalPath, 'artefato SQLite FTS concorrente', null);
+        if (raced === null || sha256(raced) !== contentHash) throw error;
+        cleanupSqliteCandidate(vaultBase, candidate);
+      }
+    } else {
+      if (sha256(existing) !== contentHash) {
+        const error = new Error(`content-addressed SQLite artifact diverges: ${relativePath}`);
+        error.code = 'EVIDENCE_SEARCH_ARTIFACT_DIVERGED';
+        throw error;
+      }
+      cleanupSqliteCandidate(vaultBase, candidate);
+    }
+    return {
+      artifact: {
+        kind: 'sqlite',
+        path: relativePath,
+        hash: contentHash,
+        fingerprint: fileFingerprint(vaultBase, finalPath, 'artefato SQLite FTS'),
+      },
+      written,
+      reason: '',
+    };
+  } catch (error) {
+    try { db?.close(); } catch { /* ignore */ }
+    cleanupSqliteCandidate(vaultBase, candidate);
+    if (required) throw error;
+    return { artifact: null, written: false, reason: error?.code || 'sqlite-build-failed' };
+  }
+}
+
+function normalizeSqliteMode(value) {
+  const mode = String(value ?? 'auto').trim().toLowerCase();
+  if (!['auto', 'off', 'required'].includes(mode)) {
+    throw new TypeError('evidence search sqlite mode must be auto, off, or required');
+  }
+  return mode;
+}
+
+function renderState({ indexHash, rowCount, source, lexical, sqlite }) {
+  return `${JSON.stringify({
+    schema_version: EVIDENCE_SEARCH_STATE_VERSION,
+    index_hash: indexHash,
+    row_count: rowCount,
+    source,
+    lexical,
+    sqlite,
+  }, null, 2)}\n`;
+}
+
+export function refreshEvidenceSearchIndex(vaultBase, rows, {
+  force = false,
+  sqlite = 'auto',
+} = {}) {
+  const sqliteMode = normalizeSqliteMode(sqlite);
+  mkdirVaultPath(vaultBase, brainDir(vaultBase), { label: 'raiz .brain da busca de evidências' });
+  mkdirVaultPath(vaultBase, searchDir(vaultBase), { label: 'diretório de artefatos da busca de evidências' });
+  const source = currentSource(vaultBase);
+  if (source.index === null) {
+    const error = new Error('EVIDENCE_INDEX.jsonl is required before building the search index');
+    error.code = 'EVIDENCE_SEARCH_SOURCE_MISSING';
+    throw error;
+  }
+
+  const previous = loadEvidenceSearchState(vaultBase);
+  if (!force && stateCurrent(vaultBase, previous)
+      && (sqliteMode !== 'required' || previous.sqlite !== null)) {
+    return {
+      state: previous,
+      reused: true,
+      lexical_written: false,
+      sqlite_written: false,
+      sqlite_available: previous.sqlite !== null,
+      sqlite_reason: previous.sqlite ? '' : 'not-built',
+    };
+  }
+
+  const canonical = canonicalRows(rows);
+  const indexHash = sha256(canonical.map((row) => stableJson(row)).join('\n'));
+  const lexicalValue = buildLexicalArtifact(canonical, indexHash);
+  const lexicalContent = lexicalFileContent(lexicalValue);
+  const lexicalResult = writeContentAddressedText(
+    vaultBase,
+    'lexical',
+    indexHash,
+    lexicalContent,
+  );
+  const sqliteResult = sqliteMode === 'off'
+    ? { artifact: null, written: false, reason: 'disabled' }
+    : buildSqliteArtifact(vaultBase, canonical, indexHash, { required: sqliteMode === 'required' });
+  const stateContent = renderState({
+    indexHash,
+    rowCount: canonical.length,
+    source,
+    lexical: lexicalResult.artifact,
+    sqlite: sqliteResult.artifact,
+  });
+  const currentState = readSafeFile(vaultBase, searchStatePath(vaultBase), 'estado do índice de busca');
+  const stateWritten = currentState !== stateContent;
+  if (stateWritten) {
+    writeVaultFileAtomic(
+      vaultBase,
+      searchStatePath(vaultBase),
+      stateContent,
+      'utf8',
+      { label: 'estado do índice de busca de evidências' },
+    );
+  }
+  const state = loadEvidenceSearchState(vaultBase);
+  if (!state || !stateCurrent(vaultBase, state)) {
+    const error = new Error('published evidence search state did not validate');
+    error.code = 'EVIDENCE_SEARCH_STATE_INVALID';
+    throw error;
+  }
+  lexicalCache.set(state.lexical.path, lexicalValue);
+  return {
+    state,
+    reused: false,
+    state_written: stateWritten,
+    lexical_written: lexicalResult.written,
+    sqlite_written: sqliteResult.written,
+    sqlite_available: Boolean(sqliteResult.artifact),
+    sqlite_reason: sqliteResult.reason,
+  };
+}
+
+function loadLexical(vaultBase, state) {
+  const cacheKey = `${state.lexical.path}:${state.lexical.fingerprint.mtime_ns}:${state.lexical.fingerprint.size}`;
+  const cached = lexicalCache.get(cacheKey) || lexicalCache.get(state.lexical.path);
+  if (cached && validateLexicalArtifact(cached, state)) return cached;
+  const raw = readSafeFile(vaultBase, artifactPath(vaultBase, state.lexical), 'artefato lexical da busca');
+  if (raw === null || sha256(raw) !== state.lexical.hash) {
+    const error = new Error('evidence lexical search artifact hash mismatch');
+    error.code = 'EVIDENCE_SEARCH_ARTIFACT_DIVERGED';
+    throw error;
+  }
+  let parsed;
+  try { parsed = JSON.parse(raw); } catch {
+    const error = new Error('evidence lexical search artifact is invalid JSON');
+    error.code = 'EVIDENCE_SEARCH_ARTIFACT_INVALID';
+    throw error;
+  }
+  if (!validateLexicalArtifact(parsed, state)) {
+    const error = new Error('evidence lexical search artifact failed validation');
+    error.code = 'EVIDENCE_SEARCH_ARTIFACT_INVALID';
+    throw error;
+  }
+  lexicalCache.set(cacheKey, parsed);
+  return parsed;
+}
+
+function ensureSearchState(vaultBase, { sqlite = 'auto' } = {}) {
+  const state = loadEvidenceSearchState(vaultBase);
+  if (stateCurrent(vaultBase, state)) return { state, rebuilt: false, ephemeral: null };
+  const rows = loadEvidenceIndex(vaultBase);
+  if (!rows.length) return { state: null, rebuilt: false, ephemeral: buildLexicalArtifact([], sha256('')) };
+  try {
+    const refreshed = refreshEvidenceSearchIndex(vaultBase, rows, { force: true, sqlite });
+    return { state: refreshed.state, rebuilt: true, ephemeral: null };
+  } catch (error) {
+    const canonical = canonicalRows(rows);
+    const indexHash = sha256(canonical.map((row) => stableJson(row)).join('\n'));
+    return {
+      state: null,
+      rebuilt: false,
+      ephemeral: buildLexicalArtifact(canonical, indexHash),
+      fallback_reason: error?.code || 'search-index-rebuild-failed',
+    };
+  }
+}
+
+function normalizeCandidateLimit(value) {
+  const limit = Number(value ?? EVIDENCE_SEARCH_DEFAULT_CANDIDATES);
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > EVIDENCE_SEARCH_MAX_CANDIDATES) {
+    throw new RangeError(`evidence search candidateLimit must be between 1 and ${EVIDENCE_SEARCH_MAX_CANDIDATES}`);
+  }
+  return limit;
+}
+
+function normalizePostingBudget(value) {
+  const budget = Number(value ?? EVIDENCE_SEARCH_DEFAULT_POSTING_BUDGET);
+  if (!Number.isSafeInteger(budget) || budget < 1 || budget > EVIDENCE_SEARCH_MAX_POSTING_BUDGET) {
+    throw new RangeError(`evidence search postingBudget must be between 1 and ${EVIDENCE_SEARCH_MAX_POSTING_BUDGET}`);
+  }
+  return budget;
+}
+
+function normalizeBackend(value) {
+  const backend = String(value ?? 'auto').trim().toLowerCase();
+  if (!['auto', 'sqlite', 'lexical'].includes(backend)) {
+    throw new TypeError('evidence search backend must be auto, sqlite, or lexical');
+  }
+  return backend;
+}
+
+function ftsQuery(query) {
+  return [...new Set(recallTerms(query))]
+    .map((term) => `"${term.replaceAll('"', '""')}"`)
+    .join(' OR ');
+}
+
+const SQL_FIELDS = new Map([
+  ['authority', 'authority'],
+  ['validity', 'validity'],
+  ['entity_type', 'entity_type'],
+  ['project_id', 'project_id'],
+  ['change_slug', 'change_slug'],
+  ['session_id', 'session_id'],
+  ['work_session_id', 'work_session_id'],
+  ['logical_path', 'logical_path'],
+]);
+
+function escapeLike(value) {
+  return String(value).replaceAll('\\', '\\\\').replaceAll('%', '\\%').replaceAll('_', '\\_');
+}
+
+function sqlFilterClause(filters) {
+  const clauses = [];
+  const parameters = [];
+  for (const [field, column] of SQL_FIELDS) {
+    const values = filters[field];
+    if (!values?.length) continue;
+    clauses.push(`r.${column} IN (${values.map(() => '?').join(', ')})`);
+    parameters.push(...values);
+  }
+  if (filters.logical_path_prefix?.length) {
+    clauses.push(`(${filters.logical_path_prefix.map(() => "r.logical_path LIKE ? ESCAPE '\\\\'").join(' OR ')})`);
+    parameters.push(...filters.logical_path_prefix.map((prefix) => `${escapeLike(prefix)}%`));
+  }
+  return {
+    sql: clauses.length ? ` AND ${clauses.join(' AND ')}` : '',
+    parameters,
+  };
+}
+
+function searchSqlite(vaultBase, state, query, filters, candidateLimit, postingBudget) {
+  const DatabaseSync = sqliteDatabaseSync();
+  if (!DatabaseSync || !state.sqlite) {
+    const error = new Error('SQLite FTS backend is unavailable');
+    error.code = 'EVIDENCE_SEARCH_SQLITE_UNAVAILABLE';
+    throw error;
+  }
+  const expression = ftsQuery(query);
+  if (!expression) return { rows: [], posting_entries: 0, has_more: false };
+  const path = artifactPath(vaultBase, state.sqlite);
+  safeFile(vaultBase, path, 'artefato SQLite FTS', { allowMissing: false });
+  let db = null;
+  try {
+    db = new DatabaseSync(path, { open: true });
+    db.exec('PRAGMA query_only = ON');
+    const indexHash = db.prepare("SELECT value FROM evidence_meta WHERE key = 'index_hash'").get()?.value;
+    const rowCount = Number(db.prepare("SELECT value FROM evidence_meta WHERE key = 'row_count'").get()?.value);
+    if (indexHash !== state.index_hash || rowCount !== state.row_count) {
+      const error = new Error('SQLite FTS metadata does not match the search state');
+      error.code = 'EVIDENCE_SEARCH_ARTIFACT_DIVERGED';
+      throw error;
+    }
+    const filter = sqlFilterClause(filters);
+    const matches = db.prepare(`
+      SELECT r.row_json,
+             bm25(evidence_fts, 0.0, 4.0, 3.0, 2.0, 1.0) AS fts_rank
+      FROM evidence_fts
+      JOIN evidence_rows r ON r.chunk_id = evidence_fts.chunk_id
+      WHERE evidence_fts MATCH ?${filter.sql}
+      ORDER BY fts_rank ASC, r.logical_path ASC, r.ordinal ASC, r.chunk_id ASC
+      LIMIT ?
+    `).all(expression, ...filter.parameters, postingBudget);
+    const rows = matches.slice(0, candidateLimit).map((match) => JSON.parse(match.row_json));
+    if (!rows.every(validEvidenceRow)) {
+      const error = new Error('SQLite FTS returned an invalid evidence row');
+      error.code = 'EVIDENCE_SEARCH_ARTIFACT_INVALID';
+      throw error;
+    }
+    return {
+      rows,
+      posting_entries: matches.length,
+      has_more: matches.length > candidateLimit || matches.length === postingBudget,
+    };
+  } finally {
+    try { db?.close(); } catch { /* ignore */ }
+  }
+}
+
+function searchLexical(artifact, query, filters, candidateLimit, postingBudget) {
+  const terms = [...new Set(recallTerms(query))];
+  if (!terms.length || !artifact.rows.length) {
+    return { rows: [], posting_entries: 0, has_more: false };
+  }
+  const allowedRows = filterEvidenceRecallRows(artifact.rows, filters);
+  const allowed = new Set(allowedRows.map((row) => row.chunk_id));
+  const scores = new Map();
+  let postingEntries = 0;
+  let truncated = false;
+  for (const term of terms) {
+    const entries = artifact.postings[term] || [];
+    const idf = Math.log(1 + artifact.row_count / Math.max(1, entries.length));
+    for (const [rowIndex, weight] of entries) {
+      if (postingEntries >= postingBudget) { truncated = true; break; }
+      postingEntries += 1;
+      const row = artifact.rows[rowIndex];
+      if (!allowed.has(row.chunk_id)) continue;
+      scores.set(rowIndex, (scores.get(rowIndex) || 0) + weight * idf);
+    }
+    if (postingEntries >= postingBudget) break;
+  }
+  const ranked = [...scores.entries()].sort((left, right) => right[1] - left[1]
+    || compareText(artifact.rows[left[0]].logical_path, artifact.rows[right[0]].logical_path)
+    || artifact.rows[left[0]].ordinal - artifact.rows[right[0]].ordinal
+    || compareText(artifact.rows[left[0]].chunk_id, artifact.rows[right[0]].chunk_id));
+  return {
+    rows: ranked.slice(0, candidateLimit).map(([rowIndex]) => artifact.rows[rowIndex]),
+    posting_entries: postingEntries,
+    has_more: truncated || ranked.length > candidateLimit,
+  };
+}
+
+export function searchEvidenceCandidates(vaultBase, query, {
+  candidateLimit: requestedCandidateLimit,
+  postingBudget: requestedPostingBudget,
+  filters = {},
+  backend: requestedBackend = 'auto',
+  sqlite = 'auto',
+} = {}) {
+  const candidateLimit = normalizeCandidateLimit(requestedCandidateLimit);
+  const postingBudget = normalizePostingBudget(requestedPostingBudget);
+  const backend = normalizeBackend(requestedBackend);
+  const normalizedFilters = normalizeEvidenceRecallFilters(filters);
+  const ensured = ensureSearchState(vaultBase, { sqlite });
+  if (!ensured.state && !ensured.ephemeral) {
+    return {
+      rows: [],
+      backend: 'empty',
+      candidate_count: 0,
+      posting_entries: 0,
+      has_more: false,
+      rebuilt: ensured.rebuilt,
+      fallback_reason: ensured.fallback_reason || '',
+      index_hash: '',
+    };
+  }
+
+  let fallbackReason = ensured.fallback_reason || '';
+  if (backend !== 'lexical' && ensured.state?.sqlite) {
+    try {
+      const result = searchSqlite(
+        vaultBase,
+        ensured.state,
+        query,
+        normalizedFilters,
+        candidateLimit,
+        postingBudget,
+      );
+      return {
+        ...result,
+        backend: 'sqlite-fts5',
+        candidate_count: result.rows.length,
+        rebuilt: ensured.rebuilt,
+        fallback_reason: fallbackReason,
+        index_hash: ensured.state.index_hash,
+      };
+    } catch (error) {
+      if (backend === 'sqlite') throw error;
+      fallbackReason = error?.code || 'sqlite-query-failed';
+    }
+  } else if (backend === 'sqlite') {
+    const error = new Error('SQLite FTS backend is unavailable');
+    error.code = 'EVIDENCE_SEARCH_SQLITE_UNAVAILABLE';
+    throw error;
+  }
+
+  let lexical = ensured.ephemeral;
+  if (!lexical && ensured.state) {
+    try {
+      lexical = loadLexical(vaultBase, ensured.state);
+    } catch (error) {
+      const rows = loadEvidenceIndex(vaultBase);
+      const canonical = canonicalRows(rows);
+      const indexHash = sha256(canonical.map((row) => stableJson(row)).join('\n'));
+      lexical = buildLexicalArtifact(canonical, indexHash);
+      fallbackReason = error?.code || 'lexical-artifact-invalid';
+    }
+  }
+  const result = searchLexical(
+    lexical,
+    query,
+    normalizedFilters,
+    candidateLimit,
+    postingBudget,
+  );
+  return {
+    ...result,
+    backend: ensured.state ? 'lexical-sidecar' : 'lexical-ephemeral',
+    candidate_count: result.rows.length,
+    rebuilt: ensured.rebuilt,
+    fallback_reason: fallbackReason,
+    index_hash: lexical.index_hash,
+  };
+}
+
+export function recallEvidenceIndexed(vaultBase, query, {
+  topK = 5,
+  now = Date.now(),
+  candidateLimit = EVIDENCE_SEARCH_DEFAULT_CANDIDATES,
+  postingBudget = EVIDENCE_SEARCH_DEFAULT_POSTING_BUDGET,
+  filters = {},
+  backend = 'auto',
+  sqlite = 'auto',
+} = {}) {
+  const candidates = searchEvidenceCandidates(vaultBase, query, {
+    candidateLimit,
+    postingBudget,
+    filters,
+    backend,
+    sqlite,
+  });
+  return {
+    results: recallEvidence(candidates.rows, query, { topK, now }),
+    metrics: {
+      backend: candidates.backend,
+      index_hash: candidates.index_hash,
+      candidate_count: candidates.candidate_count,
+      posting_entries: candidates.posting_entries,
+      has_more_candidates: candidates.has_more,
+      rebuilt: candidates.rebuilt,
+      fallback_reason: candidates.fallback_reason,
+    },
+  };
+}

--- a/packages/vault/src/index.mjs
+++ b/packages/vault/src/index.mjs
@@ -8,6 +8,7 @@ export * from './memory-handoff.mjs';
 export * from './memory-store.mjs';
 export * from './memory-scope.mjs';
 export * from './evidence-recall.mjs';
+export * from './evidence-recall-page.mjs';
 export {
   EVIDENCE_INDEX_STATE_FILE,
   EVIDENCE_INDEX_STATE_VERSION,

--- a/packages/vault/src/index.mjs
+++ b/packages/vault/src/index.mjs
@@ -9,6 +9,7 @@ export * from './memory-store.mjs';
 export * from './memory-scope.mjs';
 export * from './evidence-recall.mjs';
 export * from './evidence-recall-page.mjs';
+export * from './evidence-search-index.mjs';
 export {
   EVIDENCE_INDEX_STATE_FILE,
   EVIDENCE_INDEX_STATE_VERSION,

--- a/tests/evidence-recall-page.test.mjs
+++ b/tests/evidence-recall-page.test.mjs
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  EvidenceRecallBudgetError,
+  EvidenceRecallCursorError,
+  recallEvidence,
+  recallEvidencePage,
+} from '../hooks/evidence-recall.mjs';
+
+const NOW = Date.parse('2026-08-26T12:00:00.000Z');
+
+function evidenceRow(id, {
+  authority = 'verified',
+  validity = 'active',
+  logicalPath = `docs/${String(id).padStart(2, '0')}.md`,
+  observedAt = new Date(NOW - Number(id) * 86_400_000).toISOString(),
+  content = `ledger evidence ${id} ${'detail '.repeat(Number(id) + 2)}`,
+  projectId = 'project-a',
+} = {}) {
+  return {
+    index_version: 1,
+    project_id: projectId,
+    logical_path: logicalPath,
+    title: `Ledger ${id}`,
+    change_slug: '',
+    session_id: '',
+    work_session_id: '',
+    observed_at: observedAt,
+    chunk_id: `chunk-${id}`,
+    heading: `Ledger ${id}`,
+    entity_type: 'evidence',
+    authority,
+    validity,
+    ordinal: 0,
+    content,
+    content_hash: `content-${id}-${Buffer.byteLength(content, 'utf8')}`,
+  };
+}
+
+function canonicalRows(rows) {
+  return [...rows].sort((left, right) => left.logical_path.localeCompare(right.logical_path)
+    || left.ordinal - right.ordinal || left.chunk_id.localeCompare(right.chunk_id));
+}
+
+test('recallEvidencePage paginates the deterministic ranking without hiding late evidence', () => {
+  const rows = Array.from({ length: 7 }, (_, index) => evidenceRow(index));
+  const expected = recallEvidence(canonicalRows(rows), 'ledger', {
+    topK: rows.length,
+    now: NOW,
+  }).map((row) => row.chunk_id);
+  const found = [];
+  let cursor = null;
+  let pageNumber = 0;
+  do {
+    const page = recallEvidencePage(pageNumber % 2 ? rows : [...rows].reverse(), 'ledger', {
+      cursor,
+      limit: 2,
+      maxBytes: 128 * 1024,
+      now: NOW,
+    });
+    assert.ok(page.returned_bytes <= page.max_bytes);
+    assert.ok(page.results.every((row) => !Object.hasOwn(row, 'content')));
+    found.push(...page.results.map((row) => row.chunk_id));
+    cursor = page.next_cursor;
+    pageNumber += 1;
+  } while (cursor);
+
+  assert.deepEqual(found, expected);
+  assert.equal(found.at(-1), expected.at(-1));
+});
+
+test('recallEvidencePage binds cursors to normalized query, filters, and index state', () => {
+  const rows = [
+    evidenceRow(1, { authority: 'verified', logicalPath: 'docs/verified.md' }),
+    evidenceRow(2, { authority: 'reported', logicalPath: 'docs/reported.md' }),
+    evidenceRow(3, { authority: 'reported', logicalPath: 'docs/reported-two.md' }),
+    evidenceRow(4, { authority: 'reported', logicalPath: 'sessions/reported.md' }),
+  ];
+  const first = recallEvidencePage(rows, 'ledger', {
+    filters: { authority: 'reported', logical_path_prefix: 'docs/' },
+    limit: 1,
+    maxBytes: 128 * 1024,
+    now: NOW,
+  });
+  assert.equal(first.results.length, 1);
+  assert.equal(first.results[0].authority, 'reported');
+  assert.ok(first.results[0].logical_path.startsWith('docs/'));
+
+  assert.doesNotThrow(() => recallEvidencePage(rows, '  LEDGER  ', {
+    cursor: first.next_cursor,
+    filters: { logical_path_prefix: ['docs/'], authority: ['reported'] },
+    maxBytes: 128 * 1024,
+  }));
+  assert.throws(() => recallEvidencePage(rows, 'different query', {
+    cursor: first.next_cursor,
+    filters: { authority: 'reported', logical_path_prefix: 'docs/' },
+  }), EvidenceRecallCursorError);
+  assert.throws(() => recallEvidencePage(rows, 'ledger', {
+    cursor: first.next_cursor,
+    filters: { authority: 'verified', logical_path_prefix: 'docs/' },
+  }), EvidenceRecallCursorError);
+  assert.throws(() => recallEvidencePage([
+    ...rows,
+    evidenceRow(5, { authority: 'reported', logicalPath: 'docs/new.md' }),
+  ], 'ledger', {
+    cursor: first.next_cursor,
+    filters: { authority: 'reported', logical_path_prefix: 'docs/' },
+  }), EvidenceRecallCursorError);
+});
+
+test('recallEvidencePage rejects corrupted and unsupported cursors fail closed', () => {
+  const rows = [evidenceRow(1), evidenceRow(2)];
+  const first = recallEvidencePage(rows, 'ledger', { limit: 1, now: NOW });
+  const last = first.next_cursor.at(-1);
+  const corrupted = `${first.next_cursor.slice(0, -1)}${last === 'A' ? 'B' : 'A'}`;
+
+  assert.throws(() => recallEvidencePage(rows, 'ledger', { cursor: corrupted }), (error) => {
+    assert.ok(error instanceof EvidenceRecallCursorError);
+    assert.equal(error.code, 'EVIDENCE_RECALL_CURSOR_INVALID');
+    return true;
+  });
+  assert.throws(() => recallEvidencePage(rows, 'ledger', { cursor: 'not+a+base64url+cursor' }),
+    EvidenceRecallCursorError);
+});
+
+test('recallEvidencePage pins recency ranking to the first page as_of timestamp', () => {
+  const rows = [
+    evidenceRow(1, { observedAt: '2026-08-25T12:00:00.000Z' }),
+    evidenceRow(2, { observedAt: '2025-08-26T12:00:00.000Z' }),
+    evidenceRow(3, { observedAt: '2024-08-26T12:00:00.000Z' }),
+  ];
+  const expected = recallEvidence(canonicalRows(rows), 'ledger', {
+    topK: rows.length,
+    now: NOW,
+  }).map((row) => row.chunk_id);
+  const first = recallEvidencePage(rows, 'ledger', { limit: 1, now: NOW });
+  const second = recallEvidencePage(rows, 'ledger', {
+    cursor: first.next_cursor,
+    limit: 10,
+    now: NOW + 10 * 365 * 86_400_000,
+  });
+
+  assert.equal(second.as_of, first.as_of);
+  assert.deepEqual([
+    ...first.results.map((row) => row.chunk_id),
+    ...second.results.map((row) => row.chunk_id),
+  ], expected);
+});
+
+test('recallEvidencePage truncates excerpts to the exact serialized byte budget', () => {
+  const content = `ledger ${'á漢🙂'.repeat(900)}`;
+  const row = evidenceRow(8, { content });
+  const full = recallEvidencePage([row], 'ledger', { maxBytes: 128 * 1024, now: NOW });
+  const minimum = [{
+    ...full.results[0],
+    excerpt: '',
+    excerpt_truncated: true,
+  }];
+  const budget = Buffer.byteLength(JSON.stringify(minimum), 'utf8') + 24;
+  const bounded = recallEvidencePage([row], 'ledger', { maxBytes: budget, now: NOW });
+
+  assert.equal(bounded.returned_count, 1);
+  assert.ok(bounded.returned_bytes <= budget);
+  assert.equal(bounded.results[0].excerpt_truncated, true);
+  assert.equal(bounded.results[0].content_bytes, Buffer.byteLength(content, 'utf8'));
+  assert.equal(bounded.results[0].content_omitted, true);
+  assert.ok(!Object.hasOwn(bounded.results[0], 'content'));
+});
+
+test('recallEvidencePage reports a typed error when metadata cannot fit the budget', () => {
+  const row = evidenceRow(1);
+  assert.throws(() => recallEvidencePage([row], 'ledger', { maxBytes: 2, now: NOW }), (error) => {
+    assert.ok(error instanceof EvidenceRecallBudgetError);
+    assert.equal(error.code, 'EVIDENCE_RECALL_BUDGET_TOO_SMALL');
+    assert.ok(error.required_bytes > error.max_bytes);
+    return true;
+  });
+});
+
+test('legacy recallEvidence keeps returning raw content while paged recall stays compact', () => {
+  const row = evidenceRow(1);
+  const [legacy] = recallEvidence([row], 'ledger', { topK: 1, now: NOW });
+  const page = recallEvidencePage([row], 'ledger', { limit: 1, now: NOW });
+
+  assert.equal(legacy.content, row.content);
+  assert.ok(!Object.hasOwn(page.results[0], 'content'));
+});

--- a/tests/evidence-search-index.test.mjs
+++ b/tests/evidence-search-index.test.mjs
@@ -105,6 +105,48 @@ test('[req:RECALL-8] lexical sidecar is persistent, bounded, and reaches old evi
   }
 });
 
+test('[req:RECALL-8] SQLite availability represents FTS5 and auto mode degrades safely', () => {
+  const vault = createVault();
+  try {
+    writeDocument(vault, '04-Decisões/ADR-capacidade-fts.md', {
+      title: 'Capacidade FTS',
+      body: 'A evidência contém marcador-capacidade-fts.',
+    });
+
+    const first = build(vault, { sqlite: 'auto' });
+    assert.equal(first.search.sqlite_available, evidenceSearchSqliteAvailable());
+
+    if (evidenceSearchSqliteAvailable()) {
+      assert.equal(first.search.sqlite_reason, '');
+      assert.ok(first.search.state.sqlite);
+      return;
+    }
+
+    assert.equal(first.search.state.sqlite, null);
+    assert.ok([
+      'node-sqlite-unavailable',
+      'fts5-unavailable',
+    ].includes(first.search.sqlite_reason));
+    assert.equal(searchEvidenceCandidates(vault, 'marcador-capacidade-fts', {
+      backend: 'auto',
+      candidateLimit: 3,
+    }).rows[0].logical_path, '04-Decisões/ADR-capacidade-fts.md');
+
+    assert.throws(
+      () => refreshEvidenceSearchIndex(vault, loadEvidenceIndex(vault), {
+        force: true,
+        sqlite: 'required',
+      }),
+      (error) => [
+        'EVIDENCE_SEARCH_SQLITE_UNAVAILABLE',
+        'EVIDENCE_SEARCH_FTS5_UNAVAILABLE',
+      ].includes(error?.code),
+    );
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
 test('[req:RECALL-8] filters are equivalent across lexical and SQLite FTS backends', {
   skip: !evidenceSearchSqliteAvailable(),
 }, () => {

--- a/tests/evidence-search-index.test.mjs
+++ b/tests/evidence-search-index.test.mjs
@@ -1,0 +1,269 @@
+import assert from 'node:assert/strict';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  EVIDENCE_SEARCH_STATE_FILE,
+  evidenceSearchSqliteAvailable,
+  loadEvidenceIndex,
+  loadEvidenceSearchState,
+  recallEvidenceIndexed,
+  refreshEvidenceIndex,
+  refreshEvidenceSearchIndex,
+  searchEvidenceCandidates,
+} from '../hooks/evidence-recall.mjs';
+
+function createVault() {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-evidence-search-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  mkdirSync(join(vault, '02-Sessões'), { recursive: true });
+  mkdirSync(join(vault, '04-Decisões'), { recursive: true });
+  writeFileSync(
+    join(vault, '.brain', 'PROJECT.json'),
+    `${JSON.stringify({ projectId: 'project-search' }, null, 2)}\n`,
+  );
+  return vault;
+}
+
+function writeDocument(vault, logicalPath, {
+  title,
+  body,
+  authority = 'verified',
+  validity = 'active',
+  date = '2026-08-26',
+} = {}) {
+  const path = join(vault, ...logicalPath.split('/'));
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, [
+    '---',
+    `title: ${title}`,
+    `authority: ${authority}`,
+    `validity: ${validity}`,
+    `date: ${date}`,
+    '---',
+    `# ${title}`,
+    '',
+    '## Evidência',
+    '',
+    body,
+    '',
+  ].join('\n'));
+  return path;
+}
+
+function build(vault, options = {}) {
+  const refreshed = refreshEvidenceIndex(vault);
+  const search = refreshEvidenceSearchIndex(vault, refreshed.chunks, options);
+  return { refreshed, search };
+}
+
+test('[req:RECALL-8] lexical sidecar is persistent, bounded, and reaches old evidence', () => {
+  const vault = createVault();
+  try {
+    for (let index = 0; index < 40; index += 1) {
+      writeDocument(vault, `02-Sessões/2026-08-${String((index % 25) + 1).padStart(2, '0')}-${index}.md`, {
+        title: `Sessão ${index}`,
+        body: `registro comum de manutenção número ${index}`,
+        authority: 'reported',
+        date: `2026-08-${String((index % 25) + 1).padStart(2, '0')}`,
+      });
+    }
+    writeDocument(vault, '04-Decisões/2020-01-01-ancora-antiga.md', {
+      title: 'Âncora histórica',
+      body: 'A palavra exclusiva nebulosa-ancora preserva esta evidência antiga.',
+      date: '2020-01-01',
+    });
+
+    const first = build(vault, { sqlite: 'off' });
+    assert.equal(first.search.reused, false);
+    assert.equal(first.search.sqlite_available, false);
+    assert.equal(loadEvidenceSearchState(vault)?.row_count, first.refreshed.chunks.length);
+
+    const second = refreshEvidenceSearchIndex(vault, loadEvidenceIndex(vault), { sqlite: 'off' });
+    assert.equal(second.reused, true);
+    assert.equal(second.lexical_written, false);
+
+    const found = searchEvidenceCandidates(vault, 'nebulosa-ancora', {
+      backend: 'lexical',
+      candidateLimit: 3,
+      postingBudget: 8,
+      sqlite: 'off',
+    });
+    assert.equal(found.backend, 'lexical-sidecar');
+    assert.equal(found.rows[0].logical_path, '04-Decisões/2020-01-01-ancora-antiga.md');
+    assert.ok(found.posting_entries <= 8);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:RECALL-8] filters are equivalent across lexical and SQLite FTS backends', {
+  skip: !evidenceSearchSqliteAvailable(),
+}, () => {
+  const vault = createVault();
+  try {
+    writeDocument(vault, '04-Decisões/ADR-verificada.md', {
+      title: 'Contrato FTS verificado',
+      body: 'O contrato motor-foguete foi validado por teste.',
+      authority: 'verified',
+    });
+    writeDocument(vault, '02-Sessões/relato.md', {
+      title: 'Relato FTS',
+      body: 'O relato motor-foguete ainda é apenas observado.',
+      authority: 'reported',
+    });
+    writeDocument(vault, '04-Decisões/ADR-superada.md', {
+      title: 'Contrato antigo',
+      body: 'O contrato motor-foguete foi substituído.',
+      authority: 'verified',
+      validity: 'superseded',
+    });
+
+    build(vault, { sqlite: 'required' });
+    const options = {
+      filters: {
+        authority: 'verified',
+        validity: 'active',
+        logical_path_prefix: '04-Decisões/',
+      },
+      candidateLimit: 10,
+      postingBudget: 100,
+    };
+    const lexical = searchEvidenceCandidates(vault, 'motor-foguete', {
+      ...options,
+      backend: 'lexical',
+    });
+    const sqlite = searchEvidenceCandidates(vault, 'motor-foguete', {
+      ...options,
+      backend: 'sqlite',
+    });
+
+    assert.equal(sqlite.backend, 'sqlite-fts5');
+    assert.deepEqual(
+      sqlite.rows.map((row) => row.chunk_id).sort(),
+      lexical.rows.map((row) => row.chunk_id).sort(),
+    );
+    assert.ok(sqlite.rows.every((row) => row.authority === 'verified'
+      && row.validity === 'active'
+      && row.logical_path.startsWith('04-Decisões/')));
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:RECALL-8] source changes invalidate the derived search state and rebuild lazily', () => {
+  const vault = createVault();
+  try {
+    const document = writeDocument(vault, '04-Decisões/ADR-mutável.md', {
+      title: 'Estado inicial',
+      body: 'A evidência contém sinal-antigo.',
+    });
+    build(vault, { sqlite: 'off' });
+    const before = loadEvidenceSearchState(vault).index_hash;
+
+    writeFileSync(document, [
+      '---',
+      'title: Estado alterado',
+      'authority: verified',
+      'validity: active',
+      'date: 2026-08-26',
+      '---',
+      '# Estado alterado',
+      '',
+      '## Evidência',
+      '',
+      'A evidência agora contém sinal-novo.',
+      '',
+    ].join('\n'));
+    refreshEvidenceIndex(vault);
+
+    const result = recallEvidenceIndexed(vault, 'sinal-novo', {
+      backend: 'lexical',
+      sqlite: 'off',
+      topK: 3,
+    });
+    assert.equal(result.metrics.rebuilt, true);
+    assert.equal(result.results[0].logical_path, '04-Decisões/ADR-mutável.md');
+    assert.notEqual(loadEvidenceSearchState(vault).index_hash, before);
+    assert.equal(recallEvidenceIndexed(vault, 'sinal-antigo', {
+      backend: 'lexical', sqlite: 'off',
+    }).results.length, 0);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:RECALL-8] a corrupted lexical artifact is never trusted and falls back to authority', () => {
+  const vault = createVault();
+  try {
+    writeDocument(vault, '04-Decisões/ADR-recuperação.md', {
+      title: 'Recuperação lexical',
+      body: 'A evidência íntegra contém chave-recuperável.',
+    });
+    build(vault, { sqlite: 'off' });
+    const state = loadEvidenceSearchState(vault);
+    const artifactPath = join(vault, '.brain', ...state.lexical.path.split('/'));
+    writeFileSync(artifactPath, '{"tampered":true}\n');
+
+    const result = searchEvidenceCandidates(vault, 'chave-recuperável', {
+      backend: 'lexical',
+      sqlite: 'off',
+      candidateLimit: 5,
+    });
+    assert.equal(result.backend, 'lexical-ephemeral');
+    assert.equal(result.fallback_reason, 'EVIDENCE_SEARCH_ARTIFACT_DIVERGED');
+    assert.equal(result.rows[0].logical_path, '04-Decisões/ADR-recuperação.md');
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:RECALL-8] posting budget caps lexical work and exposes incomplete candidates', () => {
+  const vault = createVault();
+  try {
+    for (let index = 0; index < 20; index += 1) {
+      writeDocument(vault, `04-Decisões/ADR-${String(index).padStart(2, '0')}.md`, {
+        title: `Decisão ${index}`,
+        body: `termo-comum decisão ${index}`,
+      });
+    }
+    build(vault, { sqlite: 'off' });
+    const result = searchEvidenceCandidates(vault, 'termo-comum', {
+      backend: 'lexical',
+      sqlite: 'off',
+      candidateLimit: 10,
+      postingBudget: 5,
+    });
+    assert.equal(result.posting_entries, 5);
+    assert.equal(result.has_more, true);
+    assert.ok(result.rows.length <= 5);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:RECALL-8] search state remains a derived pointer, not the JSONL authority', () => {
+  const vault = createVault();
+  try {
+    writeDocument(vault, '04-Decisões/ADR-autoridade.md', {
+      title: 'Autoridade JSONL',
+      body: 'A origem mantém valor-autoritativo.',
+    });
+    build(vault, { sqlite: 'off' });
+    const statePath = join(vault, '.brain', EVIDENCE_SEARCH_STATE_FILE);
+    const state = JSON.parse(readFileSync(statePath, 'utf8'));
+    assert.equal(state.schema_version, 1);
+    assert.match(state.lexical.path, /^evidence-search\/lexical-/);
+    assert.equal(loadEvidenceIndex(vault)[0].content.includes('valor-autoritativo'), true);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Contexto

Sexto slice da issue #82, empilhado sobre a PR #115.

A paginação e o orçamento tornam a saída bounded, mas o runtime ainda precisa percorrer o JSONL completo para formar candidatos. Este PR adiciona uma camada de busca derivada e persistente: FTS5 quando `node:sqlite` está disponível e um índice lexical completo, local e limitado por orçamento como fallback.

## Arquitetura

- `EVIDENCE_INDEX.jsonl` continua sendo a autoridade;
- `EVIDENCE_SEARCH_STATE.json` é apenas um ponteiro derivado, vinculado por fingerprint ao JSONL e ao estado incremental;
- artefatos são content-addressed e publicados em `.brain/evidence-search/`;
- o índice lexical contém postings determinísticos e permite consulta por orçamento sem selecionar apenas documentos recentes;
- em Node 22.13+, um SQLite FTS5 imutável é construído opcionalmente;
- em Node 18 ou quando SQLite/FTS falha, a consulta cai para o backend lexical;
- corrupção, hardlink, fingerprint divergente ou metadata incompatível nunca autoriza o artefato derivado; a busca reconstrói ou usa uma visão lexical efêmera da autoridade.

## Mudanças

- adiciona `refreshEvidenceSearchIndex()` e `loadEvidenceSearchState()`;
- adiciona `searchEvidenceCandidates()` com:
  - backend `auto`, `sqlite` ou `lexical`;
  - `candidateLimit` entre 1 e 4096;
  - `postingBudget` entre 1 e 1.048.576 entradas;
  - filtros equivalentes aos da paginação;
  - métricas de backend, candidatos, postings, rebuild e fallback;
- adiciona `recallEvidenceIndexed()` para reranquear candidatos com o scorer atual;
- usa FTS5 `unicode61 remove_diacritics 2`, query composta apenas por termos normalizados e parâmetros SQL;
- mantém JSONL e conteúdo Markdown fora da autoridade do SQLite;
- integra o hook de contexto ao índice de candidatos, com expansão bounded e fallback para o fluxo legado;
- não adiciona dependências de runtime;
- não remove artefatos antigos neste slice.

## Segurança e degradação

- paths passam pela fronteira física do Vault;
- arquivos existentes com hardlink/symlink são rejeitados;
- SQLite é criado em candidate privado e publicado por rename para nome content-addressed;
- state só é publicado depois dos artefatos;
- FTS valida `index_hash` e `row_count` antes de consultar;
- o fallback lexical valida hash, schema, linhas, content hashes e vínculo com o estado;
- corrupção do cache nunca substitui a autoridade: a busca usa o JSONL íntegro para reconstrução/visão efêmera.

## Testes adicionados

- persistência e reutilização do sidecar lexical;
- descoberta de evidência histórica antiga;
- equivalência de filtros entre lexical e FTS5;
- invalidação por mudança do JSONL e rebuild lazy;
- corrupção do artefato lexical com fallback para autoridade;
- limite real de postings e sinalização de candidatos incompletos;
- estado derivado separado da autoridade JSONL.

## Base empilhada

A base é `wk/evidence-recall-pagination` porque este slice depende do contrato de filtros e da trilha de recall da PR #115. Depois da integração da base, pode ser retargetado sem mudança semântica.

## Validação esperada

- Node 18: contrato mínimo e sintaxe sem `node:sqlite` obrigatório;
- Node 22.13: suíte completa, incluindo FTS5;
- um runner Ubuntu, sem necessidade de Windows.

Draft enquanto a CI e a revisão do protocolo de artefatos derivados são concluídas.