### PR TITLE
feat: expor saúde do índice de recall no doctor (#82)

### DIFF
--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -134,7 +134,7 @@ export function runDoctor(argv) {
     const strictDebt = strict && (
       (health.warnings || []).length > 0
       || !['healthy'].includes(health.memoryStatus)
-      || recall.status !== 'healthy'
+      || !['healthy', 'missing'].includes(recall.status)
     );
     process.stdout.write(`\n[core] ${healthStatus || recallStatus ? 'erro estrutural' : health.memoryStatus === 'degraded' ? 'saudável com memória degradada' : 'saudável'}\n`);
     return healthStatus || recallStatus || strictDebt ? 1 : 0;
@@ -229,7 +229,7 @@ export function runDoctor(argv) {
   const strictDebt = strict && (
     (scope !== 'runtime' && (health.warnings || []).length)
     || (scope !== 'runtime' && health.memoryStatus !== 'healthy')
-    || (scope !== 'runtime' && recall.status !== 'healthy')
+    || (scope !== 'runtime' && !['healthy', 'missing'].includes(recall.status))
     || attention.length
     || repairable.length
     || warnings.length

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -4,6 +4,10 @@ import { resolve } from 'node:path';
 import { checkHarness, checkVaultLinks, checkSessionActivity, checkStackedFrontmatter, renderStackedFrontmatterLines, checkUnpricedModels, renderUnpricedModelLines, checkStaleDerivedSections, renderStaleDerivedSectionLines, checkSessionObservability, renderSessionObservabilityLines } from '../hooks/harness-doctor.mjs';
 import { diagnoseManagedWorktrees } from './worktree.mjs';
 import { runVaultHealth } from '../hooks/vault-health.mjs';
+import {
+  inspectEvidenceSearchHealth,
+  renderEvidenceSearchHealthLines,
+} from './evidence-search-health.mjs';
 import { checkSyncDefs } from './sync-defs.mjs';
 import { resolveProjectVault } from './project-vault.mjs';
 import { inspectObserverSqlOutbox } from './observer-sql-publish.mjs';
@@ -116,16 +120,24 @@ export function runDoctor(argv) {
       memoryStatus: 'blocked',
     };
   }
-  if (scope !== 'runtime') process.stdout.write(`${renderVaultHealthLines(health).join('\n')}\n`);
+  const recall = scope === 'runtime'
+    ? { status: 'skipped' }
+    : inspectEvidenceSearchHealth(vaultBase);
+  if (scope !== 'runtime') {
+    process.stdout.write(`${renderVaultHealthLines(health).join('\n')}\n`);
+    process.stdout.write(`${renderEvidenceSearchHealthLines(recall).join('\n')}\n`);
+  }
   const healthStatus = health.ok ? 0 : 1;
+  const recallStatus = recall.status === 'blocked' ? 1 : 0;
 
   if (scope === 'core') {
     const strictDebt = strict && (
       (health.warnings || []).length > 0
       || !['healthy'].includes(health.memoryStatus)
+      || recall.status !== 'healthy'
     );
-    process.stdout.write(`\n[core] ${healthStatus ? 'erro estrutural' : health.memoryStatus === 'degraded' ? 'saudável com memória degradada' : 'saudável'}\n`);
-    return healthStatus || strictDebt ? 1 : 0;
+    process.stdout.write(`\n[core] ${healthStatus || recallStatus ? 'erro estrutural' : health.memoryStatus === 'degraded' ? 'saudável com memória degradada' : 'saudável'}\n`);
+    return healthStatus || recallStatus || strictDebt ? 1 : 0;
   }
 
   // 2. Harness integrity (Wave B).
@@ -217,6 +229,7 @@ export function runDoctor(argv) {
   const strictDebt = strict && (
     (scope !== 'runtime' && (health.warnings || []).length)
     || (scope !== 'runtime' && health.memoryStatus !== 'healthy')
+    || (scope !== 'runtime' && recall.status !== 'healthy')
     || attention.length
     || repairable.length
     || warnings.length
@@ -233,5 +246,5 @@ export function runDoctor(argv) {
     || (staleDerived.notes || staleDerived.items || []).length
     || !observability.ok
   );
-  return (scope !== 'runtime' && healthStatus !== 0) || errors.length || strictDebt ? 1 : 0;
+  return (scope !== 'runtime' && (healthStatus !== 0 || recallStatus !== 0)) || errors.length || strictDebt ? 1 : 0;
 }

--- a/src/evidence-search-health.mjs
+++ b/src/evidence-search-health.mjs
@@ -1,0 +1,221 @@
+import { statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  EVIDENCE_INDEX_FILE,
+} from '../packages/vault/src/evidence-recall.mjs';
+import {
+  EVIDENCE_INDEX_STATE_FILE,
+  loadEvidenceIndexState,
+} from '../packages/vault/src/evidence-index-store.mjs';
+import {
+  EVIDENCE_SEARCH_STATE_FILE,
+  evidenceSearchSqliteAvailable,
+  loadEvidenceSearchState,
+} from '../packages/vault/src/evidence-search-index.mjs';
+import { assertVaultPathSafe } from '../packages/vault/src/vault-path-safety.mjs';
+
+export const EVIDENCE_SEARCH_HEALTH_SCHEMA_VERSION = 1;
+
+function brainDir(vaultBase) {
+  return join(vaultBase, '.brain');
+}
+
+function nsText(value, fallbackMs = 0) {
+  if (typeof value === 'bigint') return value.toString();
+  return BigInt(Math.max(0, Math.trunc(Number(fallbackMs || 0) * 1_000_000))).toString();
+}
+
+function fileInfo(vaultBase, path, label) {
+  let checked = assertVaultPathSafe(vaultBase, path, {
+    expectedType: 'file',
+    label,
+  });
+  if (!checked.exists) return { exists: false, bytes: 0, fingerprint: null };
+  checked = assertVaultPathSafe(vaultBase, checked.target, {
+    allowMissing: false,
+    expectedType: 'file',
+    label,
+  });
+  const stat = statSync(checked.target, { bigint: true });
+  return {
+    exists: true,
+    bytes: Number(stat.size),
+    fingerprint: {
+      size: stat.size.toString(),
+      mtime_ns: nsText(stat.mtimeNs, stat.mtimeMs),
+      ctime_ns: nsText(stat.ctimeNs, stat.ctimeMs),
+    },
+  };
+}
+
+function sameFingerprint(left, right) {
+  if (left === null || right === null) return left === right;
+  return Boolean(left && right)
+    && String(left.size) === String(right.size)
+    && String(left.mtime_ns) === String(right.mtime_ns)
+    && String(left.ctime_ns) === String(right.ctime_ns);
+}
+
+function safeCode(value, fallback = '') {
+  const text = String(value || fallback).trim();
+  return text
+    ? text.replace(/[^A-Za-z0-9._:-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 120)
+    : null;
+}
+
+function artifactInfo(vaultBase, artifact, kind) {
+  if (!artifact) {
+    return { status: 'not-built', bytes: 0, current: false };
+  }
+  const path = join(brainDir(vaultBase), ...String(artifact.path || '').split('/'));
+  const file = fileInfo(vaultBase, path, `artefato ${kind} da busca de evidências`);
+  if (!file.exists) return { status: 'missing', bytes: 0, current: false };
+  const current = sameFingerprint(artifact.fingerprint, file.fingerprint);
+  return {
+    status: current ? 'current' : 'stale',
+    bytes: file.bytes,
+    current,
+  };
+}
+
+export function emptyEvidenceSearchHealth() {
+  return {
+    schemaVersion: EVIDENCE_SEARCH_HEALTH_SCHEMA_VERSION,
+    status: 'unknown',
+    errorCode: null,
+    authorityStatus: 'unknown',
+    authorityBytes: 0,
+    incrementalStateStatus: 'unknown',
+    incrementalStateBytes: 0,
+    documentCount: 0,
+    searchStateStatus: 'unknown',
+    searchStateBytes: 0,
+    rowCount: 0,
+    sourceIndexCurrent: false,
+    sourceStateCurrent: false,
+    lexicalStatus: 'unknown',
+    lexicalBytes: 0,
+    sqliteStatus: 'unknown',
+    sqliteBytes: 0,
+    sqliteCapability: false,
+    backend: 'unavailable',
+  };
+}
+
+function deriveStatus(metrics) {
+  if (metrics.authorityStatus === 'missing') return 'missing';
+  if (metrics.incrementalStateStatus === 'invalid'
+      || metrics.searchStateStatus === 'invalid') return 'degraded';
+  if (metrics.searchStateStatus !== 'current') return 'warning';
+  if (metrics.lexicalStatus !== 'current') return 'degraded';
+  return 'healthy';
+}
+
+export function inspectEvidenceSearchHealth(vaultBase) {
+  const metrics = emptyEvidenceSearchHealth();
+  try {
+    const brain = brainDir(vaultBase);
+    const authority = fileInfo(
+      vaultBase,
+      join(brain, EVIDENCE_INDEX_FILE),
+      'autoridade EVIDENCE_INDEX.jsonl',
+    );
+    const incrementalFile = fileInfo(
+      vaultBase,
+      join(brain, EVIDENCE_INDEX_STATE_FILE),
+      'estado incremental EVIDENCE_INDEX_STATE.json',
+    );
+    const searchFile = fileInfo(
+      vaultBase,
+      join(brain, EVIDENCE_SEARCH_STATE_FILE),
+      'estado derivado EVIDENCE_SEARCH_STATE.json',
+    );
+
+    metrics.authorityStatus = authority.exists ? 'present' : 'missing';
+    metrics.authorityBytes = authority.bytes;
+    metrics.incrementalStateBytes = incrementalFile.bytes;
+    metrics.searchStateBytes = searchFile.bytes;
+    metrics.sqliteCapability = evidenceSearchSqliteAvailable();
+
+    const incremental = incrementalFile.exists ? loadEvidenceIndexState(vaultBase) : null;
+    metrics.incrementalStateStatus = incrementalFile.exists
+      ? (incremental ? 'ok' : 'invalid')
+      : 'missing';
+    metrics.documentCount = incremental
+      ? Object.keys(incremental.documents || {}).length
+      : 0;
+
+    const state = searchFile.exists ? loadEvidenceSearchState(vaultBase) : null;
+    if (!searchFile.exists) {
+      metrics.searchStateStatus = 'missing';
+      metrics.lexicalStatus = 'not-built';
+      metrics.sqliteStatus = 'not-built';
+      metrics.backend = authority.exists ? 'lexical-ephemeral' : 'unavailable';
+      metrics.status = deriveStatus(metrics);
+      return metrics;
+    }
+    if (!state) {
+      metrics.searchStateStatus = 'invalid';
+      metrics.lexicalStatus = 'unknown';
+      metrics.sqliteStatus = 'unknown';
+      metrics.backend = authority.exists ? 'lexical-ephemeral' : 'unavailable';
+      metrics.status = deriveStatus(metrics);
+      return metrics;
+    }
+
+    metrics.rowCount = Number(state.row_count || 0);
+    metrics.sourceIndexCurrent = sameFingerprint(state.source?.index, authority.fingerprint);
+    metrics.sourceStateCurrent = sameFingerprint(
+      state.source?.state ?? null,
+      incrementalFile.fingerprint,
+    );
+    const lexical = artifactInfo(vaultBase, state.lexical, 'lexical');
+    const sqlite = artifactInfo(vaultBase, state.sqlite, 'SQLite FTS');
+    metrics.lexicalStatus = lexical.status;
+    metrics.lexicalBytes = lexical.bytes;
+    metrics.sqliteStatus = sqlite.status;
+    metrics.sqliteBytes = sqlite.bytes;
+
+    const sourceCurrent = metrics.sourceIndexCurrent && metrics.sourceStateCurrent;
+    const artifactsCurrent = lexical.current && (!state.sqlite || sqlite.current);
+    metrics.searchStateStatus = sourceCurrent && artifactsCurrent ? 'current' : 'stale';
+    metrics.backend = metrics.searchStateStatus === 'current'
+      && sqlite.current
+      && metrics.sqliteCapability
+      ? 'sqlite-fts5'
+      : metrics.searchStateStatus === 'current' && lexical.current
+        ? 'lexical-sidecar'
+        : authority.exists
+          ? 'lexical-ephemeral'
+          : 'unavailable';
+    metrics.status = deriveStatus(metrics);
+    return metrics;
+  } catch (error) {
+    return {
+      ...metrics,
+      status: 'blocked',
+      errorCode: safeCode(error?.code, 'EVIDENCE_SEARCH_HEALTH_UNSAFE'),
+    };
+  }
+}
+
+const statusLabel = (status) => ({
+  healthy: 'saudável', warning: 'atenção', degraded: 'degradado', blocked: 'bloqueado',
+  missing: 'ausente', current: 'atual', stale: 'stale', present: 'presente', ok: 'saudável',
+  invalid: 'inválido', 'not-built': 'não construído', unknown: 'desconhecido',
+}[status] || status || 'desconhecido');
+
+export function renderEvidenceSearchHealthLines(metrics) {
+  const lines = [
+    `[recall] ${statusLabel(metrics.status)} — backend: ${metrics.backend} · SQLite/FTS5: ${metrics.sqliteCapability ? 'disponível' : 'indisponível'}`,
+    `  autoridade: ${statusLabel(metrics.authorityStatus)} · ${metrics.authorityBytes} bytes · documentos: ${metrics.documentCount} · chunks: ${metrics.rowCount}`,
+    `  incremental: ${statusLabel(metrics.incrementalStateStatus)} · ${metrics.incrementalStateBytes} bytes · busca: ${statusLabel(metrics.searchStateStatus)} · ${metrics.searchStateBytes} bytes`,
+    `  lexical: ${statusLabel(metrics.lexicalStatus)} · ${metrics.lexicalBytes} bytes · SQLite: ${statusLabel(metrics.sqliteStatus)} · ${metrics.sqliteBytes} bytes`,
+  ];
+  if (metrics.searchStateStatus === 'stale' || metrics.searchStateStatus === 'missing') {
+    lines.push('  ! o próximo recall pode reconstruir o índice derivado a partir da autoridade JSONL');
+  }
+  if (metrics.errorCode) lines.push(`  ✗ ${metrics.errorCode}`);
+  return lines;
+}

--- a/tests/doctor-evidence-search-metrics.test.mjs
+++ b/tests/doctor-evidence-search-metrics.test.mjs
@@ -1,0 +1,176 @@
+import assert from 'node:assert/strict';
+import {
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  loadEvidenceSearchState,
+  refreshEvidenceIndex,
+  refreshEvidenceSearchIndex,
+} from '../hooks/evidence-recall.mjs';
+import {
+  inspectEvidenceSearchHealth,
+  renderEvidenceSearchHealthLines,
+} from '../src/evidence-search-health.mjs';
+
+function scratch() {
+  const vault = mkdtempSync(join(tmpdir(), 'wk-doctor-evidence-search-'));
+  mkdirSync(join(vault, '.brain'), { recursive: true });
+  mkdirSync(join(vault, '04-Decisões'), { recursive: true });
+  writeFileSync(
+    join(vault, '.brain', 'PROJECT.json'),
+    `${JSON.stringify({ projectId: 'doctor-evidence-search' }, null, 2)}\n`,
+  );
+  return vault;
+}
+
+function writeDecision(vault, body) {
+  const path = join(vault, '04-Decisões', 'ADR-busca.md');
+  writeFileSync(path, [
+    '---',
+    'title: Métrica de recall',
+    'authority: verified',
+    'validity: active',
+    'date: 2026-08-27',
+    '---',
+    '# Métrica de recall',
+    '',
+    '## Evidência',
+    '',
+    body,
+    '',
+  ].join('\n'));
+  return path;
+}
+
+function build(vault) {
+  const index = refreshEvidenceIndex(vault);
+  const search = refreshEvidenceSearchIndex(vault, index.chunks, {
+    force: true,
+    sqlite: 'off',
+  });
+  return { index, search };
+}
+
+function byteSnapshot(root) {
+  const entries = [];
+  const walk = (dir, rel = '') => {
+    for (const name of readdirSync(dir).sort()) {
+      const path = join(dir, name);
+      const itemRel = rel ? `${rel}/${name}` : name;
+      if (statSync(path).isDirectory()) walk(path, itemRel);
+      else entries.push([itemRel, readFileSync(path)]);
+    }
+  };
+  walk(root);
+  return entries;
+}
+
+test('[req:RECALL-10] doctor reports current authority and bounded search artifacts read-only', () => {
+  const vault = scratch();
+  try {
+    writeDecision(vault, 'A evidência contém marcador-doctor-recall.');
+    const built = build(vault);
+    assert.equal(built.search.sqlite_available, false);
+    const before = byteSnapshot(vault);
+
+    const health = inspectEvidenceSearchHealth(vault);
+    assert.deepEqual(byteSnapshot(vault), before, 'recall health inspection must be read-only');
+    assert.equal(health.schemaVersion, 1);
+    assert.equal(health.status, 'healthy');
+    assert.equal(health.authorityStatus, 'present');
+    assert.ok(health.authorityBytes > 0);
+    assert.equal(health.incrementalStateStatus, 'ok');
+    assert.equal(health.documentCount, 1);
+    assert.equal(health.searchStateStatus, 'current');
+    assert.equal(health.rowCount, built.index.chunks.length);
+    assert.equal(health.sourceIndexCurrent, true);
+    assert.equal(health.sourceStateCurrent, true);
+    assert.equal(health.lexicalStatus, 'current');
+    assert.ok(health.lexicalBytes > health.authorityBytes);
+    assert.equal(health.sqliteStatus, 'not-built');
+    assert.equal(health.backend, 'lexical-sidecar');
+
+    const rendered = renderEvidenceSearchHealthLines(health).join('\n');
+    assert.match(rendered, /\[recall\] saudável/i);
+    assert.match(rendered, /backend: lexical-sidecar/i);
+    assert.match(rendered, /documentos: 1/i);
+    assert.match(rendered, /lexical: atual/i);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:RECALL-10] source changes expose stale derived search without rebuilding it', () => {
+  const vault = scratch();
+  try {
+    const document = writeDecision(vault, 'A evidência contém sinal-antigo-doctor.');
+    build(vault);
+    const stateBefore = readFileSync(join(vault, '.brain', 'EVIDENCE_SEARCH_STATE.json'));
+
+    writeDecision(vault, 'A evidência agora contém sinal-novo-doctor.');
+    refreshEvidenceIndex(vault);
+    const health = inspectEvidenceSearchHealth(vault);
+
+    assert.equal(health.status, 'warning');
+    assert.equal(health.searchStateStatus, 'stale');
+    assert.equal(health.sourceIndexCurrent, false);
+    assert.equal(health.backend, 'lexical-ephemeral');
+    assert.deepEqual(
+      readFileSync(join(vault, '.brain', 'EVIDENCE_SEARCH_STATE.json')),
+      stateBefore,
+      'doctor must not rebuild stale search state',
+    );
+    assert.ok(statSync(document).isFile());
+    assert.match(
+      renderEvidenceSearchHealthLines(health).join('\n'),
+      /próximo recall pode reconstruir/i,
+    );
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+});
+
+test('[req:RECALL-10] unsafe derived artifact blocks recall diagnostics without leaking a path', (t) => {
+  const vault = scratch();
+  const outside = mkdtempSync(join(tmpdir(), 'wk-doctor-evidence-search-outside-'));
+  try {
+    writeDecision(vault, 'A evidência contém marcador-hardlink-recall.');
+    build(vault);
+    const state = loadEvidenceSearchState(vault);
+    const artifact = join(vault, '.brain', ...state.lexical.path.split('/'));
+    try {
+      linkSync(artifact, join(outside, 'lexical-hardlink.json'));
+    } catch (error) {
+      if (['EPERM', 'EACCES', 'ENOTSUP', 'EXDEV'].includes(error?.code)) {
+        t.skip(`hardlinks indisponíveis neste filesystem: ${error.code}`);
+        return;
+      }
+      throw error;
+    }
+    const before = byteSnapshot(vault);
+    const health = inspectEvidenceSearchHealth(vault);
+
+    assert.equal(health.status, 'blocked');
+    assert.equal(health.errorCode, 'VAULT_PATH_UNSAFE');
+    assert.deepEqual(byteSnapshot(vault), before, 'blocked inspection must remain read-only');
+    const rendered = renderEvidenceSearchHealthLines(health).join('\n');
+    assert.match(rendered, /\[recall\] bloqueado/i);
+    assert.match(rendered, /VAULT_PATH_UNSAFE/);
+    assert.equal(rendered.includes(vault), false);
+    assert.equal(rendered.includes(outside), false);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Contexto

Décimo primeiro slice da issue #82, empilhado sobre a PR #117.

O benchmark de escala já mede construção, reutilização e consultas bounded. Este PR leva a mesma visibilidade para o diagnóstico diário sem ler o corpus completo ou reconstruir artefatos durante o `doctor`.

## Entregue

- novo inspetor read-only `src/evidence-search-health.mjs`;
- seção `[recall]` no `wendkeep doctor` com:
  - presença e bytes da autoridade `EVIDENCE_INDEX.jsonl`;
  - estado incremental e quantidade de documentos;
  - estado derivado e quantidade de chunks;
  - atualidade das fingerprints da autoridade e do sidecar;
  - estado e bytes dos artefatos lexical e SQLite;
  - capacidade real SQLite/FTS5 do runtime;
  - backend efetivo: `sqlite-fts5`, `lexical-sidecar`, `lexical-ephemeral` ou indisponível;
- estado stale sinalizado sem reconstrução automática;
- hardlink/symlink/reparse em artefato derivado reduzido a estado `blocked` e código seguro;
- `doctor --scope runtime` permanece sem inspeção do Core;
- strict não exige que um projeto sem autoridade de recall tenha criado o índice; porém, quando a autoridade existe, estados stale/inválidos entram como dívida.

## Propriedade de custo

O inspector usa somente:

- `stat` e fingerprints dos arquivos;
- os pequenos ponteiros de estado;
- contagens já materializadas.

Ele não carrega `EVIDENCE_INDEX.jsonl`, não valida todos os postings e não abre o SQLite. A consulta normal continua sendo a responsável por verificar hashes/reconstruir quando necessário.

## Testes

- índice saudável com sidecar lexical atual;
- leitura byte-for-byte sem mutação;
- mudança da autoridade exposta como stale sem rebuild;
- fallback esperado para `lexical-ephemeral`;
- hardlink de artefato bloqueado sem vazamento de path;
- renderização humana da nova seção.

## Escopo

- não altera a autoridade JSONL;
- não cria/reconstrói índices no doctor;
- não adiciona dependências;
- não altera versão, changelog, release ou workflows.

Draft enquanto a suíte canônica valida a integração sobre #117.