### PR TITLE
feat: adicionar recall paginado e indexado ao MCP (#82)

### DIFF
--- a/docs/en/commands/mcp.md
+++ b/docs/en/commands/mcp.md
@@ -63,20 +63,71 @@ wendkeep mcp config --client cursor --vault <vault>
 ```
 
 Reads: `wendkeep_project_status`, `wendkeep_context_status`, `wendkeep_memory_recall`,
-`wendkeep_memory_conflicts`, `wendkeep_change_list`, `wendkeep_change_show`,
-`wendkeep_change_status`, `wendkeep_spec_effective`, `wendkeep_task_show`,
-`wendkeep_task_evaluate`, `wendkeep_handoff_current`, `wendkeep_evidence_latest`, and
-`wendkeep_observer_query`.
+`wendkeep_evidence_recall`, `wendkeep_memory_conflicts`, `wendkeep_change_list`,
+`wendkeep_change_show`, `wendkeep_change_status`, `wendkeep_spec_effective`,
+`wendkeep_task_show`, `wendkeep_task_evaluate`, `wendkeep_handoff_current`,
+`wendkeep_evidence_latest`, and `wendkeep_observer_query`.
 
 Writes: `wendkeep_memory_assert`, `wendkeep_checkpoint_create`, `wendkeep_context_select`,
 `wendkeep_task_claim`, `wendkeep_task_complete`, and `wendkeep_handoff_publish`.
+
+## Paged indexed evidence recall
+
+`wendkeep_evidence_recall` is the bounded surface for retrieving Vault evidence. It selects
+candidates through the persistent lexical sidecar or optional SQLite/FTS5, reranks them with the
+canonical scorer, and returns a compact page. `wendkeep_memory_recall` remains available as the
+legacy API and does not silently inherit the new contract.
+
+Main input:
+
+- `project_root` and `query` are required;
+- `limit` accepts 1 through 100 results per page;
+- `cursor` is opaque and is valid only for the same query, filters, and logical index;
+- `max_bytes` accepts 2 through 524288 and exactly bounds the serialized JSON in `results`; the
+  default is 64 KiB;
+- `candidate_limit` accepts 1 through 4096 candidates;
+- `posting_budget` accepts 1 through 1048576 visited postings;
+- `backend` accepts `auto`, `sqlite`, or `lexical`;
+- `filters` supports exact matches for `authority`, `validity`, `entity_type`, `project_id`,
+  `change_slug`, `session_id`, `work_session_id`, and `logical_path`, plus
+  `logical_path_prefix`. Each filter may be a string or a string list.
+
+Example call:
+
+```json
+{
+  "name": "wendkeep_evidence_recall",
+  "arguments": {
+    "project_root": "<project>",
+    "query": "authentication contract",
+    "limit": 5,
+    "max_bytes": 65536,
+    "candidate_limit": 512,
+    "posting_budget": 65536,
+    "backend": "auto",
+    "filters": {
+      "authority": "verified",
+      "validity": "active",
+      "logical_path_prefix": "04-Decisions/"
+    }
+  }
+}
+```
+
+The response contains `results`, `next_cursor`, `has_more`, `as_of`, and page counts/bytes. Each
+result omits `content`, reports `content_bytes`, retains a bounded `excerpt`, and replaces
+`logical_path` with `logical_ref`, a Vault-relative reference—never an absolute path. The
+`candidates` block exposes backend, count, postings, rebuild, and fallback metadata. When the
+candidate budget did not cover every possible match, `complete_candidate_set` is `false`; this
+prevents a consumer from treating a truncated selection as exhaustive.
 
 ## Expected result
 
 The handshake and `tools/list` return valid JSON-RPC. Every tool declares a versioned
 effect/capability and schemas. Known reads skip the mutation gate while retaining explicit
-project/worktree binding, cursor pagination, a 1 MiB default budget, redaction, timeout, and
-cancellation. Observer is declared unavailable below Node 22.13 without blocking Core on Node 18.
+project/worktree binding, cursor pagination, budgets, redaction, timeout, and cancellation.
+Observer is declared unavailable below Node 22.13 without blocking Core on Node 18. Indexed recall
+also works on Node 18 through the lexical fallback; SQLite/FTS5 remains optional.
 
 Writes require `project_root`, `session_id`, `active_context_id`, `actor`, `reason`, the exact
 capability, and `lease.id`/`lease.expires_at`; the executor revalidates causal authorization and CLI
@@ -89,8 +140,17 @@ outcome, code, and duration—never arguments or payloads.
 - `MCP_CAPABILITY_REQUIRED` / `MCP_SCOPE_AUTH_REQUIRED`: capability missing or unauthorized.
 - `MCP_LEASE_EXPIRED`: obtain a new authorization/lease; do not hand-edit its timestamp.
 - `MCP_PROJECT_SCOPE_MISMATCH`: `project_root` and `worktree_root` use different bindings.
-- `MCP_REQUEST_TOO_LARGE` / `MCP_RESPONSE_TOO_LARGE`: use `limit` and the returned cursor.
+- `MCP_REQUEST_TOO_LARGE` / `MCP_RESPONSE_TOO_LARGE`: reduce budgets and continue with the cursor.
 - `MCP_RUNTIME_UNSUPPORTED`: use Node 22.13+ for Observer; Core remains available.
+- `MCP_EVIDENCE_QUERY_REQUIRED`: provide a non-empty query.
+- `MCP_EVIDENCE_CURSOR_INVALID`: the cursor was altered, became stale, or was reused with a
+  different query/filter set.
+- `MCP_EVIDENCE_BUDGET_TOO_SMALL`: even the next result's minimum metadata cannot fit
+  `max_bytes`.
+- `MCP_EVIDENCE_BACKEND_UNAVAILABLE`: SQLite was required but FTS5 is unavailable; use `auto` or
+  `lexical`.
+- `MCP_EVIDENCE_ARTIFACT_UNSAFE`: a derived artifact violated the Vault's physical boundary.
+- `MCP_EVIDENCE_RECALL_INVALID`: a filter, backend, or limit is outside the contract.
 
 ## Next steps
 

--- a/docs/pt-BR/commands/mcp.md
+++ b/docs/pt-BR/commands/mcp.md
@@ -63,20 +63,71 @@ O `init` gera a entrada genérica reproduzível:
 ```
 
 Reads: `wendkeep_project_status`, `wendkeep_context_status`, `wendkeep_memory_recall`,
-`wendkeep_memory_conflicts`, `wendkeep_change_list`, `wendkeep_change_show`,
-`wendkeep_change_status`, `wendkeep_spec_effective`, `wendkeep_task_show`,
-`wendkeep_task_evaluate`, `wendkeep_handoff_current`, `wendkeep_evidence_latest` e
-`wendkeep_observer_query`.
+`wendkeep_evidence_recall`, `wendkeep_memory_conflicts`, `wendkeep_change_list`,
+`wendkeep_change_show`, `wendkeep_change_status`, `wendkeep_spec_effective`,
+`wendkeep_task_show`, `wendkeep_task_evaluate`, `wendkeep_handoff_current`,
+`wendkeep_evidence_latest` e `wendkeep_observer_query`.
 
 Writes: `wendkeep_memory_assert`, `wendkeep_checkpoint_create`, `wendkeep_context_select`,
 `wendkeep_task_claim`, `wendkeep_task_complete` e `wendkeep_handoff_publish`.
+
+## Recall paginado e indexado de evidências
+
+`wendkeep_evidence_recall` é a superfície bounded para recuperar evidências do Vault. Ela seleciona
+candidatos pelo sidecar lexical persistente ou pelo SQLite/FTS5 opcional, reranqueia com o scorer
+canônico e devolve uma página compacta. `wendkeep_memory_recall` permanece disponível como API
+legada e não ganha silenciosamente o novo contrato.
+
+Entrada principal:
+
+- `project_root` e `query` são obrigatórios;
+- `limit` aceita 1 a 100 resultados por página;
+- `cursor` é opaco e só vale para a mesma consulta, filtros e índice lógico;
+- `max_bytes` aceita 2 a 524288 e limita exatamente o JSON serializado de `results`; o padrão é
+  64 KiB;
+- `candidate_limit` aceita 1 a 4096 candidatos;
+- `posting_budget` aceita 1 a 1048576 postings visitados;
+- `backend` aceita `auto`, `sqlite` ou `lexical`;
+- `filters` aceita igualdade por `authority`, `validity`, `entity_type`, `project_id`,
+  `change_slug`, `session_id`, `work_session_id` e `logical_path`, além de
+  `logical_path_prefix`. Cada filtro pode ser string ou lista de strings.
+
+Exemplo de chamada:
+
+```json
+{
+  "name": "wendkeep_evidence_recall",
+  "arguments": {
+    "project_root": "<projeto>",
+    "query": "contrato de autenticação",
+    "limit": 5,
+    "max_bytes": 65536,
+    "candidate_limit": 512,
+    "posting_budget": 65536,
+    "backend": "auto",
+    "filters": {
+      "authority": "verified",
+      "validity": "active",
+      "logical_path_prefix": "04-Decisões/"
+    }
+  }
+}
+```
+
+A resposta contém `results`, `next_cursor`, `has_more`, `as_of`, contagens e bytes da página. Cada
+resultado omite `content`, informa `content_bytes`, mantém um `excerpt` bounded e substitui
+`logical_path` por `logical_ref`, uma referência relativa ao Vault — nunca um caminho absoluto. O
+bloco `candidates` expõe backend, quantidade, postings, rebuild e fallback. Quando o orçamento de
+candidatos não cobriu todo o conjunto possível, `complete_candidate_set` é `false`; isso impede que
+o consumidor interprete uma seleção truncada como exaustiva.
 
 ## Resultado esperado
 
 O handshake e `tools/list` retornam JSON-RPC válido. Cada tool declara effect/capability e schemas
 versionados. Reads conhecidas não entram no mutation gate, mas mantêm binding explícito de
-projeto/worktree, paginação por cursor, budget padrão de 1 MiB, redaction, timeout e cancelamento.
-Observer aparece indisponível abaixo de Node 22.13 sem impedir Core no Node 18.
+projeto/worktree, paginação por cursor, budgets, redaction, timeout e cancelamento. Observer aparece
+indisponível abaixo de Node 22.13 sem impedir Core no Node 18. O recall indexado também funciona no
+Node 18 pelo fallback lexical; SQLite/FTS5 permanece opcional.
 
 Writes exigem `project_root`, `session_id`, `active_context_id`, `actor`, `reason`, capability exata
 e `lease.id`/`lease.expires_at`; o executor revalida a autorização causal e os gates da CLI. A
@@ -89,8 +140,16 @@ código e duração — nunca argumentos ou payload.
 - `MCP_CAPABILITY_REQUIRED` / `MCP_SCOPE_AUTH_REQUIRED`: capability ausente ou não autorizada.
 - `MCP_LEASE_EXPIRED`: obtenha autorização/lease nova; não altere timestamp manualmente.
 - `MCP_PROJECT_SCOPE_MISMATCH`: `project_root` e `worktree_root` pertencem a bindings diferentes.
-- `MCP_REQUEST_TOO_LARGE` / `MCP_RESPONSE_TOO_LARGE`: use `limit` e o cursor retornado.
+- `MCP_REQUEST_TOO_LARGE` / `MCP_RESPONSE_TOO_LARGE`: reduza os budgets e continue pelo cursor.
 - `MCP_RUNTIME_UNSUPPORTED`: use Node 22.13+ para Observer; Core permanece disponível.
+- `MCP_EVIDENCE_QUERY_REQUIRED`: informe uma consulta não vazia.
+- `MCP_EVIDENCE_CURSOR_INVALID`: cursor adulterado, stale ou usado com outra consulta/filtros.
+- `MCP_EVIDENCE_BUDGET_TOO_SMALL`: nem os metadados mínimos do próximo resultado cabem em
+  `max_bytes`.
+- `MCP_EVIDENCE_BACKEND_UNAVAILABLE`: o backend SQLite foi exigido, mas FTS5 não está disponível;
+  use `auto` ou `lexical`.
+- `MCP_EVIDENCE_ARTIFACT_UNSAFE`: um artefato derivado violou a fronteira física do Vault.
+- `MCP_EVIDENCE_RECALL_INVALID`: filtro, backend ou limite fora do contrato.
 
 ## Próximos passos
 

--- a/packages/mcp/src/effects.mjs
+++ b/packages/mcp/src/effects.mjs
@@ -6,6 +6,7 @@ const TOOLS = [
   ['wendkeep_project_status', 'read', 'project:status'],
   ['wendkeep_context_status', 'read', 'context:status'],
   ['wendkeep_memory_recall', 'read', 'memory:recall'],
+  ['wendkeep_evidence_recall', 'read', 'evidence:recall'],
   ['wendkeep_memory_conflicts', 'read', 'memory:conflicts'],
   ['wendkeep_change_list', 'read', 'change:list'],
   ['wendkeep_change_show', 'read', 'change:show'],
@@ -55,10 +56,10 @@ function deepFreeze(value) {
 
 export const MCP_EFFECT_MANIFEST = deepFreeze({
   schema_version: 1,
-  catalog_version: '2026-08-24',
+  catalog_version: '2026-08-27',
   server_aliases: ['wendkeep', 'wendkeep-native'],
   tools: TOOLS,
-  integrity: 'sha256:de96c2f3f5ae3d814440b541db778f87be4550ebd2ce9dd5ae2377f354770046',
+  integrity: 'sha256:1bb4d5dc62008ed23afa0d850a89bbbb77ea9cc31da79cde557aa2f02034fdde',
 });
 
 export function verifyMcpEffectManifest(manifest) {

--- a/packages/mcp/src/evidence-recall.mjs
+++ b/packages/mcp/src/evidence-recall.mjs
@@ -32,6 +32,14 @@ function backend(value) {
   return normalized;
 }
 
+function filters(value) {
+  if (value === undefined || value === null) return {};
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('filters must be an object');
+  }
+  return value;
+}
+
 function logicalReference(result) {
   const { logical_path: logicalPath, ...rest } = result || {};
   return {
@@ -88,19 +96,17 @@ export function recallEvidenceForMcp(vaultBase, args = {}) {
       EVIDENCE_SEARCH_DEFAULT_POSTING_BUDGET,
       { max: EVIDENCE_SEARCH_MAX_POSTING_BUDGET },
     );
-    const filters = args.filters && typeof args.filters === 'object' && !Array.isArray(args.filters)
-      ? args.filters
-      : {};
+    const normalizedFilters = filters(args.filters);
     const candidates = searchEvidenceCandidates(vaultBase, query, {
       candidateLimit,
       postingBudget,
-      filters,
+      filters: normalizedFilters,
       backend: backend(args.backend),
       sqlite: 'auto',
     });
     const page = recallEvidencePage(candidates.rows, query, {
       cursor: args.cursor || null,
-      filters,
+      filters: normalizedFilters,
       limit,
       maxBytes,
     });

--- a/packages/mcp/src/evidence-recall.mjs
+++ b/packages/mcp/src/evidence-recall.mjs
@@ -1,0 +1,124 @@
+import {
+  EVIDENCE_RECALL_DEFAULT_LIMIT,
+  EVIDENCE_RECALL_DEFAULT_MAX_BYTES,
+  EVIDENCE_RECALL_MAX_LIMIT,
+  EvidenceRecallBudgetError,
+  EvidenceRecallCursorError,
+  recallEvidencePage,
+} from '../../vault/src/evidence-recall-page.mjs';
+import {
+  EVIDENCE_SEARCH_DEFAULT_CANDIDATES,
+  EVIDENCE_SEARCH_DEFAULT_POSTING_BUDGET,
+  EVIDENCE_SEARCH_MAX_CANDIDATES,
+  EVIDENCE_SEARCH_MAX_POSTING_BUDGET,
+  searchEvidenceCandidates,
+} from '../../vault/src/evidence-search-index.mjs';
+
+export const MCP_EVIDENCE_RECALL_MAX_BYTES = 512 * 1024;
+
+function integer(value, fallback, { min = 1, max } = {}) {
+  const number = Number(value ?? fallback);
+  if (!Number.isSafeInteger(number) || number < min || number > max) {
+    throw new RangeError(`value must be an integer between ${min} and ${max}`);
+  }
+  return number;
+}
+
+function backend(value) {
+  const normalized = String(value ?? 'auto').trim().toLowerCase();
+  if (!['auto', 'sqlite', 'lexical'].includes(normalized)) {
+    throw new TypeError('backend must be auto, sqlite, or lexical');
+  }
+  return normalized;
+}
+
+function logicalReference(result) {
+  const { logical_path: logicalPath, ...rest } = result || {};
+  return {
+    ...rest,
+    logical_ref: String(logicalPath || ''),
+  };
+}
+
+function mappedError(error) {
+  if (String(error?.code || '').startsWith('MCP_')) return error;
+  let code = 'MCP_EVIDENCE_RECALL_FAILED';
+  if (error instanceof EvidenceRecallCursorError
+      || error?.code === 'EVIDENCE_RECALL_CURSOR_INVALID') {
+    code = 'MCP_EVIDENCE_CURSOR_INVALID';
+  } else if (error instanceof EvidenceRecallBudgetError
+      || error?.code === 'EVIDENCE_RECALL_BUDGET_TOO_SMALL') {
+    code = 'MCP_EVIDENCE_BUDGET_TOO_SMALL';
+  } else if (error?.code === 'EVIDENCE_SEARCH_SQLITE_UNAVAILABLE'
+      || error?.code === 'EVIDENCE_SEARCH_FTS5_UNAVAILABLE') {
+    code = 'MCP_EVIDENCE_BACKEND_UNAVAILABLE';
+  } else if (error?.code === 'VAULT_PATH_UNSAFE') {
+    code = 'MCP_EVIDENCE_ARTIFACT_UNSAFE';
+  } else if (error instanceof TypeError || error instanceof RangeError) {
+    code = 'MCP_EVIDENCE_RECALL_INVALID';
+  }
+  return Object.assign(new Error(error?.message || 'evidence recall failed'), {
+    code,
+    cause: error,
+  });
+}
+
+export function recallEvidenceForMcp(vaultBase, args = {}) {
+  try {
+    const query = String(args.query || '').trim();
+    if (!query) {
+      throw Object.assign(new Error('query is required'), {
+        code: 'MCP_EVIDENCE_QUERY_REQUIRED',
+      });
+    }
+    const limit = integer(args.limit, EVIDENCE_RECALL_DEFAULT_LIMIT, {
+      max: EVIDENCE_RECALL_MAX_LIMIT,
+    });
+    const maxBytes = integer(args.max_bytes, EVIDENCE_RECALL_DEFAULT_MAX_BYTES, {
+      min: 2,
+      max: MCP_EVIDENCE_RECALL_MAX_BYTES,
+    });
+    const candidateLimit = integer(
+      args.candidate_limit,
+      Math.max(EVIDENCE_SEARCH_DEFAULT_CANDIDATES, limit),
+      { max: EVIDENCE_SEARCH_MAX_CANDIDATES },
+    );
+    const postingBudget = integer(
+      args.posting_budget,
+      EVIDENCE_SEARCH_DEFAULT_POSTING_BUDGET,
+      { max: EVIDENCE_SEARCH_MAX_POSTING_BUDGET },
+    );
+    const filters = args.filters && typeof args.filters === 'object' && !Array.isArray(args.filters)
+      ? args.filters
+      : {};
+    const candidates = searchEvidenceCandidates(vaultBase, query, {
+      candidateLimit,
+      postingBudget,
+      filters,
+      backend: backend(args.backend),
+      sqlite: 'auto',
+    });
+    const page = recallEvidencePage(candidates.rows, query, {
+      cursor: args.cursor || null,
+      filters,
+      limit,
+      maxBytes,
+    });
+    return {
+      schema_version: 1,
+      ...page,
+      results: page.results.map(logicalReference),
+      candidates: {
+        backend: candidates.backend,
+        count: candidates.candidate_count,
+        posting_entries: candidates.posting_entries,
+        has_more: candidates.has_more,
+        rebuilt: candidates.rebuilt,
+        fallback_reason: candidates.fallback_reason || '',
+      },
+      complete_candidate_set: candidates.has_more !== true,
+    };
+  } catch (error) {
+    throw mappedError(error);
+  }
+}

--- a/packages/mcp/src/executor.mjs
+++ b/packages/mcp/src/executor.mjs
@@ -23,6 +23,7 @@ import {
 } from '../../vault/src/memory-store.mjs';
 import { scopeForMemoryKey } from '../../vault/src/memory-scope.mjs';
 import { sanitizeMemoryText } from '../../vault/src/memory-schema.mjs';
+import { recallEvidenceForMcp } from './evidence-recall.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const BIN = join(ROOT, 'bin', 'wendkeep.mjs');
@@ -304,6 +305,9 @@ export async function executeNativeMcpTool(tool, args, { signal } = {}) {
     return sanitize(recallEvidence(loadEvidenceIndex(ctx.vaultBase), String(args.query || ''), {
       topK: Math.min(Number(args.limit || 10), 100),
     }));
+  }
+  if (tool.name === 'wendkeep_evidence_recall') {
+    return sanitize(recallEvidenceForMcp(ctx.vaultBase, args));
   }
   if (tool.name === 'wendkeep_memory_conflicts') {
     return sanitize(listMemoryCandidates(ctx.vaultBase, { activeOnly: true }).candidates);

--- a/packages/mcp/src/server.mjs
+++ b/packages/mcp/src/server.mjs
@@ -3,6 +3,9 @@ import { MCP_EFFECT_MANIFEST, resolveMcpToolEffect } from './effects.mjs';
 const DEFAULT_PAGE_SIZE = 50;
 const MAX_PAGE_SIZE = 100;
 const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_EVIDENCE_BYTES = 512 * 1024;
+const MAX_EVIDENCE_CANDIDATES = 4096;
+const MAX_EVIDENCE_POSTINGS = 1_048_576;
 
 function boundedInteger(value, fallback, maximum = MAX_PAGE_SIZE) {
   const parsed = Number.parseInt(value, 10);
@@ -42,6 +45,7 @@ function availability(tool, nodeVersion) {
 
 const TOOL_REQUIRED_ARGUMENTS = Object.freeze({
   wendkeep_context_status: ['session_id'],
+  wendkeep_evidence_recall: ['query'],
   wendkeep_change_show: ['change'],
   wendkeep_change_status: ['change'],
   wendkeep_task_show: ['session_id', 'task'],
@@ -54,6 +58,13 @@ const TOOL_REQUIRED_ARGUMENTS = Object.freeze({
   wendkeep_task_complete: ['task'],
   wendkeep_handoff_publish: ['payload'],
 });
+
+const stringOrStringList = {
+  oneOf: [
+    { type: 'string' },
+    { type: 'array', items: { type: 'string' }, uniqueItems: true },
+  ],
+};
 
 function inputSchema(tool) {
   const required = ['project_root'];
@@ -87,6 +98,25 @@ function inputSchema(tool) {
       query: { type: 'string' },
       cursor: { type: 'string' },
       limit: { type: 'integer', minimum: 1, maximum: MAX_PAGE_SIZE },
+      max_bytes: { type: 'integer', minimum: 2, maximum: MAX_EVIDENCE_BYTES },
+      candidate_limit: { type: 'integer', minimum: 1, maximum: MAX_EVIDENCE_CANDIDATES },
+      posting_budget: { type: 'integer', minimum: 1, maximum: MAX_EVIDENCE_POSTINGS },
+      backend: { type: 'string', enum: ['auto', 'sqlite', 'lexical'] },
+      filters: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          authority: stringOrStringList,
+          validity: stringOrStringList,
+          entity_type: stringOrStringList,
+          project_id: stringOrStringList,
+          change_slug: stringOrStringList,
+          session_id: stringOrStringList,
+          work_session_id: stringOrStringList,
+          logical_path: stringOrStringList,
+          logical_path_prefix: stringOrStringList,
+        },
+      },
       payload: { type: 'object' },
     },
   };

--- a/tests/mcp-evidence-recall.test.mjs
+++ b/tests/mcp-evidence-recall.test.mjs
@@ -1,0 +1,223 @@
+import assert from 'node:assert/strict';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { bindProjectVault } from '../packages/vault/src/project-vault.mjs';
+import { recallEvidenceForMcp } from '../packages/mcp/src/evidence-recall.mjs';
+import { MCP_EFFECT_MANIFEST } from '../packages/mcp/src/effects.mjs';
+import { executeNativeMcpTool } from '../packages/mcp/src/executor.mjs';
+import { createNativeMcpServer } from '../packages/mcp/src/server.mjs';
+import {
+  refreshEvidenceIndex,
+  refreshEvidenceSearchIndex,
+} from '../hooks/evidence-recall.mjs';
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'wk-mcp-evidence-recall-'));
+  const project = join(root, 'project');
+  const vault = join(root, 'vault');
+  mkdirSync(project);
+  mkdirSync(vault);
+  const binding = bindProjectVault({ projectRoot: project, vaultPath: vault });
+  mkdirSync(join(vault, '04-Decisões'), { recursive: true });
+  return {
+    root,
+    project,
+    vault,
+    projectId: binding.projectId,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function writeDecision(vault, name, body, {
+  authority = 'verified',
+  validity = 'active',
+  date = '2026-08-27',
+} = {}) {
+  writeFileSync(join(vault, '04-Decisões', `${name}.md`), [
+    '---',
+    `title: ${name}`,
+    `authority: ${authority}`,
+    `validity: ${validity}`,
+    `date: ${date}`,
+    '---',
+    `# ${name}`,
+    '',
+    '## Evidência',
+    '',
+    body,
+    '',
+  ].join('\n'));
+}
+
+function build(vault) {
+  const index = refreshEvidenceIndex(vault);
+  refreshEvidenceSearchIndex(vault, index.chunks, {
+    force: true,
+    sqlite: 'off',
+  });
+  return index;
+}
+
+function request(id, method, params = {}) {
+  return { jsonrpc: '2.0', id, method, params };
+}
+
+test('[req:MCP-10] evidence recall pages indexed candidates with opaque cursors and byte budgets', () => {
+  const item = fixture();
+  try {
+    writeDecision(item.vault, 'ADR-motor-a', 'O contrato motor-foguete alfa foi validado.');
+    writeDecision(item.vault, 'ADR-motor-b', 'O contrato motor-foguete beta foi validado.');
+    writeDecision(item.vault, 'ADR-motor-c', 'O contrato motor-foguete gama foi validado.');
+    build(item.vault);
+
+    const first = recallEvidenceForMcp(item.vault, {
+      query: 'motor-foguete contrato',
+      backend: 'lexical',
+      filters: { authority: 'verified', validity: 'active' },
+      limit: 1,
+      max_bytes: 4096,
+      candidate_limit: 10,
+      posting_budget: 100,
+    });
+    assert.equal(first.results.length, 1);
+    assert.equal(first.has_more, true);
+    assert.ok(first.next_cursor);
+    assert.equal(first.results[0].content_omitted, true);
+    assert.equal(Object.hasOwn(first.results[0], 'content'), false);
+    assert.equal(Object.hasOwn(first.results[0], 'logical_path'), false);
+    assert.match(first.results[0].logical_ref, /^04-Decisões\//);
+    assert.equal(first.candidates.backend, 'lexical-sidecar');
+    assert.equal(first.candidates.has_more, false);
+    assert.equal(first.complete_candidate_set, true);
+    assert.ok(first.returned_bytes <= first.max_bytes);
+
+    const second = recallEvidenceForMcp(item.vault, {
+      query: 'motor-foguete contrato',
+      backend: 'lexical',
+      filters: { authority: 'verified', validity: 'active' },
+      cursor: first.next_cursor,
+      limit: 1,
+      max_bytes: 4096,
+      candidate_limit: 10,
+      posting_budget: 100,
+    });
+    assert.equal(second.results.length, 1);
+    assert.notEqual(second.results[0].logical_ref, first.results[0].logical_ref);
+    assert.equal(second.as_of, first.as_of);
+    assert.equal(second.offset, 1);
+
+    assert.throws(
+      () => recallEvidenceForMcp(item.vault, {
+        query: 'consulta diferente',
+        cursor: first.next_cursor,
+        backend: 'lexical',
+      }),
+      { code: 'MCP_EVIDENCE_CURSOR_INVALID' },
+    );
+    assert.throws(
+      () => recallEvidenceForMcp(item.vault, {
+        query: 'motor-foguete contrato',
+        backend: 'lexical',
+        max_bytes: 2,
+      }),
+      { code: 'MCP_EVIDENCE_BUDGET_TOO_SMALL' },
+    );
+    assert.throws(
+      () => recallEvidenceForMcp(item.vault, {
+        query: 'motor-foguete contrato',
+        filters: [],
+      }),
+      { code: 'MCP_EVIDENCE_RECALL_INVALID' },
+    );
+  } finally {
+    item.cleanup();
+  }
+});
+
+test('[req:MCP-10] native executor preserves relative provenance without local paths', async () => {
+  const item = fixture();
+  try {
+    writeDecision(item.vault, 'ADR-nebulosa', 'A âncora nebulosa-executor preserva a evidência.');
+    build(item.vault);
+    const tool = MCP_EFFECT_MANIFEST.tools.find((candidate) => (
+      candidate.name === 'wendkeep_evidence_recall'
+    ));
+    assert.equal(tool.effect, 'read');
+    assert.equal(tool.capability, 'evidence:recall');
+
+    const result = await executeNativeMcpTool(tool, {
+      project_root: item.project,
+      query: 'nebulosa-executor',
+      backend: 'lexical',
+      limit: 5,
+      max_bytes: 8192,
+    });
+    assert.equal(result.schema_version, 1);
+    assert.equal(result.results.length, 1);
+    assert.equal(result.results[0].logical_ref, '04-Decisões/ADR-nebulosa.md');
+    assert.equal(Object.hasOwn(result.results[0], 'logical_path'), false);
+    assert.equal(result.candidates.backend, 'lexical-sidecar');
+    assert.doesNotMatch(JSON.stringify(result), /wk-mcp-evidence-recall|[A-Z]:\\|\/tmp\//i);
+  } finally {
+    item.cleanup();
+  }
+});
+
+test('[req:MCP-10] server advertises typed recall inputs and rejects a missing query pre-execution', async () => {
+  let executions = 0;
+  const server = createNativeMcpServer({
+    defaultPageSize: 100,
+    executeTool: async () => {
+      executions += 1;
+      return {
+        results: [{ logical_ref: '04-Decisões/ADR.md', excerpt: 'ok' }],
+        next_cursor: 'opaque-cursor',
+        has_more: true,
+      };
+    },
+  });
+  const listed = await server.handle(request(1, 'tools/list'));
+  const descriptor = listed.result.tools.find((tool) => (
+    tool.name === 'wendkeep_evidence_recall'
+  ));
+  assert.ok(descriptor);
+  assert.equal(descriptor.annotations.readOnlyHint, true);
+  assert.ok(descriptor.inputSchema.required.includes('query'));
+  assert.equal(descriptor.inputSchema.properties.backend.enum.includes('lexical'), true);
+  assert.equal(descriptor.inputSchema.properties.max_bytes.maximum, 512 * 1024);
+  assert.equal(descriptor.inputSchema.properties.candidate_limit.maximum, 4096);
+  assert.equal(descriptor.inputSchema.properties.posting_budget.maximum, 1_048_576);
+  assert.equal(descriptor.inputSchema.properties.filters.additionalProperties, false);
+
+  const missing = await server.handle(request(2, 'tools/call', {
+    name: 'wendkeep_evidence_recall',
+    arguments: { project_root: 'C:/projects/a' },
+  }));
+  assert.equal(missing.result.isError, true);
+  assert.equal(missing.result.structuredContent.error.code, 'MCP_ARGUMENT_REQUIRED');
+  assert.equal(executions, 0);
+
+  const called = await server.handle(request(3, 'tools/call', {
+    name: 'wendkeep_evidence_recall',
+    arguments: {
+      project_root: 'C:/projects/a',
+      query: 'contrato',
+      limit: 1,
+      max_bytes: 4096,
+      backend: 'auto',
+      filters: { authority: 'verified' },
+    },
+  }));
+  assert.equal(called.result.isError, false);
+  assert.equal(executions, 1);
+  assert.equal(called.result.structuredContent.next_cursor, 'opaque-cursor');
+  assert.equal(Object.hasOwn(called.result.structuredContent, 'items'), false);
+});


### PR DESCRIPTION
## Contexto

Décimo terceiro slice da issue #82, empilhado sobre a PR #122.

A paginação, o sidecar lexical, o FTS opcional e as métricas já existem no Core/Observer. Este PR expõe uma read MCP específica para esse contrato sem alterar silenciosamente `wendkeep_memory_recall`, que permanece como superfície legada.

## Nova tool

`wendkeep_evidence_recall` (`read`, capability `evidence:recall`).

Entrada:

- `project_root` e `query` obrigatórios;
- `limit` entre 1 e 100;
- cursor opaco vinculado à consulta, filtros, índice e `as_of`;
- `max_bytes` entre 2 e 524288 para o JSON exato de `results`;
- `candidate_limit` entre 1 e 4096;
- `posting_budget` entre 1 e 1048576;
- backend `auto`, `sqlite` ou `lexical`;
- filtros exatos por autoridade, validade, entidade, projeto, change, sessão, work session e logical path, além de prefixo.

## Saída

- página compacta com `results`, `next_cursor`, `has_more`, `as_of`, contagens e bytes;
- conteúdo integral omitido; cada item informa `content_bytes` e `excerpt` bounded;
- `logical_path` interno é substituído por `logical_ref`, relativo ao Vault;
- métricas de candidatos: backend, quantidade, postings, rebuild e fallback;
- `complete_candidate_set` deixa explícito quando o orçamento de candidatos não cobriu todo o conjunto possível.

## Compatibilidade

- `wendkeep_memory_recall` continua com o contrato atual;
- a nova tool funciona no Node 18 pelo sidecar lexical;
- SQLite/FTS5 permanece opcional e o modo `auto` degrada com segurança;
- o catálogo de effects foi versionado em `2026-08-27` e o integrity hash foi recalculado;
- respostas objeto preservam o cursor próprio da tool, sem repaginação genérica do servidor.

## Erros tipados

- `MCP_EVIDENCE_QUERY_REQUIRED`;
- `MCP_EVIDENCE_CURSOR_INVALID`;
- `MCP_EVIDENCE_BUDGET_TOO_SMALL`;
- `MCP_EVIDENCE_BACKEND_UNAVAILABLE`;
- `MCP_EVIDENCE_ARTIFACT_UNSAFE`;
- `MCP_EVIDENCE_RECALL_INVALID`.

## Testes

- paginação real sobre sidecar lexical e cursor opaco;
- `as_of` fixado entre páginas;
- cursor rejeitado com consulta divergente;
- orçamento mínimo rejeitado com erro tipado;
- filtros inválidos rejeitados;
- executor real com binding projeto↔Vault e ausência de paths locais;
- descriptor MCP com schemas e limites explícitos;
- query ausente bloqueada antes da execução;
- cursor próprio preservado na resposta do servidor.

## Documentação

A referência MCP foi atualizada em PT-BR e EN com parâmetros, exemplo, saída, compatibilidade e diagnóstico dos novos códigos.

## Escopo

- não altera a autoridade `EVIDENCE_INDEX.jsonl`;
- não envia dados a serviço externo;
- não adiciona dependências;
- não altera versão, changelog, release ou workflows.

Draft enquanto a suíte canônica valida a integração sobre #122.