### PR TITLE
feat: publicar métricas de escala da memória no Observer (#82)

### DIFF
--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import { checkHarness, checkVaultLinks, checkSessionActivity, checkStackedFrontmatter, renderStackedFrontmatterLines, checkUnpricedModels, renderUnpricedModelLines, checkStaleDerivedSections, renderStaleDerivedSectionLines, checkSessionObservability, renderSessionObservabilityLines } from '../hooks/harness-doctor.mjs';
 import { diagnoseManagedWorktrees } from './worktree.mjs';
 import { runVaultHealth } from '../hooks/vault-health.mjs';
+import { augmentVaultHealthWithMemoryScale } from './memory-scale-health.mjs';
 import { checkSyncDefs } from './sync-defs.mjs';
 import { resolveProjectVault } from './project-vault.mjs';
 import { inspectObserverSqlOutbox } from './observer-sql-publish.mjs';
@@ -17,6 +18,12 @@ import { readProjectForValidation } from '../packages/vault/src/validate-memory.
 
 const healthStatusLabel = (status) => ({
   healthy: 'saudável', warning: 'atenção', degraded: 'degradada', blocked: 'bloqueada', legacy: 'legado',
+}[status] || status || 'desconhecido');
+
+const artifactStatusLabel = (status) => ({
+  ok: 'saudável', healthy: 'saudável', warning: 'atenção', degraded: 'degradado',
+  missing: 'ausente', empty: 'vazio', invalid: 'inválido', corrupt: 'corrompido',
+  blocked: 'bloqueado', unknown: 'desconhecido',
 }[status] || status || 'desconhecido');
 
 const metricValue = (value) => value === null || value === undefined || value === '' ? 'n/a' : value;
@@ -49,6 +56,19 @@ export function renderVaultHealthLines(result) {
   );
   const repairableHandoffs = Number(memory.repairableHandoffs || 0);
   lines.push(`  ledger: ${metricValue(memory.ledgerEvents)} evento(s) · outbox: ${metricValue(memory.pendingOutbox)} · candidates: ${metricValue(memory.candidates)} · conflitos: ${metricValue(memory.activeConflicts)}${repairableHandoffs ? ` · handoffs reparáveis: ${repairableHandoffs}` : ''}`);
+  if (memory.scaleSchemaVersion === 1) {
+    lines.push(
+      `  replay: snapshot ${artifactStatusLabel(memory.snapshotStatus)} · cobertos: ${metricValue(memory.snapshotEvents)} evento(s) · tail: ${metricValue(memory.snapshotTailEvents)} evento(s)/${metricValue(memory.snapshotTailBytes)} bytes · ledger no snapshot: ${metricValue(memory.snapshotLedgerBytes)} bytes`,
+    );
+    if (memory.snapshotReason) lines.push(`    ↳ snapshot: ${memory.snapshotReason}`);
+    lines.push(
+      `  segmentos: ${artifactStatusLabel(memory.segmentStatus)} · ${metricValue(memory.segmentCount)} segmento(s) · cobertos: ${metricValue(memory.segmentCoveredEvents)} evento(s)/${metricValue(memory.segmentCoveredBytes)} bytes · pendentes: ${metricValue(memory.segmentPendingEvents)}`,
+    );
+    lines.push(
+      `  rotação: geração ${artifactStatusLabel(memory.generationStatus)} #${metricValue(memory.generation)} · origem: ${metricValue(memory.generationSourceEvents)} · tail ativo: ${metricValue(memory.generationActiveTailEvents)} · journal: ${artifactStatusLabel(memory.rotationJournal)} · receipts: ${metricValue(memory.rotationReceipts)} (${artifactStatusLabel(memory.rotationReceiptCheckpoint)})`,
+    );
+    if (memory.scaleErrorCode) lines.push(`    ↳ escala: ${memory.scaleErrorCode}`);
+  }
   const semanticKeys = memory.semanticActiveKeys || [];
   const semanticProjected = memory.semanticProjectedKeys || [];
   const semanticMissing = memory.semanticMissingKeys || [];
@@ -105,7 +125,10 @@ export function runDoctor(argv) {
   // 1. Session/vault integrity. The standalone hook remains JSON; doctor renders it for humans.
   let health;
   try {
-    health = runVaultHealth({ vaultBase, session });
+    health = augmentVaultHealthWithMemoryScale(
+      runVaultHealth({ vaultBase, session }),
+      vaultBase,
+    );
   } catch (error) {
     health = {
       ok: false,

--- a/src/memory-scale-health.mjs
+++ b/src/memory-scale-health.mjs
@@ -1,0 +1,210 @@
+import {
+  readMemoryLedgerGeneration,
+  readMemoryProjectionSnapshot,
+  readMemoryRotationJournal,
+  readMemoryRotationReceipts,
+  readMemorySegmentManifest,
+} from '../hooks/memory-store.mjs';
+import {
+  quoteCommandArgument,
+  WENDKEEP_COMMAND,
+} from '../hooks/obsidian-common.mjs';
+
+export const MEMORY_SCALE_HEALTH_SCHEMA_VERSION = 1;
+
+function safeReason(value, fallback = '') {
+  const text = String(value || fallback).trim();
+  return text
+    ? text.replace(/[^A-Za-z0-9._:-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 120)
+    : null;
+}
+
+function numberMetric(value) {
+  const number = Number(value || 0);
+  return Number.isSafeInteger(number) && number >= 0 ? number : 0;
+}
+
+export function emptyMemoryScaleMetrics() {
+  return {
+    scaleSchemaVersion: MEMORY_SCALE_HEALTH_SCHEMA_VERSION,
+    scaleStatus: 'unknown',
+    scaleErrorCode: null,
+    snapshotStatus: 'unknown',
+    snapshotReason: null,
+    snapshotEvents: 0,
+    snapshotLedgerBytes: 0,
+    snapshotTailEvents: 0,
+    snapshotTailBytes: 0,
+    segmentStatus: 'unknown',
+    segmentCount: 0,
+    segmentCoveredEvents: 0,
+    segmentCoveredBytes: 0,
+    segmentPendingEvents: 0,
+    generationStatus: 'unknown',
+    generation: 0,
+    generationSourceEvents: 0,
+    generationActiveTailEvents: 0,
+    generationRotatedAt: null,
+    rotationJournal: 'unknown',
+    rotationRecoveryRequired: false,
+    rotationReceiptsStatus: 'unknown',
+    rotationReceipts: 0,
+    rotationReceiptCheckpoint: 'unknown',
+  };
+}
+
+function inspectSnapshot(vaultBase, metrics) {
+  try {
+    const snapshot = readMemoryProjectionSnapshot(vaultBase);
+    const tailStatus = snapshot.status === 'ok' ? snapshot.tail?.status : null;
+    metrics.snapshotStatus = snapshot.status === 'ok' && tailStatus !== 'ok'
+      ? 'invalid'
+      : snapshot.status;
+    metrics.snapshotReason = safeReason(
+      snapshot.reason || snapshot.tail?.reason,
+      metrics.snapshotStatus === 'invalid' ? 'snapshot-tail-unavailable' : '',
+    );
+    if (snapshot.status === 'ok') {
+      metrics.snapshotEvents = numberMetric(snapshot.snapshot?.event_count);
+      metrics.snapshotLedgerBytes = numberMetric(snapshot.snapshot?.ledger_bytes);
+      metrics.snapshotTailEvents = Array.isArray(snapshot.tail?.events)
+        ? snapshot.tail.events.length
+        : 0;
+      metrics.snapshotTailBytes = numberMetric(snapshot.tail?.bytes);
+    }
+  } catch (error) {
+    if (error?.code === 'VAULT_PATH_UNSAFE') throw error;
+    metrics.snapshotStatus = 'invalid';
+    metrics.snapshotReason = safeReason(error?.code, 'snapshot-read-failed');
+  }
+}
+
+function inspectSegments(vaultBase, ledgerEvents, metrics) {
+  try {
+    const manifest = readMemorySegmentManifest(vaultBase);
+    metrics.segmentStatus = manifest.status;
+    if (manifest.status === 'ok') {
+      metrics.segmentCount = numberMetric(manifest.manifest?.segment_count);
+      metrics.segmentCoveredEvents = numberMetric(manifest.manifest?.covered_event_count);
+      metrics.segmentCoveredBytes = numberMetric(manifest.manifest?.covered_bytes);
+    }
+    metrics.segmentPendingEvents = Math.max(
+      0,
+      numberMetric(ledgerEvents) - metrics.segmentCoveredEvents,
+    );
+  } catch (error) {
+    if (error?.code === 'VAULT_PATH_UNSAFE') throw error;
+    metrics.segmentStatus = 'invalid';
+    metrics.scaleErrorCode ||= safeReason(error?.code, 'segment-manifest-read-failed');
+  }
+}
+
+function inspectRotation(vaultBase, ledgerEvents, metrics) {
+  try {
+    const generation = readMemoryLedgerGeneration(vaultBase);
+    metrics.generationStatus = generation.status;
+    if (generation.status === 'ok') {
+      metrics.generation = numberMetric(generation.state?.generation);
+      metrics.generationSourceEvents = numberMetric(generation.state?.source_event_count);
+      metrics.generationActiveTailEvents = Math.max(
+        0,
+        numberMetric(ledgerEvents) - metrics.generationSourceEvents,
+      );
+      metrics.generationRotatedAt = String(generation.state?.rotated_at || '') || null;
+    }
+  } catch (error) {
+    if (error?.code === 'VAULT_PATH_UNSAFE') throw error;
+    metrics.generationStatus = 'invalid';
+    metrics.scaleErrorCode ||= safeReason(error?.code, 'generation-read-failed');
+  }
+
+  try {
+    const journal = readMemoryRotationJournal(vaultBase);
+    metrics.rotationJournal = journal.status === 'ok'
+      ? String(journal.journal?.stage || 'invalid')
+      : journal.status;
+    metrics.rotationRecoveryRequired = journal.status !== 'missing';
+  } catch (error) {
+    if (error?.code === 'VAULT_PATH_UNSAFE') throw error;
+    metrics.rotationJournal = 'invalid';
+    metrics.rotationRecoveryRequired = true;
+    metrics.scaleErrorCode ||= safeReason(error?.code, 'rotation-journal-read-failed');
+  }
+
+  try {
+    const receipts = readMemoryRotationReceipts(vaultBase);
+    metrics.rotationReceiptsStatus = receipts.status;
+    metrics.rotationReceipts = Array.isArray(receipts.receipts)
+      ? receipts.receipts.length
+      : 0;
+    metrics.rotationReceiptCheckpoint = String(receipts.checkpointStatus || 'unknown');
+  } catch (error) {
+    if (error?.code === 'VAULT_PATH_UNSAFE') throw error;
+    metrics.rotationReceiptsStatus = 'invalid';
+    metrics.rotationReceiptCheckpoint = 'invalid';
+    metrics.scaleErrorCode ||= safeReason(error?.code, 'rotation-receipts-read-failed');
+  }
+}
+
+function deriveScaleStatus(metrics) {
+  const invalid = [
+    metrics.snapshotStatus,
+    metrics.segmentStatus,
+    metrics.generationStatus,
+    metrics.rotationJournal,
+    metrics.rotationReceiptsStatus,
+    metrics.rotationReceiptCheckpoint,
+  ].some((status) => ['invalid', 'corrupt', 'blocked'].includes(status));
+  if (invalid || metrics.scaleErrorCode) return 'degraded';
+  if (metrics.rotationRecoveryRequired) return 'warning';
+  return 'healthy';
+}
+
+export function inspectMemoryScaleHealth(vaultBase, { ledgerEvents = 0 } = {}) {
+  const metrics = emptyMemoryScaleMetrics();
+  inspectSnapshot(vaultBase, metrics);
+  inspectSegments(vaultBase, ledgerEvents, metrics);
+  inspectRotation(vaultBase, ledgerEvents, metrics);
+  metrics.scaleStatus = deriveScaleStatus(metrics);
+  return metrics;
+}
+
+function statusCommand(vaultBase) {
+  return `${WENDKEEP_COMMAND} memory status --gate --vault ${quoteCommandArgument(vaultBase)}`;
+}
+
+export function augmentVaultHealthWithMemoryScale(result, vaultBase) {
+  const memory = result?.metrics?.memory;
+  if (!memory || ['legacy', 'blocked'].includes(result.memoryStatus)) return result;
+
+  try {
+    const scale = inspectMemoryScaleHealth(vaultBase, {
+      ledgerEvents: memory.ledgerEvents,
+    });
+    return {
+      ...result,
+      metrics: {
+        ...result.metrics,
+        memory: { ...memory, ...scale },
+      },
+    };
+  } catch (error) {
+    const code = safeReason(error?.code, 'memory-scale-boundary-unsafe');
+    const failure = `Memória: Artefatos de escala da memória estão inseguros ou ilegíveis (${code}). Inspecione com: ${statusCommand(vaultBase)}.`;
+    return {
+      ...result,
+      ok: false,
+      memoryStatus: 'blocked',
+      failures: [...(result.failures || []), failure],
+      metrics: {
+        ...result.metrics,
+        memory: {
+          ...memory,
+          ...emptyMemoryScaleMetrics(),
+          scaleStatus: 'blocked',
+          scaleErrorCode: code,
+        },
+      },
+    };
+  }
+}

--- a/src/observer-snapshot.mjs
+++ b/src/observer-snapshot.mjs
@@ -5,6 +5,7 @@ import { allChangesState } from '../hooks/change-core.mjs';
 import { readControl, readSessionRegistry } from '../hooks/obsidian-common.mjs';
 import { runVaultHealth } from '../hooks/vault-health.mjs';
 import { readProjectForValidation } from '../packages/vault/src/validate-memory.mjs';
+import { augmentVaultHealthWithMemoryScale } from './memory-scale-health.mjs';
 import { inspectSyncOutbox, readLocalSyncState } from './sync-outbox.mjs';
 
 export const OBSERVER_SCHEMA_VERSION = 1;
@@ -25,6 +26,11 @@ function safeText(value, max = MAX_TEXT) {
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, max);
+}
+
+function safeCount(value) {
+  const number = Number(value || 0);
+  return Number.isSafeInteger(number) && number >= 0 ? number : 0;
 }
 
 function isoNow(value) {
@@ -65,9 +71,51 @@ function activeSessionSummary(vaultBase, control, registry) {
   };
 }
 
+function memoryScaleSummary(memory = {}) {
+  if (memory.scaleSchemaVersion !== 1) return null;
+  return {
+    schema_version: 1,
+    status: safeText(memory.scaleStatus || 'unknown', 32),
+    ...(memory.scaleErrorCode ? { error_code: safeText(memory.scaleErrorCode, 120) } : {}),
+    snapshot: {
+      status: safeText(memory.snapshotStatus || 'unknown', 32),
+      ...(memory.snapshotReason ? { reason: safeText(memory.snapshotReason, 120) } : {}),
+      event_count: safeCount(memory.snapshotEvents),
+      ledger_bytes: safeCount(memory.snapshotLedgerBytes),
+      tail_events: safeCount(memory.snapshotTailEvents),
+      tail_bytes: safeCount(memory.snapshotTailBytes),
+    },
+    segments: {
+      status: safeText(memory.segmentStatus || 'unknown', 32),
+      count: safeCount(memory.segmentCount),
+      covered_events: safeCount(memory.segmentCoveredEvents),
+      covered_bytes: safeCount(memory.segmentCoveredBytes),
+      pending_events: safeCount(memory.segmentPendingEvents),
+    },
+    generation: {
+      status: safeText(memory.generationStatus || 'unknown', 32),
+      number: safeCount(memory.generation),
+      source_events: safeCount(memory.generationSourceEvents),
+      active_tail_events: safeCount(memory.generationActiveTailEvents),
+      rotated_at: safeText(memory.generationRotatedAt || '', 40),
+    },
+    rotation: {
+      journal: safeText(memory.rotationJournal || 'unknown', 32),
+      recovery_required: memory.rotationRecoveryRequired === true,
+      receipts_status: safeText(memory.rotationReceiptsStatus || 'unknown', 32),
+      receipts: safeCount(memory.rotationReceipts),
+      receipt_checkpoint: safeText(memory.rotationReceiptCheckpoint || 'unknown', 32),
+    },
+  };
+}
+
 function healthSummary(vaultBase) {
   try {
-    const health = runVaultHealth({ vaultBase });
+    const health = augmentVaultHealthWithMemoryScale(
+      runVaultHealth({ vaultBase }),
+      vaultBase,
+    );
+    const memoryScale = memoryScaleSummary(health.metrics?.memory);
     return {
       ok: health.ok === true,
       status: safeText(health.memoryStatus || (health.ok ? 'healthy' : 'degraded'), 40),
@@ -75,6 +123,7 @@ function healthSummary(vaultBase) {
       warning_count: Array.isArray(health.warnings) ? health.warnings.length : 0,
       registry_sessions: Number(health.metrics?.registrySessions || 0),
       derived_notes: Number(health.metrics?.derivedNotes || 0),
+      ...(memoryScale ? { memory_scale: memoryScale } : {}),
     };
   } catch {
     return {

--- a/tests/doctor-memory-scale-metrics.test.mjs
+++ b/tests/doctor-memory-scale-metrics.test.mjs
@@ -1,0 +1,211 @@
+import assert from 'node:assert/strict';
+import {
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  MEMORY_SNAPSHOT_FILE,
+  enqueueMemoryEvent,
+  projectMemoryOutbox,
+  rotateMemoryLedger,
+  sealMemorySegments,
+} from '../hooks/memory-store.mjs';
+import {
+  augmentVaultHealthWithMemoryScale,
+  inspectMemoryScaleHealth,
+} from '../src/memory-scale-health.mjs';
+import { renderVaultHealthLines } from '../src/doctor.mjs';
+
+const PROJECT_ID = 'doctor-memory-scale';
+
+function scratch() {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-doctor-memory-scale-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  writeFileSync(
+    join(vault, '.brain', 'PROJECT.json'),
+    `${JSON.stringify({ projectId: PROJECT_ID }, null, 2)}\n`,
+  );
+  return vault;
+}
+
+function memoryEvent(index) {
+  const suffix = String(index).padStart(3, '0');
+  return {
+    v: 1,
+    project_id: PROJECT_ID,
+    event_id: `mem-doctor-scale-${suffix}`,
+    memory_key: 'next.doctor-scale',
+    operation: 'assert',
+    value: `doctor-scale-${suffix}`,
+    authority: 'verified',
+    canonical_session_id: 'doctor-scale-session',
+    activation_id: 'doctor-scale-activation',
+    activation_epoch: 1,
+    turn_sequence: index,
+    source_turn_id: `doctor-scale-turn-${suffix}`,
+    observed_at: `2026-08-26T04:${String(index).padStart(2, '0')}:00.000Z`,
+    evidence: ['doctor-memory-scale-metrics.test.mjs'],
+  };
+}
+
+function seed(vault, from, to, { snapshot = false } = {}) {
+  for (let index = from; index <= to; index += 1) {
+    enqueueMemoryEvent(vault, memoryEvent(index));
+  }
+  return projectMemoryOutbox(vault, snapshot ? { snapshot: { force: true } } : {});
+}
+
+function baseHealth(ledgerEvents) {
+  return {
+    ok: true,
+    session: '',
+    failures: [],
+    warnings: [],
+    memoryStatus: 'healthy',
+    metrics: {
+      registrySessions: 0,
+      derivedNotes: 0,
+      memory: {
+        schemaVersion: 2,
+        revision: ledgerEvents,
+        eventCursor: `mem-doctor-scale-${String(ledgerEvents).padStart(3, '0')}`,
+        stateHash: 'a'.repeat(64),
+        ledgerEvents,
+        pendingOutbox: 0,
+        candidates: 0,
+        activeConflicts: 0,
+        repairableHandoffs: 0,
+        semanticCode: 'healthy',
+        semanticActiveKeys: ['next.doctor-scale'],
+        semanticProjectedKeys: ['next.doctor-scale'],
+        semanticMissingKeys: [],
+      },
+    },
+  };
+}
+
+function byteSnapshot(vault) {
+  const entries = [];
+  const walk = (dir, rel = '') => {
+    for (const name of readdirSync(dir).sort()) {
+      const path = join(dir, name);
+      const itemRel = rel ? `${rel}/${name}` : name;
+      if (statSync(path).isDirectory()) walk(path, itemRel);
+      else entries.push([itemRel, readFileSync(path)]);
+    }
+  };
+  walk(join(vault, '.brain'));
+  return entries;
+}
+
+test('[req:MEM-SCALE-3] doctor exposes snapshot, segment and generation coverage read-only', () => {
+  const vault = scratch();
+  try {
+    const projected = seed(vault, 1, 4, { snapshot: true });
+    assert.equal(projected.snapshotStatus, 'written');
+    const sealed = sealMemorySegments(vault, {
+      maxEvents: 2,
+      maxBytes: 1024 * 1024,
+      force: true,
+    });
+    assert.equal(sealed.coveredEvents, 4);
+
+    const before = byteSnapshot(vault);
+    const initial = augmentVaultHealthWithMemoryScale(baseHealth(4), vault);
+    assert.deepEqual(byteSnapshot(vault), before, 'doctor scale inspection must be read-only');
+    assert.equal(initial.metrics.memory.scaleStatus, 'healthy');
+    assert.equal(initial.metrics.memory.snapshotStatus, 'ok');
+    assert.equal(initial.metrics.memory.snapshotEvents, 4);
+    assert.equal(initial.metrics.memory.snapshotTailEvents, 0);
+    assert.equal(initial.metrics.memory.segmentStatus, 'ok');
+    assert.equal(initial.metrics.memory.segmentCount, 2);
+    assert.equal(initial.metrics.memory.segmentCoveredEvents, 4);
+    assert.equal(initial.metrics.memory.segmentPendingEvents, 0);
+    assert.equal(initial.metrics.memory.generationStatus, 'missing');
+    assert.equal(initial.metrics.memory.rotationJournal, 'missing');
+    assert.equal(initial.metrics.memory.rotationReceipts, 0);
+
+    const rendered = renderVaultHealthLines(initial).join('\n');
+    assert.match(rendered, /replay: snapshot saudável/i);
+    assert.match(rendered, /segmentos: saudável.*2 segmento\(s\).*cobertos: 4/i);
+    assert.match(rendered, /rotação: geração ausente #0.*journal: ausente/i);
+
+    const rotated = rotateMemoryLedger(vault, {
+      apply: true,
+      reason: 'validar métricas de escala do doctor',
+      authorizedBy: 'doctor-scale-test',
+      now: '2026-08-26T05:00:00.000Z',
+    });
+    assert.equal(rotated.status, 'rotated');
+
+    const afterRotation = augmentVaultHealthWithMemoryScale(baseHealth(4), vault);
+    assert.equal(afterRotation.metrics.memory.generationStatus, 'ok');
+    assert.equal(afterRotation.metrics.memory.generation, 1);
+    assert.equal(afterRotation.metrics.memory.generationSourceEvents, 4);
+    assert.equal(afterRotation.metrics.memory.generationActiveTailEvents, 0);
+    assert.equal(afterRotation.metrics.memory.rotationJournal, 'missing');
+    assert.equal(afterRotation.metrics.memory.rotationRecoveryRequired, false);
+    assert.equal(afterRotation.metrics.memory.rotationReceiptsStatus, 'ok');
+    assert.equal(afterRotation.metrics.memory.rotationReceipts, 1);
+    assert.equal(afterRotation.metrics.memory.rotationReceiptCheckpoint, 'ok');
+
+    const incremental = seed(vault, 5, 5);
+    assert.equal(incremental.replayMode, 'snapshot-tail');
+    assert.equal(incremental.replayedEvents, 1);
+    const withTail = augmentVaultHealthWithMemoryScale(baseHealth(5), vault);
+    assert.equal(withTail.metrics.memory.snapshotEvents, 4);
+    assert.equal(withTail.metrics.memory.snapshotTailEvents, 1);
+    assert.equal(withTail.metrics.memory.segmentCoveredEvents, 4);
+    assert.equal(withTail.metrics.memory.segmentPendingEvents, 1);
+    assert.equal(withTail.metrics.memory.generationActiveTailEvents, 1);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:MEM-SCALE-4] unsafe optional scale artifact blocks doctor with a safe command', (t) => {
+  const vault = scratch();
+  const outside = mkdtempSync(join(tmpdir(), 'wk-doctor-memory-scale-outside-'));
+  try {
+    seed(vault, 1, 1, { snapshot: true });
+    const snapshot = join(vault, '.brain', MEMORY_SNAPSHOT_FILE);
+    const alias = join(outside, 'snapshot-alias.json');
+    try {
+      linkSync(snapshot, alias);
+    } catch (error) {
+      if (['EPERM', 'EACCES', 'ENOTSUP', 'EXDEV'].includes(error?.code)) {
+        t.skip(`hardlinks indisponíveis neste filesystem: ${error.code}`);
+        return;
+      }
+      throw error;
+    }
+    const before = byteSnapshot(vault);
+
+    assert.throws(
+      () => inspectMemoryScaleHealth(vault, { ledgerEvents: 1 }),
+      (error) => error?.code === 'VAULT_PATH_UNSAFE',
+    );
+    const result = augmentVaultHealthWithMemoryScale(baseHealth(1), vault);
+    assert.equal(result.ok, false);
+    assert.equal(result.memoryStatus, 'blocked');
+    assert.equal(result.metrics.memory.scaleStatus, 'blocked');
+    assert.match(result.failures.join('\n'), /Artefatos de escala da memória.*inseguros/i);
+    assert.ok(result.failures.join('\n').includes(
+      `npx --no-install wendkeep memory status --gate --vault "${vault}"`,
+    ));
+    assert.deepEqual(byteSnapshot(vault), before, 'blocked inspection must remain read-only');
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});

--- a/tests/observer-memory-scale-metrics.test.mjs
+++ b/tests/observer-memory-scale-metrics.test.mjs
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict';
+import {
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  MEMORY_SNAPSHOT_FILE,
+  enqueueMemoryEvent,
+  projectMemoryOutbox,
+  rotateMemoryLedger,
+  sealMemorySegments,
+} from '../hooks/memory-store.mjs';
+import {
+  buildProjectSnapshot,
+  validateObserverSnapshot,
+} from '../src/observer-snapshot.mjs';
+import {
+  ensureObserverDatabase,
+  readSqlProjectOverview,
+  registerSqlProject,
+  upsertSqlProjectSnapshot,
+} from '../src/observer-sql-store.mjs';
+import { renderCoreSkeleton } from '../src/validate-core.mjs';
+import {
+  makeDataDir,
+  makeObserverFixture,
+} from './helpers/observer-fixture.mjs';
+
+const PROJECT_ID = 'observer-memory-scale';
+
+function memoryEvent(index) {
+  const suffix = String(index).padStart(3, '0');
+  return {
+    v: 1,
+    project_id: PROJECT_ID,
+    event_id: `mem-observer-scale-${suffix}`,
+    memory_key: 'next.observer-scale',
+    operation: 'assert',
+    value: `observer-scale-${suffix}`,
+    authority: 'verified',
+    canonical_session_id: 'fixture-session',
+    activation_id: 'observer-scale-activation',
+    activation_epoch: 1,
+    turn_sequence: index,
+    source_turn_id: `observer-scale-turn-${suffix}`,
+    observed_at: `2026-08-26T06:${String(index).padStart(2, '0')}:00.000Z`,
+    evidence: ['observer-memory-scale-metrics.test.mjs'],
+  };
+}
+
+function prepareFixture() {
+  const fixture = makeObserverFixture({
+    projectId: PROJECT_ID,
+    projectName: 'Observer Memory Scale',
+  });
+  writeFileSync(
+    join(fixture.vaultBase, '.brain', 'CORE.md'),
+    renderCoreSkeleton(),
+  );
+  return fixture;
+}
+
+function seed(vaultBase, index, { snapshot = false } = {}) {
+  enqueueMemoryEvent(vaultBase, memoryEvent(index));
+  return projectMemoryOutbox(
+    vaultBase,
+    snapshot ? { snapshot: { force: true } } : {},
+  );
+}
+
+test('[req:OBS-SCALE-1] Observer persists the same bounded memory scale metrics as doctor', () => {
+  const fixture = prepareFixture();
+  const dataDir = makeDataDir();
+  let db;
+  try {
+    const first = seed(fixture.vaultBase, 1, { snapshot: true });
+    assert.equal(first.snapshotStatus, 'written');
+    const sealed = sealMemorySegments(fixture.vaultBase, {
+      maxEvents: 1,
+      maxBytes: 1024 * 1024,
+      force: true,
+    });
+    assert.equal(sealed.coveredEvents, 1);
+    const rotated = rotateMemoryLedger(fixture.vaultBase, {
+      apply: true,
+      reason: 'validar métricas de escala no Observer',
+      authorizedBy: 'observer-scale-test',
+      now: '2026-08-26T06:30:00.000Z',
+    });
+    assert.equal(rotated.status, 'rotated');
+
+    const second = seed(fixture.vaultBase, 2);
+    assert.equal(second.replayMode, 'snapshot-tail');
+    assert.equal(second.replayedEvents, 1);
+
+    const snapshot = buildProjectSnapshot({
+      vaultBase: fixture.vaultBase,
+      projectRoot: fixture.projectRoot,
+      now: '2026-08-26T07:00:00.000Z',
+    });
+    const scale = snapshot.health.memory_scale;
+    assert.equal(scale.schema_version, 1);
+    assert.equal(scale.status, 'healthy');
+    assert.deepEqual(scale.snapshot, {
+      status: 'ok',
+      event_count: 1,
+      ledger_bytes: scale.snapshot.ledger_bytes,
+      tail_events: 1,
+      tail_bytes: scale.snapshot.tail_bytes,
+    });
+    assert.ok(scale.snapshot.ledger_bytes > 0);
+    assert.ok(scale.snapshot.tail_bytes > 0);
+    assert.deepEqual(scale.segments, {
+      status: 'ok',
+      count: 1,
+      covered_events: 1,
+      covered_bytes: scale.segments.covered_bytes,
+      pending_events: 1,
+    });
+    assert.ok(scale.segments.covered_bytes > 0);
+    assert.deepEqual(scale.generation, {
+      status: 'ok',
+      number: 1,
+      source_events: 1,
+      active_tail_events: 1,
+      rotated_at: '2026-08-26T06:30:00.000Z',
+    });
+    assert.deepEqual(scale.rotation, {
+      journal: 'missing',
+      recovery_required: false,
+      receipts_status: 'ok',
+      receipts: 1,
+      receipt_checkpoint: 'ok',
+    });
+    assert.equal(validateObserverSnapshot(snapshot, { projectId: PROJECT_ID }).ok, true);
+
+    const serialized = JSON.stringify(snapshot);
+    assert.equal(serialized.includes(fixture.vaultBase), false);
+    assert.equal(serialized.includes('observer-scale-001'), false);
+    assert.equal(serialized.includes('observer-scale-002'), false);
+
+    db = ensureObserverDatabase(dataDir);
+    const registered = registerSqlProject(db, {
+      projectId: PROJECT_ID,
+      projectName: fixture.projectName,
+      wendkeepVersion: snapshot.wendkeep_version,
+    });
+    assert.equal(registered.registered, true);
+    assert.equal(upsertSqlProjectSnapshot(db, snapshot).accepted, true);
+    const overview = readSqlProjectOverview(db, PROJECT_ID);
+    assert.deepEqual(overview.snapshot.health.memory_scale, scale);
+  } finally {
+    db?.close();
+    fixture.cleanup();
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-SCALE-2] unsafe scale artifacts publish only blocked sanitized metadata', (t) => {
+  const fixture = prepareFixture();
+  const outside = mkdtempSync(join(tmpdir(), 'wk-observer-scale-outside-'));
+  try {
+    seed(fixture.vaultBase, 1, { snapshot: true });
+    const snapshotPath = join(fixture.vaultBase, '.brain', MEMORY_SNAPSHOT_FILE);
+    try {
+      linkSync(snapshotPath, join(outside, 'snapshot-hardlink.json'));
+    } catch (error) {
+      if (['EPERM', 'EACCES', 'ENOTSUP', 'EXDEV'].includes(error?.code)) {
+        t.skip(`hardlinks indisponíveis neste filesystem: ${error.code}`);
+        return;
+      }
+      throw error;
+    }
+
+    const snapshot = buildProjectSnapshot({
+      vaultBase: fixture.vaultBase,
+      projectRoot: fixture.projectRoot,
+      now: '2026-08-26T07:30:00.000Z',
+    });
+    assert.equal(snapshot.health.ok, false);
+    assert.equal(snapshot.health.status, 'blocked');
+    assert.equal(snapshot.health.memory_scale.status, 'blocked');
+    assert.equal(snapshot.health.memory_scale.error_code, 'VAULT_PATH_UNSAFE');
+    assert.equal(validateObserverSnapshot(snapshot, { projectId: PROJECT_ID }).ok, true);
+
+    const serialized = JSON.stringify(snapshot);
+    assert.equal(serialized.includes(fixture.vaultBase), false);
+    assert.equal(serialized.includes(outside), false);
+    assert.equal(serialized.includes('snapshot-hardlink.json'), false);
+  } finally {
+    fixture.cleanup();
+    rmSync(outside, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Contexto

Décimo slice da issue #82, empilhado sobre a PR #119.

O `wendkeep doctor` já expõe snapshot, tail, segmentos e gerações do ledger. Este PR publica a mesma visão sanitizada no snapshot operacional do Observer, preservando a fronteira de privacidade e a autoridade local do Vault.

## Entregue

- `health.memory_scale` versionado no snapshot do Observer;
- métricas sanitizadas para:
  - snapshot: estado, cobertura, bytes e tail;
  - segmentos: quantidade, cobertura, bytes e pendências;
  - geração: número, origem, tail ativo e data da rotação;
  - rotação: journal, recovery, receipts e checkpoint;
- persistência integral dessas métricas em `project_snapshots` e leitura via overview;
- ausência de paths, event IDs, valores de memória, conteúdo do ledger ou nomes de arquivos;
- boundary fail-closed: artefato opcional inseguro publica somente estado `blocked` e código seguro;
- limite existente de 32 KiB do snapshot preservado.

## Contrato de privacidade

O Observer recebe somente contagens, estados, bytes e timestamps. Não recebe:

- conteúdo de `CORE.md` ou `SHARED_MEMORY.md`;
- eventos ou valores do ledger;
- IDs causais de memória;
- paths absolutos do Vault;
- nomes de arquivos físicos de snapshot, segmento, backup ou receipt.

## Testes

- snapshot real com geração 1, um segmento selado e um evento de tail;
- persistência SQLite e leitura pelo `readSqlProjectOverview()`;
- validação do snapshot sanitizado;
- ausência de paths e valores causais no JSON;
- hardlink em `MEMORY_SNAPSHOT.json` reduzido a metadata bloqueada e sanitizada.

## Escopo

- não altera schema SQL: os dados permanecem no JSON versionado de `project_snapshots`;
- não altera ingest incremental, documentos, transcripts ou FTS;
- não cria ou modifica artefatos de memória;
- não altera versão, changelog, release ou workflows.

Draft enquanto a suíte canônica valida a integração sobre #119.