### PR TITLE
feat: expor métricas de escala da memória no doctor (#82)

### DIFF
--- a/scripts/benchmark-memory-replay.mjs
+++ b/scripts/benchmark-memory-replay.mjs
@@ -1,0 +1,265 @@
+import {
+  appendFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { pathToFileURL } from 'node:url';
+
+import {
+  MEMORY_SNAPSHOT_FILE,
+  canonicalMemoryJson,
+  readMemoryProjectionSnapshot,
+  reprojectMemoryLedger,
+} from '../hooks/memory-store.mjs';
+
+export const DEFAULT_SCALE_EVENTS = 100_000;
+export const SCALE_MEMORY_KEY = 'next.scale-benchmark';
+
+function normalizeEventCount(value, fallback = DEFAULT_SCALE_EVENTS) {
+  const count = Number(value ?? fallback);
+  if (!Number.isSafeInteger(count) || count < 1 || count > 1_000_000) {
+    throw new RangeError('benchmark events must be an integer between 1 and 1000000');
+  }
+  return count;
+}
+
+function observedAt(index) {
+  return new Date(Date.UTC(2026, 7, 26, 0, 0, 0, index)).toISOString();
+}
+
+export function createSyntheticMemoryEvents(count, {
+  projectId = 'benchmark-memory-replay',
+  startIndex = 0,
+} = {}) {
+  const eventCount = normalizeEventCount(count);
+  if (!Number.isSafeInteger(startIndex) || startIndex < 0
+      || startIndex + eventCount > Number.MAX_SAFE_INTEGER) {
+    throw new RangeError('benchmark startIndex must define a safe non-negative range');
+  }
+
+  const events = new Array(eventCount);
+  for (let offset = 0; offset < eventCount; offset += 1) {
+    const index = startIndex + offset;
+    const suffix = String(index).padStart(7, '0');
+    events[offset] = {
+      v: 1,
+      project_id: projectId,
+      event_id: `mem-scale-${suffix}`,
+      memory_key: SCALE_MEMORY_KEY,
+      operation: 'assert',
+      value: `scale-value-${suffix}`,
+      authority: 'verified',
+      canonical_session_id: 'session-memory-scale',
+      activation_id: 'activation-memory-scale',
+      activation_epoch: 1,
+      turn_sequence: index + 1,
+      source_turn_id: `turn-memory-scale-${suffix}`,
+      observed_at: observedAt(index),
+      evidence: ['memory-scale-benchmark'],
+    };
+  }
+  return events;
+}
+
+function createBenchmarkVault(projectId) {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-memory-scale-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  writeFileSync(
+    join(vault, '.brain', 'PROJECT.json'),
+    `${JSON.stringify({ projectId }, null, 2)}\n`,
+  );
+  return vault;
+}
+
+function ledgerPath(vault) {
+  return join(vault, '.brain', 'MEMORY_EVENTS.jsonl');
+}
+
+function writeLedger(vault, events) {
+  const content = `${events.map((event) => canonicalMemoryJson(event)).join('\n')}\n`;
+  writeFileSync(ledgerPath(vault), content);
+  return Buffer.byteLength(content, 'utf8');
+}
+
+function appendLedgerEvent(vault, event) {
+  const content = `${canonicalMemoryJson(event)}\n`;
+  appendFileSync(ledgerPath(vault), content);
+  return Buffer.byteLength(content, 'utf8');
+}
+
+function fileBytes(path) {
+  return Number(statSync(path).size);
+}
+
+function elapsed(startedAt) {
+  return Math.round((performance.now() - startedAt) * 1000) / 1000;
+}
+
+export function runMemoryReplayScaleBenchmark({
+  events: requestedEvents = DEFAULT_SCALE_EVENTS,
+  keepVault = false,
+} = {}) {
+  const eventCount = normalizeEventCount(requestedEvents);
+  const projectId = `benchmark-memory-replay-${eventCount}`;
+  const vault = createBenchmarkVault(projectId);
+  const rssBefore = process.memoryUsage().rss;
+
+  try {
+    const generationStarted = performance.now();
+    const events = createSyntheticMemoryEvents(eventCount, { projectId });
+    const generationMs = elapsed(generationStarted);
+    const initialLedgerBytes = writeLedger(vault, events);
+
+    const fullStarted = performance.now();
+    const full = reprojectMemoryLedger(vault, { snapshot: { force: true } });
+    const fullReplayMs = elapsed(fullStarted);
+
+    const warmStarted = performance.now();
+    const warm = reprojectMemoryLedger(vault);
+    const warmReplayMs = elapsed(warmStarted);
+
+    const tailEvent = createSyntheticMemoryEvents(1, {
+      projectId,
+      startIndex: eventCount,
+    })[0];
+    const tailBytes = appendLedgerEvent(vault, tailEvent);
+
+    const tailStarted = performance.now();
+    const tail = reprojectMemoryLedger(vault);
+    const tailReplayMs = elapsed(tailStarted);
+
+    const advanceStarted = performance.now();
+    const advanced = reprojectMemoryLedger(vault, { snapshot: { force: true } });
+    const snapshotAdvanceMs = elapsed(advanceStarted);
+
+    const finalWarmStarted = performance.now();
+    const finalWarm = reprojectMemoryLedger(vault);
+    const finalWarmMs = elapsed(finalWarmStarted);
+
+    const snapshot = readMemoryProjectionSnapshot(vault);
+    const snapshotFile = join(vault, '.brain', MEMORY_SNAPSHOT_FILE);
+    const sharedFile = join(vault, '.brain', 'SHARED_MEMORY.md');
+    const result = {
+      schema_version: 1,
+      events: eventCount,
+      timings_ms: {
+        generation: generationMs,
+        full_replay: fullReplayMs,
+        warm_replay: warmReplayMs,
+        one_event_tail_replay: tailReplayMs,
+        snapshot_advance: snapshotAdvanceMs,
+        final_warm_replay: finalWarmMs,
+      },
+      bytes: {
+        initial_ledger: initialLedgerBytes,
+        appended_tail: tailBytes,
+        active_ledger: fileBytes(ledgerPath(vault)),
+        snapshot: fileBytes(snapshotFile),
+        shared_projection: fileBytes(sharedFile),
+      },
+      memory: {
+        rss_before: rssBefore,
+        rss_after: process.memoryUsage().rss,
+      },
+      full: {
+        status: full.status,
+        replay_mode: full.replayMode,
+        replayed_events: full.replayedEvents,
+        snapshot_status: full.snapshotStatus,
+        snapshot_fallback: full.snapshotFallback,
+        state_hash: full.stateHash,
+      },
+      warm: {
+        status: warm.status,
+        replay_mode: warm.replayMode,
+        replayed_events: warm.replayedEvents,
+        snapshot_status: warm.snapshotStatus,
+        state_hash: warm.stateHash,
+      },
+      tail: {
+        status: tail.status,
+        replay_mode: tail.replayMode,
+        replayed_events: tail.replayedEvents,
+        snapshot_status: tail.snapshotStatus,
+        state_hash: tail.stateHash,
+      },
+      advanced: {
+        status: advanced.status,
+        replay_mode: advanced.replayMode,
+        replayed_events: advanced.replayedEvents,
+        snapshot_status: advanced.snapshotStatus,
+        snapshot_event_count: advanced.snapshotEventCount,
+        state_hash: advanced.stateHash,
+      },
+      final_warm: {
+        status: finalWarm.status,
+        replay_mode: finalWarm.replayMode,
+        replayed_events: finalWarm.replayedEvents,
+        snapshot_status: finalWarm.snapshotStatus,
+        state_hash: finalWarm.stateHash,
+      },
+      snapshot: {
+        status: snapshot.status,
+        event_count: snapshot.snapshot?.event_count ?? null,
+        tail_events: snapshot.tail?.events?.length ?? null,
+        through_event_id: snapshot.snapshot?.through_event_id || '',
+      },
+      contracts: {
+        full_replay_complete: full.replayMode === 'full'
+          && full.replayedEvents === eventCount,
+        warm_replay_zero: warm.replayMode === 'snapshot-tail'
+          && warm.replayedEvents === 0,
+        one_event_tail_only: tail.replayMode === 'snapshot-tail'
+          && tail.replayedEvents === 1,
+        snapshot_advanced: advanced.snapshotStatus === 'written'
+          && advanced.snapshotEventCount === eventCount + 1,
+        final_warm_replay_zero: finalWarm.replayMode === 'snapshot-tail'
+          && finalWarm.replayedEvents === 0,
+        projection_stable: full.stateHash === warm.stateHash
+          && tail.stateHash === advanced.stateHash
+          && advanced.stateHash === finalWarm.stateHash,
+      },
+      ...(keepVault ? { vault } : {}),
+    };
+    result.memory.rss_delta = result.memory.rss_after - result.memory.rss_before;
+    return result;
+  } finally {
+    if (!keepVault) rmSync(vault, { recursive: true, force: true });
+  }
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = () => {
+      index += 1;
+      if (index >= argv.length) throw new TypeError(`missing value for ${arg}`);
+      return argv[index];
+    };
+    if (arg === '--events') options.events = next();
+    else if (arg === '--keep-vault') options.keepVault = true;
+    else if (arg === '--help' || arg === '-h') options.help = true;
+    else throw new TypeError(`unknown benchmark option: ${arg}`);
+  }
+  return options;
+}
+
+const HELP = `Memory replay scale benchmark\n\nUsage:\n  node scripts/benchmark-memory-replay.mjs [options]\n\nOptions:\n  --events <n>    Synthetic ledger events (default: ${DEFAULT_SCALE_EVENTS})\n  --keep-vault    Preserve the generated temporary Vault\n  --help          Show this help\n`;
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) process.stdout.write(HELP);
+    else process.stdout.write(`${JSON.stringify(runMemoryReplayScaleBenchmark(options), null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(`${error?.stack || error}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import { checkHarness, checkVaultLinks, checkSessionActivity, checkStackedFrontmatter, renderStackedFrontmatterLines, checkUnpricedModels, renderUnpricedModelLines, checkStaleDerivedSections, renderStaleDerivedSectionLines, checkSessionObservability, renderSessionObservabilityLines } from '../hooks/harness-doctor.mjs';
 import { diagnoseManagedWorktrees } from './worktree.mjs';
 import { runVaultHealth } from '../hooks/vault-health.mjs';
+import { augmentVaultHealthWithMemoryScale } from './memory-scale-health.mjs';
 import { checkSyncDefs } from './sync-defs.mjs';
 import { resolveProjectVault } from './project-vault.mjs';
 import { inspectObserverSqlOutbox } from './observer-sql-publish.mjs';
@@ -17,6 +18,12 @@ import { readProjectForValidation } from '../packages/vault/src/validate-memory.
 
 const healthStatusLabel = (status) => ({
   healthy: 'saudável', warning: 'atenção', degraded: 'degradada', blocked: 'bloqueada', legacy: 'legado',
+}[status] || status || 'desconhecido');
+
+const artifactStatusLabel = (status) => ({
+  ok: 'saudável', healthy: 'saudável', warning: 'atenção', degraded: 'degradado',
+  missing: 'ausente', empty: 'vazio', invalid: 'inválido', corrupt: 'corrompido',
+  blocked: 'bloqueado', unknown: 'desconhecido',
 }[status] || status || 'desconhecido');
 
 const metricValue = (value) => value === null || value === undefined || value === '' ? 'n/a' : value;
@@ -49,6 +56,19 @@ export function renderVaultHealthLines(result) {
   );
   const repairableHandoffs = Number(memory.repairableHandoffs || 0);
   lines.push(`  ledger: ${metricValue(memory.ledgerEvents)} evento(s) · outbox: ${metricValue(memory.pendingOutbox)} · candidates: ${metricValue(memory.candidates)} · conflitos: ${metricValue(memory.activeConflicts)}${repairableHandoffs ? ` · handoffs reparáveis: ${repairableHandoffs}` : ''}`);
+  if (memory.scaleSchemaVersion === 1) {
+    lines.push(
+      `  replay: snapshot ${artifactStatusLabel(memory.snapshotStatus)} · cobertos: ${metricValue(memory.snapshotEvents)} evento(s) · tail: ${metricValue(memory.snapshotTailEvents)} evento(s)/${metricValue(memory.snapshotTailBytes)} bytes · ledger no snapshot: ${metricValue(memory.snapshotLedgerBytes)} bytes`,
+    );
+    if (memory.snapshotReason) lines.push(`    ↳ snapshot: ${memory.snapshotReason}`);
+    lines.push(
+      `  segmentos: ${artifactStatusLabel(memory.segmentStatus)} · ${metricValue(memory.segmentCount)} segmento(s) · cobertos: ${metricValue(memory.segmentCoveredEvents)} evento(s)/${metricValue(memory.segmentCoveredBytes)} bytes · pendentes: ${metricValue(memory.segmentPendingEvents)}`,
+    );
+    lines.push(
+      `  rotação: geração ${artifactStatusLabel(memory.generationStatus)} #${metricValue(memory.generation)} · origem: ${metricValue(memory.generationSourceEvents)} · tail ativo: ${metricValue(memory.generationActiveTailEvents)} · journal: ${artifactStatusLabel(memory.rotationJournal)} · receipts: ${metricValue(memory.rotationReceipts)} (${artifactStatusLabel(memory.rotationReceiptCheckpoint)})`,
+    );
+    if (memory.scaleErrorCode) lines.push(`    ↳ escala: ${memory.scaleErrorCode}`);
+  }
   const semanticKeys = memory.semanticActiveKeys || [];
   const semanticProjected = memory.semanticProjectedKeys || [];
   const semanticMissing = memory.semanticMissingKeys || [];
@@ -105,7 +125,10 @@ export function runDoctor(argv) {
   // 1. Session/vault integrity. The standalone hook remains JSON; doctor renders it for humans.
   let health;
   try {
-    health = runVaultHealth({ vaultBase, session });
+    health = augmentVaultHealthWithMemoryScale(
+      runVaultHealth({ vaultBase, session }),
+      vaultBase,
+    );
   } catch (error) {
     health = {
       ok: false,

--- a/src/memory-scale-health.mjs
+++ b/src/memory-scale-health.mjs
@@ -1,0 +1,210 @@
+import {
+  readMemoryLedgerGeneration,
+  readMemoryProjectionSnapshot,
+  readMemoryRotationJournal,
+  readMemoryRotationReceipts,
+  readMemorySegmentManifest,
+} from '../hooks/memory-store.mjs';
+import {
+  quoteCommandArgument,
+  WENDKEEP_COMMAND,
+} from '../hooks/obsidian-common.mjs';
+
+export const MEMORY_SCALE_HEALTH_SCHEMA_VERSION = 1;
+
+function safeReason(value, fallback = '') {
+  const text = String(value || fallback).trim();
+  return text
+    ? text.replace(/[^A-Za-z0-9._:-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 120)
+    : null;
+}
+
+function numberMetric(value) {
+  const number = Number(value || 0);
+  return Number.isSafeInteger(number) && number >= 0 ? number : 0;
+}
+
+export function emptyMemoryScaleMetrics() {
+  return {
+    scaleSchemaVersion: MEMORY_SCALE_HEALTH_SCHEMA_VERSION,
+    scaleStatus: 'unknown',
+    scaleErrorCode: null,
+    snapshotStatus: 'unknown',
+    snapshotReason: null,
+    snapshotEvents: 0,
+    snapshotLedgerBytes: 0,
+    snapshotTailEvents: 0,
+    snapshotTailBytes: 0,
+    segmentStatus: 'unknown',
+    segmentCount: 0,
+    segmentCoveredEvents: 0,
+    segmentCoveredBytes: 0,
+    segmentPendingEvents: 0,
+    generationStatus: 'unknown',
+    generation: 0,
+    generationSourceEvents: 0,
+    generationActiveTailEvents: 0,
+    generationRotatedAt: null,
+    rotationJournal: 'unknown',
+    rotationRecoveryRequired: false,
+    rotationReceiptsStatus: 'unknown',
+    rotationReceipts: 0,
+    rotationReceiptCheckpoint: 'unknown',
+  };
+}
+
+function inspectSnapshot(vaultBase, metrics) {
+  try {
+    const snapshot = readMemoryProjectionSnapshot(vaultBase);
+    const tailStatus = snapshot.status === 'ok' ? snapshot.tail?.status : null;
+    metrics.snapshotStatus = snapshot.status === 'ok' && tailStatus !== 'ok'
+      ? 'invalid'
+      : snapshot.status;
+    metrics.snapshotReason = safeReason(
+      snapshot.reason || snapshot.tail?.reason,
+      metrics.snapshotStatus === 'invalid' ? 'snapshot-tail-unavailable' : '',
+    );
+    if (snapshot.status === 'ok') {
+      metrics.snapshotEvents = numberMetric(snapshot.snapshot?.event_count);
+      metrics.snapshotLedgerBytes = numberMetric(snapshot.snapshot?.ledger_bytes);
+      metrics.snapshotTailEvents = Array.isArray(snapshot.tail?.events)
+        ? snapshot.tail.events.length
+        : 0;
+      metrics.snapshotTailBytes = numberMetric(snapshot.tail?.bytes);
+    }
+  } catch (error) {
+    if (error?.code === 'VAULT_PATH_UNSAFE') throw error;
+    metrics.snapshotStatus = 'invalid';
+    metrics.snapshotReason = safeReason(error?.code, 'snapshot-read-failed');
+  }
+}
+
+function inspectSegments(vaultBase, ledgerEvents, metrics) {
+  try {
+    const manifest = readMemorySegmentManifest(vaultBase);
+    metrics.segmentStatus = manifest.status;
+    if (manifest.status === 'ok') {
+      metrics.segmentCount = numberMetric(manifest.manifest?.segment_count);
+      metrics.segmentCoveredEvents = numberMetric(manifest.manifest?.covered_event_count);
+      metrics.segmentCoveredBytes = numberMetric(manifest.manifest?.covered_bytes);
+    }
+    metrics.segmentPendingEvents = Math.max(
+      0,
+      numberMetric(ledgerEvents) - metrics.segmentCoveredEvents,
+    );
+  } catch (error) {
+    if (error?.code === 'VAULT_PATH_UNSAFE') throw error;
+    metrics.segmentStatus = 'invalid';
+    metrics.scaleErrorCode ||= safeReason(error?.code, 'segment-manifest-read-failed');
+  }
+}
+
+function inspectRotation(vaultBase, ledgerEvents, metrics) {
+  try {
+    const generation = readMemoryLedgerGeneration(vaultBase);
+    metrics.generationStatus = generation.status;
+    if (generation.status === 'ok') {
+      metrics.generation = numberMetric(generation.state?.generation);
+      metrics.generationSourceEvents = numberMetric(generation.state?.source_event_count);
+      metrics.generationActiveTailEvents = Math.max(
+        0,
+        numberMetric(ledgerEvents) - metrics.generationSourceEvents,
+      );
+      metrics.generationRotatedAt = String(generation.state?.rotated_at || '') || null;
+    }
+  } catch (error) {
+    if (error?.code === 'VAULT_PATH_UNSAFE') throw error;
+    metrics.generationStatus = 'invalid';
+    metrics.scaleErrorCode ||= safeReason(error?.code, 'generation-read-failed');
+  }
+
+  try {
+    const journal = readMemoryRotationJournal(vaultBase);
+    metrics.rotationJournal = journal.status === 'ok'
+      ? String(journal.journal?.stage || 'invalid')
+      : journal.status;
+    metrics.rotationRecoveryRequired = journal.status !== 'missing';
+  } catch (error) {
+    if (error?.code === 'VAULT_PATH_UNSAFE') throw error;
+    metrics.rotationJournal = 'invalid';
+    metrics.rotationRecoveryRequired = true;
+    metrics.scaleErrorCode ||= safeReason(error?.code, 'rotation-journal-read-failed');
+  }
+
+  try {
+    const receipts = readMemoryRotationReceipts(vaultBase);
+    metrics.rotationReceiptsStatus = receipts.status;
+    metrics.rotationReceipts = Array.isArray(receipts.receipts)
+      ? receipts.receipts.length
+      : 0;
+    metrics.rotationReceiptCheckpoint = String(receipts.checkpointStatus || 'unknown');
+  } catch (error) {
+    if (error?.code === 'VAULT_PATH_UNSAFE') throw error;
+    metrics.rotationReceiptsStatus = 'invalid';
+    metrics.rotationReceiptCheckpoint = 'invalid';
+    metrics.scaleErrorCode ||= safeReason(error?.code, 'rotation-receipts-read-failed');
+  }
+}
+
+function deriveScaleStatus(metrics) {
+  const invalid = [
+    metrics.snapshotStatus,
+    metrics.segmentStatus,
+    metrics.generationStatus,
+    metrics.rotationJournal,
+    metrics.rotationReceiptsStatus,
+    metrics.rotationReceiptCheckpoint,
+  ].some((status) => ['invalid', 'corrupt', 'blocked'].includes(status));
+  if (invalid || metrics.scaleErrorCode) return 'degraded';
+  if (metrics.rotationRecoveryRequired) return 'warning';
+  return 'healthy';
+}
+
+export function inspectMemoryScaleHealth(vaultBase, { ledgerEvents = 0 } = {}) {
+  const metrics = emptyMemoryScaleMetrics();
+  inspectSnapshot(vaultBase, metrics);
+  inspectSegments(vaultBase, ledgerEvents, metrics);
+  inspectRotation(vaultBase, ledgerEvents, metrics);
+  metrics.scaleStatus = deriveScaleStatus(metrics);
+  return metrics;
+}
+
+function statusCommand(vaultBase) {
+  return `${WENDKEEP_COMMAND} memory status --gate --vault ${quoteCommandArgument(vaultBase)}`;
+}
+
+export function augmentVaultHealthWithMemoryScale(result, vaultBase) {
+  const memory = result?.metrics?.memory;
+  if (!memory || ['legacy', 'blocked'].includes(result.memoryStatus)) return result;
+
+  try {
+    const scale = inspectMemoryScaleHealth(vaultBase, {
+      ledgerEvents: memory.ledgerEvents,
+    });
+    return {
+      ...result,
+      metrics: {
+        ...result.metrics,
+        memory: { ...memory, ...scale },
+      },
+    };
+  } catch (error) {
+    const code = safeReason(error?.code, 'memory-scale-boundary-unsafe');
+    const failure = `Memória: Artefatos de escala da memória estão inseguros ou ilegíveis (${code}). Inspecione com: ${statusCommand(vaultBase)}.`;
+    return {
+      ...result,
+      ok: false,
+      memoryStatus: 'blocked',
+      failures: [...(result.failures || []), failure],
+      metrics: {
+        ...result.metrics,
+        memory: {
+          ...memory,
+          ...emptyMemoryScaleMetrics(),
+          scaleStatus: 'blocked',
+          scaleErrorCode: code,
+        },
+      },
+    };
+  }
+}

--- a/tests/doctor-memory-scale-metrics.test.mjs
+++ b/tests/doctor-memory-scale-metrics.test.mjs
@@ -1,0 +1,211 @@
+import assert from 'node:assert/strict';
+import {
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  MEMORY_SNAPSHOT_FILE,
+  enqueueMemoryEvent,
+  projectMemoryOutbox,
+  rotateMemoryLedger,
+  sealMemorySegments,
+} from '../hooks/memory-store.mjs';
+import {
+  augmentVaultHealthWithMemoryScale,
+  inspectMemoryScaleHealth,
+} from '../src/memory-scale-health.mjs';
+import { renderVaultHealthLines } from '../src/doctor.mjs';
+
+const PROJECT_ID = 'doctor-memory-scale';
+
+function scratch() {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-doctor-memory-scale-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  writeFileSync(
+    join(vault, '.brain', 'PROJECT.json'),
+    `${JSON.stringify({ projectId: PROJECT_ID }, null, 2)}\n`,
+  );
+  return vault;
+}
+
+function memoryEvent(index) {
+  const suffix = String(index).padStart(3, '0');
+  return {
+    v: 1,
+    project_id: PROJECT_ID,
+    event_id: `mem-doctor-scale-${suffix}`,
+    memory_key: 'next.doctor-scale',
+    operation: 'assert',
+    value: `doctor-scale-${suffix}`,
+    authority: 'verified',
+    canonical_session_id: 'doctor-scale-session',
+    activation_id: 'doctor-scale-activation',
+    activation_epoch: 1,
+    turn_sequence: index,
+    source_turn_id: `doctor-scale-turn-${suffix}`,
+    observed_at: `2026-08-26T04:${String(index).padStart(2, '0')}:00.000Z`,
+    evidence: ['doctor-memory-scale-metrics.test.mjs'],
+  };
+}
+
+function seed(vault, from, to, { snapshot = false } = {}) {
+  for (let index = from; index <= to; index += 1) {
+    enqueueMemoryEvent(vault, memoryEvent(index));
+  }
+  return projectMemoryOutbox(vault, snapshot ? { snapshot: { force: true } } : {});
+}
+
+function baseHealth(ledgerEvents) {
+  return {
+    ok: true,
+    session: '',
+    failures: [],
+    warnings: [],
+    memoryStatus: 'healthy',
+    metrics: {
+      registrySessions: 0,
+      derivedNotes: 0,
+      memory: {
+        schemaVersion: 2,
+        revision: ledgerEvents,
+        eventCursor: `mem-doctor-scale-${String(ledgerEvents).padStart(3, '0')}`,
+        stateHash: 'a'.repeat(64),
+        ledgerEvents,
+        pendingOutbox: 0,
+        candidates: 0,
+        activeConflicts: 0,
+        repairableHandoffs: 0,
+        semanticCode: 'healthy',
+        semanticActiveKeys: ['next.doctor-scale'],
+        semanticProjectedKeys: ['next.doctor-scale'],
+        semanticMissingKeys: [],
+      },
+    },
+  };
+}
+
+function byteSnapshot(vault) {
+  const entries = [];
+  const walk = (dir, rel = '') => {
+    for (const name of readdirSync(dir).sort()) {
+      const path = join(dir, name);
+      const itemRel = rel ? `${rel}/${name}` : name;
+      if (statSync(path).isDirectory()) walk(path, itemRel);
+      else entries.push([itemRel, readFileSync(path)]);
+    }
+  };
+  walk(join(vault, '.brain'));
+  return entries;
+}
+
+test('[req:MEM-SCALE-3] doctor exposes snapshot, segment and generation coverage read-only', () => {
+  const vault = scratch();
+  try {
+    const projected = seed(vault, 1, 4, { snapshot: true });
+    assert.equal(projected.snapshotStatus, 'written');
+    const sealed = sealMemorySegments(vault, {
+      maxEvents: 2,
+      maxBytes: 1024 * 1024,
+      force: true,
+    });
+    assert.equal(sealed.coveredEvents, 4);
+
+    const before = byteSnapshot(vault);
+    const initial = augmentVaultHealthWithMemoryScale(baseHealth(4), vault);
+    assert.deepEqual(byteSnapshot(vault), before, 'doctor scale inspection must be read-only');
+    assert.equal(initial.metrics.memory.scaleStatus, 'healthy');
+    assert.equal(initial.metrics.memory.snapshotStatus, 'ok');
+    assert.equal(initial.metrics.memory.snapshotEvents, 4);
+    assert.equal(initial.metrics.memory.snapshotTailEvents, 0);
+    assert.equal(initial.metrics.memory.segmentStatus, 'ok');
+    assert.equal(initial.metrics.memory.segmentCount, 2);
+    assert.equal(initial.metrics.memory.segmentCoveredEvents, 4);
+    assert.equal(initial.metrics.memory.segmentPendingEvents, 0);
+    assert.equal(initial.metrics.memory.generationStatus, 'missing');
+    assert.equal(initial.metrics.memory.rotationJournal, 'missing');
+    assert.equal(initial.metrics.memory.rotationReceipts, 0);
+
+    const rendered = renderVaultHealthLines(initial).join('\n');
+    assert.match(rendered, /replay: snapshot saudável/i);
+    assert.match(rendered, /segmentos: saudável.*2 segmento\(s\).*cobertos: 4/i);
+    assert.match(rendered, /rotação: geração ausente #0.*journal: ausente/i);
+
+    const rotated = rotateMemoryLedger(vault, {
+      apply: true,
+      reason: 'validar métricas de escala do doctor',
+      authorizedBy: 'doctor-scale-test',
+      now: '2026-08-26T05:00:00.000Z',
+    });
+    assert.equal(rotated.status, 'rotated');
+
+    const afterRotation = augmentVaultHealthWithMemoryScale(baseHealth(4), vault);
+    assert.equal(afterRotation.metrics.memory.generationStatus, 'ok');
+    assert.equal(afterRotation.metrics.memory.generation, 1);
+    assert.equal(afterRotation.metrics.memory.generationSourceEvents, 4);
+    assert.equal(afterRotation.metrics.memory.generationActiveTailEvents, 0);
+    assert.equal(afterRotation.metrics.memory.rotationJournal, 'missing');
+    assert.equal(afterRotation.metrics.memory.rotationRecoveryRequired, false);
+    assert.equal(afterRotation.metrics.memory.rotationReceiptsStatus, 'ok');
+    assert.equal(afterRotation.metrics.memory.rotationReceipts, 1);
+    assert.equal(afterRotation.metrics.memory.rotationReceiptCheckpoint, 'ok');
+
+    const incremental = seed(vault, 5, 5);
+    assert.equal(incremental.replayMode, 'snapshot-tail');
+    assert.equal(incremental.replayedEvents, 1);
+    const withTail = augmentVaultHealthWithMemoryScale(baseHealth(5), vault);
+    assert.equal(withTail.metrics.memory.snapshotEvents, 4);
+    assert.equal(withTail.metrics.memory.snapshotTailEvents, 1);
+    assert.equal(withTail.metrics.memory.segmentCoveredEvents, 4);
+    assert.equal(withTail.metrics.memory.segmentPendingEvents, 1);
+    assert.equal(withTail.metrics.memory.generationActiveTailEvents, 1);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-SCALE-4] unsafe optional scale artifact blocks doctor with a safe command', (t) => {
+  const vault = scratch();
+  const outside = mkdtempSync(join(tmpdir(), 'wk-doctor-memory-scale-outside-'));
+  try {
+    seed(vault, 1, 1, { snapshot: true });
+    const snapshot = join(vault, '.brain', MEMORY_SNAPSHOT_FILE);
+    const alias = join(outside, 'snapshot-alias.json');
+    try {
+      linkSync(snapshot, alias);
+    } catch (error) {
+      if (['EPERM', 'EACCES', 'ENOTSUP', 'EXDEV'].includes(error?.code)) {
+        t.skip(`hardlinks indisponíveis neste filesystem: ${error.code}`);
+        return;
+      }
+      throw error;
+    }
+    const before = byteSnapshot(vault);
+
+    assert.throws(
+      () => inspectMemoryScaleHealth(vault, { ledgerEvents: 1 }),
+      (error) => error?.code === 'VAULT_PATH_UNSAFE',
+    );
+    const result = augmentVaultHealthWithMemoryScale(baseHealth(1), vault);
+    assert.equal(result.ok, false);
+    assert.equal(result.memoryStatus, 'blocked');
+    assert.equal(result.metrics.memory.scaleStatus, 'blocked');
+    assert.match(result.failures.join('\n'), /Artefatos de escala da memória.*inseguros/i);
+    assert.ok(result.failures.join('\n').includes(
+      `npx --no-install wendkeep memory status --gate --vault "${vault}"`,
+    ));
+    assert.deepEqual(byteSnapshot(vault), before, 'blocked inspection must remain read-only');
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});

--- a/tests/memory-replay-scale.test.mjs
+++ b/tests/memory-replay-scale.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  SCALE_MEMORY_KEY,
+  createSyntheticMemoryEvents,
+  runMemoryReplayScaleBenchmark,
+} from '../scripts/benchmark-memory-replay.mjs';
+
+const CI_SCALE_EVENTS = 25_000;
+
+test('[req:MEM-SCALE-1] synthetic memory ledger is deterministic and causally monotonic', () => {
+  const first = createSyntheticMemoryEvents(500);
+  const second = createSyntheticMemoryEvents(500);
+  assert.deepEqual(second, first);
+  assert.equal(first.length, 500);
+  assert.equal(first[0].memory_key, SCALE_MEMORY_KEY);
+  assert.equal(first[0].turn_sequence, 1);
+  assert.equal(first.at(-1).turn_sequence, 500);
+  assert.equal(new Set(first.map((event) => event.event_id)).size, first.length);
+  assert.ok(first.every((event, index) => (
+    index === 0 || event.observed_at > first[index - 1].observed_at
+  )));
+});
+
+test('[req:MEM-SCALE-2] large snapshot replay reads only the tail after the first projection', {
+  timeout: 180_000,
+}, () => {
+  const result = runMemoryReplayScaleBenchmark({ events: CI_SCALE_EVENTS });
+
+  assert.equal(result.events, CI_SCALE_EVENTS);
+  assert.equal(result.full.replay_mode, 'full');
+  assert.equal(result.full.replayed_events, CI_SCALE_EVENTS);
+  assert.equal(result.full.snapshot_status, 'written');
+
+  assert.equal(result.warm.replay_mode, 'snapshot-tail');
+  assert.equal(result.warm.replayed_events, 0);
+  assert.equal(result.tail.replay_mode, 'snapshot-tail');
+  assert.equal(result.tail.replayed_events, 1);
+
+  assert.equal(result.advanced.replay_mode, 'snapshot-tail');
+  assert.equal(result.advanced.replayed_events, 1);
+  assert.equal(result.advanced.snapshot_status, 'written');
+  assert.equal(result.advanced.snapshot_event_count, CI_SCALE_EVENTS + 1);
+
+  assert.equal(result.final_warm.replay_mode, 'snapshot-tail');
+  assert.equal(result.final_warm.replayed_events, 0);
+  assert.deepEqual(result.contracts, {
+    full_replay_complete: true,
+    warm_replay_zero: true,
+    one_event_tail_only: true,
+    snapshot_advanced: true,
+    final_warm_replay_zero: true,
+    projection_stable: true,
+  });
+
+  assert.equal(result.snapshot.status, 'ok');
+  assert.equal(result.snapshot.event_count, CI_SCALE_EVENTS + 1);
+  assert.equal(result.snapshot.tail_events, 0);
+  assert.match(result.snapshot.through_event_id, /mem-scale-0025000$/);
+  assert.ok(result.bytes.initial_ledger > 0);
+  assert.ok(result.bytes.snapshot > 0);
+  assert.ok(result.bytes.shared_projection > 0);
+});


### PR DESCRIPTION
## Contexto

Nono slice da issue #82, empilhado sobre a PR #118.

Os benchmarks agora provam que snapshots e índices mantêm o trabalho bounded, mas essa cobertura ainda não aparece no diagnóstico diário. Este PR adiciona ao `wendkeep doctor` uma visão read-only de snapshot, tail, segmentos e gerações do ledger.

## Entregue

- novo inspetor `src/memory-scale-health.mjs`;
- métricas versionadas (`scaleSchemaVersion: 1`) para:
  - estado do snapshot;
  - eventos e bytes cobertos pelo snapshot;
  - eventos e bytes do tail;
  - estado, quantidade, cobertura e pendência dos segmentos;
  - geração atual do ledger;
  - eventos da geração de origem e tail ativo;
  - estágio do journal de rotação;
  - quantidade e checkpoint dos receipts;
- integração no `wendkeep doctor` sem alterar o hook JSON legado;
- renderização humana separada para replay, segmentos e rotação;
- motivos reduzidos a códigos seguros, sem paths ou conteúdo privado;
- boundary fail-closed: hardlink/symlink/reparse em artefato opcional bloqueia o doctor com comando seguro;
- leitura sem lock e sem mutação de snapshot, manifest, journal, generation ou receipts.

## Exemplo de saída

```text
replay: snapshot saudável · cobertos: 4 evento(s) · tail: 1 evento(s)/... bytes
segmentos: saudável · 2 segmento(s) · cobertos: 4 evento(s) · pendentes: 1
rotação: geração saudável #1 · origem: 4 · tail ativo: 1 · journal: ausente · receipts: 1 (saudável)
```

## Testes

- cobertura inicial de snapshot e segmentos;
- rotação para geração 1 e receipt encadeado;
- append posterior refletido como tail de snapshot, segmento e geração;
- renderização humana do doctor;
- inspeção byte-for-byte read-only;
- hardlink em `MEMORY_SNAPSHOT.json` bloqueado com `memory status --gate` usando o Vault resolvido.

## Escopo

- não altera a autoridade do ledger;
- não verifica novamente todos os arquivos de segmentos — lê o manifest já validado pelo protocolo;
- não cria snapshot, segmento ou receipt;
- não altera versão, changelog, release ou workflows.

Draft enquanto a suíte canônica valida a integração sobre #118.