### PR TITLE
feat: publicar saúde do índice de recall no Observer (#82)

### DIFF
--- a/src/observer-snapshot.mjs
+++ b/src/observer-snapshot.mjs
@@ -5,6 +5,7 @@ import { allChangesState } from '../hooks/change-core.mjs';
 import { readControl, readSessionRegistry } from '../hooks/obsidian-common.mjs';
 import { runVaultHealth } from '../hooks/vault-health.mjs';
 import { readProjectForValidation } from '../packages/vault/src/validate-memory.mjs';
+import { inspectEvidenceSearchHealth } from './evidence-search-health.mjs';
 import { inspectSyncOutbox, readLocalSyncState } from './sync-outbox.mjs';
 
 export const OBSERVER_SCHEMA_VERSION = 1;
@@ -25,6 +26,11 @@ function safeText(value, max = MAX_TEXT) {
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, max);
+}
+
+function safeCount(value) {
+  const number = Number(value || 0);
+  return Number.isSafeInteger(number) && number >= 0 ? number : 0;
 }
 
 function isoNow(value) {
@@ -65,9 +71,44 @@ function activeSessionSummary(vaultBase, control, registry) {
   };
 }
 
+function recallSearchSummary(metrics) {
+  return {
+    schema_version: 1,
+    status: safeText(metrics?.status || 'unknown', 32),
+    ...(metrics?.errorCode ? { error_code: safeText(metrics.errorCode, 120) } : {}),
+    authority: {
+      status: safeText(metrics?.authorityStatus || 'unknown', 32),
+      bytes: safeCount(metrics?.authorityBytes),
+    },
+    incremental: {
+      status: safeText(metrics?.incrementalStateStatus || 'unknown', 32),
+      bytes: safeCount(metrics?.incrementalStateBytes),
+      documents: safeCount(metrics?.documentCount),
+    },
+    search: {
+      status: safeText(metrics?.searchStateStatus || 'unknown', 32),
+      bytes: safeCount(metrics?.searchStateBytes),
+      chunks: safeCount(metrics?.rowCount),
+      source_index_current: metrics?.sourceIndexCurrent === true,
+      source_state_current: metrics?.sourceStateCurrent === true,
+    },
+    lexical: {
+      status: safeText(metrics?.lexicalStatus || 'unknown', 32),
+      bytes: safeCount(metrics?.lexicalBytes),
+    },
+    sqlite: {
+      status: safeText(metrics?.sqliteStatus || 'unknown', 32),
+      bytes: safeCount(metrics?.sqliteBytes),
+      capability: metrics?.sqliteCapability === true,
+    },
+    backend: safeText(metrics?.backend || 'unavailable', 40),
+  };
+}
+
 function healthSummary(vaultBase) {
   try {
     const health = runVaultHealth({ vaultBase });
+    const recall = recallSearchSummary(inspectEvidenceSearchHealth(vaultBase));
     return {
       ok: health.ok === true,
       status: safeText(health.memoryStatus || (health.ok ? 'healthy' : 'degraded'), 40),
@@ -75,6 +116,7 @@ function healthSummary(vaultBase) {
       warning_count: Array.isArray(health.warnings) ? health.warnings.length : 0,
       registry_sessions: Number(health.metrics?.registrySessions || 0),
       derived_notes: Number(health.metrics?.derivedNotes || 0),
+      recall_search: recall,
     };
   } catch {
     return {

--- a/tests/observer-evidence-search-metrics.test.mjs
+++ b/tests/observer-evidence-search-metrics.test.mjs
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import {
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  loadEvidenceSearchState,
+  refreshEvidenceIndex,
+  refreshEvidenceSearchIndex,
+} from '../hooks/evidence-recall.mjs';
+import {
+  buildProjectSnapshot,
+  validateObserverSnapshot,
+} from '../src/observer-snapshot.mjs';
+import {
+  ensureObserverDatabase,
+  readSqlProjectOverview,
+  registerSqlProject,
+  upsertSqlProjectSnapshot,
+} from '../src/observer-sql-store.mjs';
+import { renderCoreSkeleton } from '../src/validate-core.mjs';
+import {
+  makeDataDir,
+  makeObserverFixture,
+} from './helpers/observer-fixture.mjs';
+
+const PROJECT_ID = 'observer-evidence-search';
+const MARKER = 'marcador-privado-observer-recall';
+
+function prepareFixture() {
+  const fixture = makeObserverFixture({
+    projectId: PROJECT_ID,
+    projectName: 'Observer Evidence Search',
+  });
+  writeFileSync(
+    join(fixture.vaultBase, '.brain', 'CORE.md'),
+    renderCoreSkeleton(),
+  );
+  mkdirSync(join(fixture.vaultBase, '04-Decisões'), { recursive: true });
+  return fixture;
+}
+
+function writeDecision(vaultBase, body) {
+  const path = join(vaultBase, '04-Decisões', 'ADR-observer-recall.md');
+  writeFileSync(path, [
+    '---',
+    'title: Métrica do Observer',
+    'authority: verified',
+    'validity: active',
+    'date: 2026-08-27',
+    '---',
+    '# Métrica do Observer',
+    '',
+    '## Evidência',
+    '',
+    body,
+    '',
+  ].join('\n'));
+  return path;
+}
+
+function buildSearch(vaultBase) {
+  const index = refreshEvidenceIndex(vaultBase);
+  const search = refreshEvidenceSearchIndex(vaultBase, index.chunks, {
+    force: true,
+    sqlite: 'off',
+  });
+  return { index, search };
+}
+
+test('[req:OBS-RECALL-1] Observer persists sanitized recall index health in project snapshots', () => {
+  const fixture = prepareFixture();
+  const dataDir = makeDataDir();
+  let db;
+  try {
+    writeDecision(fixture.vaultBase, `A evidência contém ${MARKER}.`);
+    const built = buildSearch(fixture.vaultBase);
+    const snapshot = buildProjectSnapshot({
+      vaultBase: fixture.vaultBase,
+      projectRoot: fixture.projectRoot,
+      now: '2026-08-27T01:00:00.000Z',
+    });
+    const recall = snapshot.health.recall_search;
+
+    assert.equal(recall.schema_version, 1);
+    assert.equal(recall.status, 'healthy');
+    assert.deepEqual(recall.authority, {
+      status: 'present',
+      bytes: recall.authority.bytes,
+    });
+    assert.ok(recall.authority.bytes > 0);
+    assert.equal(recall.incremental.status, 'ok');
+    assert.ok(recall.incremental.documents >= 3);
+    assert.equal(recall.search.status, 'current');
+    assert.equal(recall.search.chunks, built.index.chunks.length);
+    assert.equal(recall.search.source_index_current, true);
+    assert.equal(recall.search.source_state_current, true);
+    assert.equal(recall.lexical.status, 'current');
+    assert.ok(recall.lexical.bytes > recall.authority.bytes);
+    assert.equal(recall.sqlite.status, 'not-built');
+    assert.equal(recall.sqlite.bytes, 0);
+    assert.equal(recall.backend, 'lexical-sidecar');
+    assert.equal(validateObserverSnapshot(snapshot, { projectId: PROJECT_ID }).ok, true);
+
+    const serialized = JSON.stringify(snapshot);
+    assert.equal(serialized.includes(fixture.vaultBase), false);
+    assert.equal(serialized.includes(MARKER), false);
+    assert.equal(serialized.includes('ADR-observer-recall.md'), false);
+
+    db = ensureObserverDatabase(dataDir);
+    const registered = registerSqlProject(db, {
+      projectId: PROJECT_ID,
+      projectName: fixture.projectName,
+      wendkeepVersion: snapshot.wendkeep_version,
+    });
+    assert.equal(registered.registered, true);
+    assert.equal(upsertSqlProjectSnapshot(db, snapshot).accepted, true);
+    const overview = readSqlProjectOverview(db, PROJECT_ID);
+    assert.deepEqual(overview.snapshot.health.recall_search, recall);
+  } finally {
+    db?.close();
+    fixture.cleanup();
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+test('[req:OBS-RECALL-2] stale authority is published as bounded metadata without rebuilding', () => {
+  const fixture = prepareFixture();
+  try {
+    writeDecision(fixture.vaultBase, 'A evidência contém sinal-antigo-observer.');
+    buildSearch(fixture.vaultBase);
+    const statePath = join(fixture.vaultBase, '.brain', 'EVIDENCE_SEARCH_STATE.json');
+    const stateBefore = readFileSync(statePath);
+
+    writeDecision(fixture.vaultBase, 'A evidência agora contém sinal-novo-observer.');
+    refreshEvidenceIndex(fixture.vaultBase);
+    const snapshot = buildProjectSnapshot({
+      vaultBase: fixture.vaultBase,
+      projectRoot: fixture.projectRoot,
+      now: '2026-08-27T01:10:00.000Z',
+    });
+    const recall = snapshot.health.recall_search;
+
+    assert.equal(recall.status, 'warning');
+    assert.equal(recall.search.status, 'stale');
+    assert.equal(recall.search.source_index_current, false);
+    assert.equal(recall.backend, 'lexical-ephemeral');
+    assert.deepEqual(readFileSync(statePath), stateBefore);
+    assert.equal(validateObserverSnapshot(snapshot, { projectId: PROJECT_ID }).ok, true);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test('[req:OBS-RECALL-3] unsafe recall artifact publishes only blocked sanitized metadata', (t) => {
+  const fixture = prepareFixture();
+  const outside = mkdtempSync(join(tmpdir(), 'wk-observer-recall-outside-'));
+  try {
+    writeDecision(fixture.vaultBase, `A evidência contém ${MARKER}.`);
+    buildSearch(fixture.vaultBase);
+    const state = loadEvidenceSearchState(fixture.vaultBase);
+    const artifact = join(fixture.vaultBase, '.brain', ...state.lexical.path.split('/'));
+    try {
+      linkSync(artifact, join(outside, 'recall-hardlink.json'));
+    } catch (error) {
+      if (['EPERM', 'EACCES', 'ENOTSUP', 'EXDEV'].includes(error?.code)) {
+        t.skip(`hardlinks indisponíveis neste filesystem: ${error.code}`);
+        return;
+      }
+      throw error;
+    }
+
+    const snapshot = buildProjectSnapshot({
+      vaultBase: fixture.vaultBase,
+      projectRoot: fixture.projectRoot,
+      now: '2026-08-27T01:20:00.000Z',
+    });
+    const recall = snapshot.health.recall_search;
+    assert.equal(recall.status, 'blocked');
+    assert.equal(recall.error_code, 'VAULT_PATH_UNSAFE');
+    assert.equal(validateObserverSnapshot(snapshot, { projectId: PROJECT_ID }).ok, true);
+
+    const serialized = JSON.stringify(snapshot);
+    assert.equal(serialized.includes(fixture.vaultBase), false);
+    assert.equal(serialized.includes(outside), false);
+    assert.equal(serialized.includes(MARKER), false);
+    assert.equal(serialized.includes('recall-hardlink.json'), false);
+  } finally {
+    fixture.cleanup();
+    rmSync(outside, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Contexto

Décimo segundo slice da issue #82, empilhado sobre a PR #121.

O `wendkeep doctor` já mostra se a autoridade, o estado incremental e os sidecars do recall estão atuais. Este PR publica a mesma visão sanitizada no snapshot operacional do Observer.

## Entregue

- `health.recall_search` versionado no snapshot do Observer;
- metadata sanitizada para:
  - autoridade: estado e bytes;
  - índice incremental: estado, bytes e documentos;
  - ponteiro de busca: estado, bytes, chunks e atualidade das fontes;
  - sidecar lexical: estado e bytes;
  - SQLite: estado, bytes e capacidade FTS5;
  - backend efetivo;
- persistência em `project_snapshots` e leitura pelo overview SQL;
- estado stale publicado sem reconstrução;
- artefato derivado inseguro reduzido a `blocked` e código seguro;
- limite existente de 32 KiB preservado.

## Contrato de privacidade

O snapshot não publica:

- conteúdo de evidência;
- termos ou consultas;
- títulos, headings ou logical paths;
- hashes de conteúdo ou IDs de chunks;
- nomes físicos de artefatos;
- paths absolutos do Vault.

Somente estados, contagens, bytes, booleans de atualidade e o backend são enviados ao Observer.

## Testes

- índice lexical atual persistido e lido pelo overview SQL;
- snapshot validado e sem marcador privado ou nome de documento;
- mudança da autoridade publicada como stale/`lexical-ephemeral` sem rebuild;
- hardlink do sidecar publicado apenas como metadata bloqueada e sanitizada.

## Escopo

- não altera schema SQL: a estrutura fica no JSON versionado do snapshot;
- não altera ingest, FTS do Observer ou documentos;
- não abre nem reconstrói o índice de recall;
- não altera versão, changelog, release ou workflows.

Draft enquanto a suíte canônica valida a integração sobre #121.