### PR TITLE
docs: planejar finalização incremental do control plane

### DIFF
--- a/docs/superpowers/specs/2026-08-29-wendkeep-control-plane-finalization-design.md
+++ b/docs/superpowers/specs/2026-08-29-wendkeep-control-plane-finalization-design.md
@@ -1,8 +1,8 @@
 # Design — finalização incremental do WendKeep Control Plane
 
-**Status:** aprovado em conversa em 2026-08-29  
-**Perfil operacional:** `OFF`; governança pelo harness nativo, Keep Core ativo  
-**Escopo:** issues #40, #69, #81, #83 e #84 no repositório WendKeep
+- **Status:** aprovado em conversa em 2026-08-29
+- **Perfil operacional:** `OFF`; governança pelo harness nativo, Keep Core ativo
+- **Escopo:** issues #40, #69, #81, #83 e #84 no repositório WendKeep
 
 ## Contexto
 

--- a/docs/superpowers/specs/2026-08-29-wendkeep-control-plane-finalization-design.md
+++ b/docs/superpowers/specs/2026-08-29-wendkeep-control-plane-finalization-design.md
@@ -1,0 +1,257 @@
+# Design — finalização incremental do WendKeep Control Plane
+
+**Status:** aprovado em conversa em 2026-08-29  
+**Perfil operacional:** `OFF`; governança pelo harness nativo, Keep Core ativo  
+**Escopo:** issues #40, #69, #81, #83 e #84 no repositório WendKeep
+
+## Contexto
+
+A epic #69 possui doze das dezesseis entregas concluídas. As issues #70–#80 e #82 já foram
+entregues, mas o checklist da epic ainda não reflete esse estado. As quatro lacunas materiais são:
+
+- #40 — política universal de commit baseada em evidências;
+- #81 — segurança, autorização e ciclo de vida dos dados do Observer;
+- #83 — bridges oficiais para Spec Kit e Superpowers sem autoridade duplicada;
+- #84 — modularização final, migrations, CI e supply-chain hardening.
+
+A #84 depende das três primeiras e do receipt de commit da #40. A #69 só pode ser encerrada
+depois do E2E global do programa.
+
+## Decisões aprovadas
+
+| Tema | Decisão |
+|---|---|
+| Perfil | Permanecer em `OFF`; não criar leases, flows ou changes do Wend Runtime. |
+| Execução | Desenvolvimento paralelo das fundações, integração serial em `main`. |
+| Publicação | Produzir versões intermediárias `0.x`; não declarar `1.0.0`. |
+| PRs | Uma implementação revisável por PR; #84 será dividida em fases menores. |
+| Testes | Testes focados durante Red/Green; suíte longa somente no candidato final pré-merge. |
+| Merge | Só integrar commit final com testes focados, revisão, suíte longa e check remoto verdes. |
+| Epic | Atualizar #69 progressivamente e fechá-la apenas após todos os filhos e o E2E global. |
+
+## Topologia de branches e releases
+
+As três fundações podem ser desenvolvidas em paralelo:
+
+```text
+wk/universal-commit   (#40) ─┐
+wk/observer-security (#81) ─┼─→ #84 em fases → E2E global → fechar #69
+wk/ecosystem-bridges (#83) ─┘
+```
+
+A construção pode ocorrer em worktrees independentes, mas os merges serão serializados:
+
+1. #40;
+2. #81;
+3. #83;
+4. fases da #84;
+5. fechamento da #69.
+
+Cada branch nasce da `main` vigente. Antes da janela de integração, a branch é reconciliada com a
+`main` mais recente. Somente então são definidos o próximo minor `0.x`, o bump e a entrada do
+`CHANGELOG.md`. Isso evita colisões entre branches paralelas e impede reservar números que outra
+release possa ocupar.
+
+Uma referência inicial de cadência é `0.87.0` para #40, `0.88.0` para #81 e `0.89.0` para #83.
+Esses números são indicativos: `npm view wendkeep version` e o estado remoto são autoridade antes
+de cada bump.
+
+## #40 — commit universal baseado em evidências
+
+### Objetivo
+
+Gerar e validar mensagens de commit determinísticas sem depender do comportamento de um host ou
+modelo específico e sem inventar provas.
+
+### Componentes
+
+- kernel de commit com entrada tipada e saída determinística;
+- coletor limitado a diff staged, tarefas, ADR, Evidence Envelope, evidência e verdict válidos;
+- skill canônica `wk-commit` sincronizável para Codex e Claude;
+- wrappers Node multiplataforma em `.githooks/`;
+- `prepare-commit-msg` idempotente para estruturar o rascunho;
+- `commit-msg` para rejeitar formato, autoridade, privacidade ou evidência inválidos;
+- validação equivalente no CI para detectar bypass local.
+
+### Regras de autoridade e privacidade
+
+- somente evidência ligada ao checkout e commit correto pode ser promovida como verificada;
+- campos privados do Vault/runtime nunca entram na mensagem;
+- segredos, tokens, caminhos locais e PII são rejeitados ou sanitizados;
+- coautoria só é registrada quando uma identidade factual está disponível;
+- amend, merge, squash, reuso de mensagem e commits sem change não duplicam nem fabricam corpo.
+
+## #81 — segurança e ciclo de vida do Observer
+
+### Objetivo
+
+Transformar as proteções locais atuais em um contrato explícito de captura, autorização, retenção,
+purge, auditoria e criptografia.
+
+### Componentes
+
+- threat model e classificação versionada de dados;
+- policy engine por classe, path, entidade, projeto e operação;
+- redaction configurável para conteúdo documental, prompts, respostas e transcripts;
+- registry de tokens armazenados por hash, com projeto, roles, scopes, expiração e revogação;
+- matriz endpoint × capability aplicada a leituras e mutações;
+- retention runner e purge transacional, idempotente e acompanhado por receipt;
+- audit log sem registrar o conteúdo sensível acessado;
+- adapter de criptografia at rest com AES-256-GCM e material de chave externo;
+- migrations seguras para bancos, outbox e conteúdo existentes;
+- integração com publisher, MCP, sync e dashboard.
+
+### Defaults de segurança
+
+- ingest e mutações exigem autenticação;
+- leituras sensíveis exigem autorização mesmo em loopback;
+- agregados não sensíveis podem permanecer abertos em loopback quando a política permitir;
+- política que exige criptografia falha fechada quando a chave está ausente ou inválida;
+- purge remove derivados e índices, registra tombstone/receipt e não expõe o payload removido.
+
+O novo contrato substitui explicitamente a regra histórica que permitia mutações locais sem Bearer.
+
+## #83 — bridges oficiais do ecossistema
+
+### Objetivo
+
+Integrar Spec Kit e Superpowers como adapters opcionais, preservando o WendKeep como autoridade de
+contratos, evidência e estado governado.
+
+### Contrato do bridge
+
+- schema versionado com ownership, origem, IDs, hashes e compatibility range;
+- matriz explícita de precedência e conflito;
+- habilitação independente de cada adapter;
+- ausência ou versão incompatível produz diagnóstico tipado, sem fallback silencioso.
+
+### Spec Kit
+
+- detector/importador somente leitura;
+- preservação de IDs e hashes da fonte;
+- referência externa, nunca cópia promovida automaticamente a autoridade canônica;
+- bloqueio de execução quando drift ou ownership concorrente for detectado.
+
+### Superpowers
+
+- dispatch derivado dos task/handoff contracts canônicos;
+- ingest de artifacts, reviews e commits inicialmente como `reported`;
+- promoção para `verified` somente após prova Git, CI ou Evidence Envelope compatível;
+- nenhuma escrita direta sobre o plano ou tarefas canônicas.
+
+O E2E isolado cobre Spec Kit → bridge → WendKeep → Superpowers → artifacts/review → prova Git/CI →
+cleanup.
+
+## #84 — modularização, migrations, CI e supply chain
+
+A issue será dividida em PRs menores, mantendo um único checklist de fechamento.
+
+### Fase A — packages e fachadas
+
+- extrair worktrees, Observer, sync e contracts/evidence para packages com APIs públicas claras;
+- manter fachadas legadas finas durante a janela de compatibilidade;
+- reduzir `src/memory.mjs`, `src/init.mjs` e hooks de sessão a composição/orquestração;
+- preservar grafo acíclico e impedir imports reversos.
+
+### Fase B — migration harness
+
+- registry unificado de migrations para Vault, ledger, active contexts, Observer e portable state;
+- operações `plan`, `apply`, `rollback` e `repair` com journal e receipt;
+- fixtures N-2 e N-1;
+- crash injection por etapa, retomada idempotente e validação pós-reparo;
+- falha fechada para versão futura ou estado incompatível.
+
+### Fase C — CI e supply chain
+
+- matriz relevante com Linux, Windows, macOS e Node 20;
+- thresholds de coverage por package e mutation testing nos kernels críticos;
+- Actions fixadas por commit SHA e permissões mínimas por job;
+- CodeQL, dependency review, SBOM e proveniência do tarball;
+- branch protection com os checks finais requeridos antes do merge.
+
+### Fase D — compatibilidade e fechamento técnico
+
+- tarball instalado em consumidor isolado com configurações Claude, Codex e MCP;
+- matriz pública de compatibilidade;
+- política de suporte, depreciação e remoção das fachadas legadas;
+- documentação arquitetural PT-BR/EN;
+- integração do receipt da #40 ao fechamento de commit/release.
+
+As fases permanecem em versões `0.x`; o encerramento da #84 não implica release `1.0.0`.
+
+## #69 — fechamento do programa
+
+Após cada issue filha:
+
+1. atualizar somente os checkboxes correspondentes na epic;
+2. registrar o PR, versão, tag, Release e evidência de merge;
+3. não marcar o DoD global por inferência.
+
+O E2E final parte de clone limpo e comprova:
+
+- duas worktrees concorrentes sem troca de contexto, handoff ou evidência;
+- prova vinculada ao checkout exato;
+- retomada por contratos estruturados;
+- transporte de authored state sem runtime privado;
+- MCP capability-gated;
+- degradação explícita dos hosts;
+- cleanup pós-merge;
+- segurança e ciclo de vida do Observer;
+- bridges sem autoridade duplicada;
+- commit derivado de prova fresca;
+- migrations, pacote instalado e receipts/release alinhados.
+
+Somente depois desse E2E os itens restantes do DoD e a #69 podem ser fechados.
+
+## Estratégia de testes
+
+### Durante Red/Green
+
+- executar apenas o arquivo, package ou cenário diretamente afetado;
+- usar testes discriminantes para contratos, segurança, migrations e falhas esperadas;
+- rodar checks rápidos de sintaxe, fronteira, privacidade ou documentação somente quando aplicáveis;
+- não executar a suíte completa após ajustes pequenos.
+
+### Candidato final pré-merge
+
+Para o commit final de cada PR:
+
+1. executar todos os testes focados da issue;
+2. executar checks de pacote, privacidade, documentação bilíngue e tarball quando aplicáveis;
+3. revisar o diff de forma independente;
+4. executar a suíte longa completa uma vez;
+5. exigir o check remoto do PR verde.
+
+Qualquer alteração posterior invalida o candidato e exige nova prova proporcional; se o commit
+mudar depois da suíte longa, a suíte longa é repetida. Após o merge, não há repetição manual: a
+matriz automática de release é a validação remota.
+
+## Tratamento de falhas
+
+- falha focada bloqueia a tarefa correspondente;
+- falha longa no candidato bloqueia o merge e é investigada antes de nova execução completa;
+- conflito de versão/changelog é resolvido somente após reconciliar com a `main` e o npm atual;
+- drift externo nos bridges bloqueia import/dispatch;
+- chave ausente sob política de criptografia obrigatória bloqueia persistência sensível;
+- migration interrompida retoma pelo journal ou executa repair explícito;
+- check remoto ou branch protection divergente bloqueia merge/release;
+- nenhum gate é contornado para cumprir calendário.
+
+## Fora do escopo
+
+- declarar ou publicar `1.0.0`;
+- tornar Spec Kit ou Superpowers autoridades do estado WendKeep;
+- armazenar chaves criptográficas dentro do repositório ou banco do Observer;
+- publicar Vault, runtime privado, transcripts ou dados reais;
+- remover fachadas legadas sem janela documentada de compatibilidade;
+- agrupar todas as entregas em uma mega-PR;
+- executar repetidamente a suíte longa durante desenvolvimento incremental.
+
+## Critérios de conclusão do design
+
+- #40, #81 e #83 possuem PRs e releases intermediárias independentes;
+- #84 é entregue em fases revisáveis, todas em versões `0.x`;
+- cada merge corresponde a um commit final testado e a um check remoto verde;
+- npm, tag, GitHub Release e changelog permanecem alinhados por versão;
+- #69 reflete os estados reais e só fecha após o E2E program-level;
+- o perfil persistente continua `OFF` durante todo o programa.

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/phase-01-universal-commit.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/phase-01-universal-commit.md
@@ -2,9 +2,9 @@
 
 ## Visão geral
 
-**Branch:** `wk/universal-commit`  
-**Prioridade:** alta; desbloqueia receipt final da #84  
-**Estado:** pendente
+- **Branch:** `wk/universal-commit`
+- **Prioridade:** alta; desbloqueia receipt final da #84
+- **Estado:** pendente
 
 Criar uma mensagem de commit reproduzível em hosts diferentes, baseada somente em prova permitida.
 

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/phase-01-universal-commit.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/phase-01-universal-commit.md
@@ -1,0 +1,93 @@
+# Fase 01 — #40: commit universal baseado em evidências
+
+## Visão geral
+
+**Branch:** `wk/universal-commit`  
+**Prioridade:** alta; desbloqueia receipt final da #84  
+**Estado:** pendente
+
+Criar uma mensagem de commit reproduzível em hosts diferentes, baseada somente em prova permitida.
+
+## Requisitos
+
+- Entrada tipada: staged diff, identidade factual, ADR, tarefas e referências de evidência.
+- Saída determinística e idempotente.
+- Nenhum acesso irrestrito ao conteúdo privado do Vault.
+- `prepare-commit-msg` estrutura; `commit-msg` valida.
+- Amend, merge, squash e commits sem contexto não recebem conteúdo falso ou duplicado.
+- CI detecta mensagens inválidas mesmo quando hooks locais foram ignorados.
+
+## Arquitetura
+
+```text
+evidence refs + staged diff + identity
+                ↓
+        @wendkeep/commit kernel
+          ↙                 ↘
+prepare-commit-msg       commit-msg/CI
+```
+
+O kernel recebe dados já limitados e sanitizados. Ele não resolve autoridade por texto livre.
+
+## Arquivos
+
+### Criar
+
+- `C:/GitHub/WendKeep/packages/commit/package.json` — workspace `@wendkeep/commit`.
+- `C:/GitHub/WendKeep/packages/commit/src/index.mjs` — API pública.
+- `C:/GitHub/WendKeep/packages/commit/src/commit-input.mjs` — normalização e schema.
+- `C:/GitHub/WendKeep/packages/commit/src/commit-message.mjs` — render determinístico.
+- `C:/GitHub/WendKeep/packages/commit/src/commit-policy.mjs` — validação/privacidade.
+- `C:/GitHub/WendKeep/schema/commit-message-v1.schema.json` — contrato versionado.
+- `C:/GitHub/WendKeep/.githooks/prepare-commit-msg` — wrapper portátil.
+- `C:/GitHub/WendKeep/.githooks/commit-msg` — wrapper portátil.
+- `C:/GitHub/WendKeep/scripts/validate-commit-range.mjs` — gate remoto.
+- `C:/GitHub/WendKeep/tests/commit-message.test.mjs` — kernel e mutantes.
+- `C:/GitHub/WendKeep/tests/git-commit-hooks.test.mjs` — Git real Windows/POSIX.
+- `C:/GitHub/WendKeep/tests/commit-range-policy.test.mjs` — bypass/API/CI.
+- `C:/GitHub/WendKeep/docs/pt-BR/commands/commit.md`.
+- `C:/GitHub/WendKeep/docs/en/commands/commit.md`.
+
+### Modificar
+
+- `C:/GitHub/WendKeep/bin/wendkeep.mjs` — comando de preparação/validação.
+- `C:/GitHub/WendKeep/packages/cli/src/index.mjs` — roteamento CLI.
+- `C:/GitHub/WendKeep/src/init.mjs` — instalação opt-in de `core.hooksPath`.
+- `C:/GitHub/WendKeep/src/doctor.mjs` — diagnóstico e recuperação dos hooks.
+- `C:/GitHub/WendKeep/src/skills-seed.mjs` — skill `wk-commit` Codex/Claude.
+- `C:/GitHub/WendKeep/.github/workflows/test.yml` — validação de commits do PR.
+- `C:/GitHub/WendKeep/package.json` — workspace/export/check/files.
+- `C:/GitHub/WendKeep/README.md` e `README.en.md` — resumo bilíngue.
+
+## Passos
+
+1. Escrever testes vermelhos do schema, determinismo, privacidade e autoridade.
+2. Implementar normalização e render sem I/O.
+3. Implementar policy validator e mutantes de prova ausente/falsa.
+4. Criar wrappers Git e testes em repositórios temporários reais.
+5. Integrar CLI, init, doctor e skill.
+6. Adicionar gate de range de commits ao workflow.
+7. Documentar instalação, diagnóstico e recuperação em PT-BR/EN.
+8. Preparar candidato final, revisão e gates de integração.
+
+## Testes focados
+
+- `node --test tests/commit-message.test.mjs`
+- `node --test tests/git-commit-hooks.test.mjs`
+- `node --test tests/commit-range-policy.test.mjs`
+- Testes existentes de envelope, provenance, skills, init e doctor afetados.
+
+## Critérios de sucesso
+
+- Codex e Claude produzem mensagem equivalente para a mesma entrada.
+- Hooks rejeitam corpo/ADR/evidência inválidos sem vazar conteúdo privado.
+- Gate remoto detecta bypass local.
+- Hooks passam em Windows e POSIX.
+- Docs PT-BR/EN e tarball contêm a nova superfície.
+
+## Riscos e mitigação
+
+- **Hook quebra commits comuns:** ativação opt-in e bypass documentado apenas para commits fora do contrato.
+- **Leitura privada excessiva:** API recebe referências sanitizadas, não o Vault inteiro.
+- **Diferença de shell:** lógica em Node; scripts de hook só delegam.
+- **Mensagem instável:** ordenação canônica e snapshot tests sem timestamps voláteis.

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/phase-02-observer-security.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/phase-02-observer-security.md
@@ -1,0 +1,107 @@
+# Fase 02 — #81: segurança e ciclo de vida do Observer
+
+## Visão geral
+
+**Branch:** `wk/observer-security`  
+**Prioridade:** alta; superfície sensível  
+**Estado:** pendente
+
+Adicionar policy, AuthZ, retenção, purge, auditoria e criptografia sem quebrar isolamento por projeto.
+
+## Requisitos
+
+- Threat model e classificação oficial.
+- Captura e redaction por classe/path/entidade/projeto.
+- Tokens hashados com roles, scopes, expiração, rotação e revogação.
+- Leituras sensíveis autenticadas, inclusive loopback.
+- Retention/purge idempotente com receipt.
+- Encryption-at-rest com chave externa e falha fechada quando obrigatória.
+- Audit log sem payload sensível.
+- Migration segura e integração com publisher, MCP, sync e dashboard.
+
+## Arquitetura
+
+```text
+publisher/API/MCP/sync
+        ↓
+ policy → redaction → authorization
+        ↓              ↓
+ encrypted store    access audit
+        ↓
+ retention/purge → deletion receipt
+```
+
+O package Observer recebe interfaces explícitas para clock, key provider e receipt sink; testes não
+dependem de segredos ou tempo real.
+
+## Arquivos
+
+### Criar
+
+- `C:/GitHub/WendKeep/packages/observer/package.json`.
+- `C:/GitHub/WendKeep/packages/observer/src/policy.mjs`.
+- `C:/GitHub/WendKeep/packages/observer/src/redaction.mjs`.
+- `C:/GitHub/WendKeep/packages/observer/src/authz.mjs`.
+- `C:/GitHub/WendKeep/packages/observer/src/token-registry.mjs`.
+- `C:/GitHub/WendKeep/packages/observer/src/encryption.mjs`.
+- `C:/GitHub/WendKeep/packages/observer/src/retention.mjs`.
+- `C:/GitHub/WendKeep/packages/observer/src/purge.mjs`.
+- `C:/GitHub/WendKeep/packages/observer/src/audit.mjs`.
+- `C:/GitHub/WendKeep/packages/observer/src/index.mjs`.
+- `C:/GitHub/WendKeep/schema/observer/004-security.sql` — tokens, audit e receipts.
+- `C:/GitHub/WendKeep/schema/observer-policy-v1.schema.json`.
+- `C:/GitHub/WendKeep/tests/observer-policy.test.mjs`.
+- `C:/GitHub/WendKeep/tests/observer-authz.test.mjs`.
+- `C:/GitHub/WendKeep/tests/observer-retention-purge.test.mjs`.
+- `C:/GitHub/WendKeep/tests/observer-encryption.test.mjs`.
+- `C:/GitHub/WendKeep/tests/observer-security-migration.test.mjs`.
+- `C:/GitHub/WendKeep/docs/pt-BR/commands/observer-security.md`.
+- `C:/GitHub/WendKeep/docs/en/commands/observer-security.md`.
+
+### Modificar
+
+- `C:/GitHub/WendKeep/src/observer-auth.mjs` e `observer-privacy.mjs` — fachadas compatíveis.
+- `C:/GitHub/WendKeep/src/observer-server.mjs` — middleware endpoint × capability.
+- `C:/GitHub/WendKeep/src/observer-sql-publish.mjs` — policy/redaction/encryption.
+- `C:/GitHub/WendKeep/src/observer-sql-store.mjs` — store e purge transacional.
+- `C:/GitHub/WendKeep/src/observer-sql-migrate.mjs` — migration 004.
+- `C:/GitHub/WendKeep/src/observer-transcript-store.mjs` — conteúdo cifrado.
+- `C:/GitHub/WendKeep/hooks/observer-publish.mjs` — policy explícita/fail-open controlado.
+- `C:/GitHub/WendKeep/packages/mcp/src/executor.mjs` — scopes Observer.
+- `C:/GitHub/WendKeep/src/sync-protocol.mjs` — metadata de policy sem duplicar autoridade.
+- `C:/GitHub/WendKeep/web/observer/app.mjs` — administração e redaction visual.
+- Docs e READMEs PT-BR/EN correspondentes.
+
+## Passos
+
+1. Fixar threat model, data classes e supersession do contrato local-open.
+2. Implementar policy/redaction puras com corpus adversarial.
+3. Implementar token registry e AuthZ project-scoped.
+4. Aplicar middleware a cada endpoint e bloquear leituras sensíveis sem scope.
+5. Implementar adapter AES-256-GCM e key provider externo.
+6. Implementar TTL runner e purge transacional com receipt/audit.
+7. Criar migration idempotente, backup e rollback seguro.
+8. Integrar publisher, MCP, sync e dashboard.
+9. Atualizar documentação bilíngue e preparar candidato.
+
+## Testes focados
+
+- Novos cinco arquivos de segurança.
+- `observer-project-isolation`, `observer-sql-api`, `observer-sql-publish`, `observer-server`.
+- Fixtures de token expirado/revogado, scope cruzado, chave errada e purge interrompido.
+- Teste preexistente de lote gzip >64 MB deve estar verde no candidato, sem atribuir regressão falsa à #81.
+
+## Critérios de sucesso
+
+- Nenhum token acessa projeto/scope alheio.
+- Conteúdo sensível não aparece em store, export ou audit quando policy proíbe.
+- Purge repetido é seguro e possui receipt verificável.
+- Dados protegidos não são legíveis sem a chave correta.
+- Upgrade de DB existente preserva dados permitidos e falha recuperavelmente.
+
+## Riscos e mitigação
+
+- **Lockout local:** comando de recuperação offline, explícito e auditado.
+- **Perda por purge:** dry-run, transação, receipt e política mínima documentada.
+- **Chave indisponível:** falha fechada apenas quando policy exige; diagnóstico sem segredo.
+- **Drift UI/API:** contract tests da matriz endpoint × capability.

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/phase-02-observer-security.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/phase-02-observer-security.md
@@ -2,9 +2,9 @@
 
 ## Visão geral
 
-**Branch:** `wk/observer-security`  
-**Prioridade:** alta; superfície sensível  
-**Estado:** pendente
+- **Branch:** `wk/observer-security`
+- **Prioridade:** alta; superfície sensível
+- **Estado:** pendente
 
 Adicionar policy, AuthZ, retenção, purge, auditoria e criptografia sem quebrar isolamento por projeto.
 

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/phase-03-ecosystem-bridges.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/phase-03-ecosystem-bridges.md
@@ -2,9 +2,9 @@
 
 ## Visão geral
 
-**Branch:** `wk/ecosystem-bridges`  
-**Prioridade:** alta  
-**Estado:** pendente
+- **Branch:** `wk/ecosystem-bridges`
+- **Prioridade:** alta
+- **Estado:** pendente
 
 Adicionar adapters opcionais sem criar uma segunda autoridade de plano, tarefa ou evidência.
 

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/phase-03-ecosystem-bridges.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/phase-03-ecosystem-bridges.md
@@ -1,0 +1,91 @@
+# Fase 03 — #83: bridges Spec Kit e Superpowers
+
+## Visão geral
+
+**Branch:** `wk/ecosystem-bridges`  
+**Prioridade:** alta  
+**Estado:** pendente
+
+Adicionar adapters opcionais sem criar uma segunda autoridade de plano, tarefa ou evidência.
+
+## Requisitos
+
+- Bridge schema e matriz de ownership/precedência versionados.
+- Importador Spec Kit read-only com IDs/hashes preservados.
+- Drift e ownership concorrente bloqueiam execução.
+- Dispatch Superpowers deriva somente dos contratos canônicos.
+- Artifacts externos entram como `reported` até prova Git/CI.
+- Adapters habilitáveis separadamente e protegidos por compatibility ranges.
+- Ausência/incompatibilidade gera diagnóstico tipado.
+
+## Arquitetura
+
+```text
+Spec Kit --read-only--> bridge projection
+                              ↓
+WendKeep task/handoff/artifact authority
+                              ↓
+                   Superpowers dispatch
+                              ↓
+external artifacts --verify Git/CI--> Evidence Envelope
+```
+
+## Arquivos
+
+### Criar
+
+- `C:/GitHub/WendKeep/schema/ecosystem-bridge-v1.schema.json`.
+- `C:/GitHub/WendKeep/packages/integrations/src/bridge-contract.mjs`.
+- `C:/GitHub/WendKeep/packages/integrations/src/bridge-diagnostics.mjs`.
+- `C:/GitHub/WendKeep/packages/integrations/src/spec-kit-adapter.mjs`.
+- `C:/GitHub/WendKeep/packages/integrations/src/superpowers-adapter.mjs`.
+- `C:/GitHub/WendKeep/packages/integrations/src/bridge-config.mjs`.
+- `C:/GitHub/WendKeep/tests/ecosystem-bridge-contract.test.mjs`.
+- `C:/GitHub/WendKeep/tests/spec-kit-adapter.test.mjs`.
+- `C:/GitHub/WendKeep/tests/superpowers-adapter.test.mjs`.
+- `C:/GitHub/WendKeep/tests/ecosystem-bridge-e2e.test.mjs`.
+- `C:/GitHub/WendKeep/docs/pt-BR/commands/ecosystem-bridges.md`.
+- `C:/GitHub/WendKeep/docs/en/commands/ecosystem-bridges.md`.
+
+### Modificar
+
+- `C:/GitHub/WendKeep/packages/integrations/src/index.mjs` — exports.
+- `C:/GitHub/WendKeep/packages/integrations/src/capabilities.mjs` — adapters/ranges.
+- `C:/GitHub/WendKeep/src/task-contracts.mjs` — entrada externa nunca verificada por default.
+- `C:/GitHub/WendKeep/src/task.mjs` — diagnostics/dispatch sem ownership externo.
+- `C:/GitHub/WendKeep/src/doctor.mjs` — detecção e compatibilidade.
+- `C:/GitHub/WendKeep/bin/wendkeep.mjs` e `packages/cli/src/index.mjs` — comandos bridge.
+- `C:/GitHub/WendKeep/package.json` — schema/docs/check/tarball.
+- READMEs e guias PT-BR/EN correspondentes.
+
+## Passos
+
+1. Escrever schema, matriz de autoridade e testes de conflito.
+2. Tornar autoridade externa `reported` por construção.
+3. Implementar detecção e import Spec Kit sem writes.
+4. Implementar drift/hash/ID diagnostics.
+5. Implementar dispatch Superpowers a partir de contracts derivados.
+6. Verificar artifacts/reviews/commits por Git/CI antes de promover autoridade.
+7. Cobrir adapter ausente, incompatível e desabilitado.
+8. Executar E2E em consumidor isolado e documentar small/medium/large.
+
+## Testes focados
+
+- Quatro novos arquivos de bridge.
+- `task-contracts`, `host-capabilities`, `doctor`, `mcp` e tarball afetados.
+- Mutantes: adapter escreve plano, external vira verified, hash ignorado, range ignorado.
+
+## Critérios de sucesso
+
+- Spec Kit nunca modifica o estado canônico.
+- Superpowers nunca assume ownership de plano/tarefa.
+- Drift é diagnosticado antes de execute/verify.
+- Artifacts só viram `verified` com prova independente.
+- Cada adapter funciona ausente/desabilitado sem degradar o Core.
+
+## Riscos e mitigação
+
+- **Formato externo volátil:** compatibility range e parser isolado por versão.
+- **Autoridade duplicada:** ownership obrigatório no schema e conflito fail-closed.
+- **Texto não confiável:** normalização estrutural; nunca executar comandos importados.
+- **Dependência opcional quebrando install:** zero import/autoload quando adapter desabilitado.

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/phase-04-package-extraction.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/phase-04-package-extraction.md
@@ -2,9 +2,9 @@
 
 ## Visão geral
 
-**Branch:** `wk/architecture-packages-0x`  
-**Dependências:** fases 01–03 integradas  
-**Estado:** bloqueada
+- **Branch:** `wk/architecture-packages-0x`
+- **Dependências:** fases 01–03 integradas
+- **Estado:** bloqueada
 
 Extrair domínios sem quebrar exports legados nem criar ciclos.
 

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/phase-04-package-extraction.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/phase-04-package-extraction.md
@@ -1,0 +1,73 @@
+# Fase 04 — #84-A: packages e fachadas
+
+## Visão geral
+
+**Branch:** `wk/architecture-packages-0x`  
+**Dependências:** fases 01–03 integradas  
+**Estado:** bloqueada
+
+Extrair domínios sem quebrar exports legados nem criar ciclos.
+
+## Grafo-alvo
+
+```text
+cli → harness/worktrees/observer/sync/mcp
+harness → contracts/evidence/integrations/vault
+worktrees → contracts/vault
+observer → integrations/vault
+sync → integrations/vault
+mcp → contracts/evidence/integrations/vault
+```
+
+Packages de domínio não importam CLI. Fachadas `src/*` só delegam durante a janela de suporte.
+
+## Arquivos
+
+### Criar
+
+- `C:/GitHub/WendKeep/packages/worktrees/` — create/list/status/open/cleanup.
+- `C:/GitHub/WendKeep/packages/sync/` — protocol/outbox/adapters.
+- `C:/GitHub/WendKeep/packages/contracts/` — task/handoff/artifact/TDD contracts.
+- `C:/GitHub/WendKeep/packages/evidence/` — envelope, provenance e receipt interfaces.
+- Tests públicos por package e contract tests das fachadas.
+
+### Modificar
+
+- `C:/GitHub/WendKeep/src/worktree.mjs` e `worktree-cleanup.mjs` — fachadas.
+- `C:/GitHub/WendKeep/src/sync-*.mjs` — fachadas.
+- `C:/GitHub/WendKeep/src/task-contracts.mjs`, `tdd-attestation*.mjs`, `evidence-envelope.mjs`,
+  `provenance-*.mjs` e `receipt-ledger.mjs` — fachadas/composição.
+- `C:/GitHub/WendKeep/src/memory.mjs` — remover responsabilidades já encapsuladas.
+- `C:/GitHub/WendKeep/src/init.mjs` e hooks de sessão — apenas composição.
+- `C:/GitHub/WendKeep/package.json` — exports públicos e deprecation controlada.
+- `C:/GitHub/WendKeep/tests/modular-package-boundaries.test.mjs` — grafo completo.
+
+## Passos
+
+1. Gerar dependency graph atual e definir ownership arquivo a arquivo.
+2. Extrair um domínio por commit lógico, começando por contracts/evidence.
+3. Extrair worktrees e sync.
+4. Completar o package Observer iniciado na fase 02.
+5. Converter `src/*` em fachadas sem comportamento.
+6. Adicionar contract tests comparando API nova e fachada.
+7. Publicar exports e avisos de depreciação sem remoção imediata.
+
+## Testes focados
+
+- Boundary tests estáticos após cada extração.
+- Testes públicos do domínio movido.
+- Testes das fachadas e tarball somente quando exports mudarem.
+- Sem suíte longa entre extrações; uma vez no candidato final.
+
+## Critérios de sucesso
+
+- Grafo acíclico e sem import reverso.
+- Packages utilizáveis sem carregar CLI ou Observer indevidamente.
+- Fachadas legadas mantêm comportamento e códigos de erro.
+- `src/memory.mjs` e `src/init.mjs` ficam estritamente orquestradores.
+
+## Riscos e mitigação
+
+- **Mega-diff:** extrações ordenadas e commits lógicos dentro do mesmo PR revisável.
+- **Ciclo oculto:** gate estático a cada passo.
+- **Quebra de consumidor:** contract tests e janela de depreciação.

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/phase-05-migration-harness.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/phase-05-migration-harness.md
@@ -1,0 +1,76 @@
+# Fase 05 — #84-B: migration harness
+
+## Visão geral
+
+**Branch:** `wk/migration-harness-0x`  
+**Dependência:** packages da fase 04  
+**Estado:** bloqueada
+
+Unificar migrations de Vault, ledger, contexts, Observer e portable state com recuperação explícita.
+
+## Arquitetura
+
+```text
+registry → plan → journal → apply step(s) → verify → receipt
+                    ↘ crash ↙
+                 resume/repair/rollback
+```
+
+Cada migration declara origem, destino, preconditions, passos idempotentes, verificação e estratégia
+de rollback/repair.
+
+## Arquivos
+
+### Criar
+
+- `C:/GitHub/WendKeep/packages/migrations/package.json`.
+- `C:/GitHub/WendKeep/packages/migrations/src/registry.mjs`.
+- `C:/GitHub/WendKeep/packages/migrations/src/runner.mjs`.
+- `C:/GitHub/WendKeep/packages/migrations/src/journal.mjs`.
+- `C:/GitHub/WendKeep/packages/migrations/src/receipt.mjs`.
+- `C:/GitHub/WendKeep/packages/migrations/src/index.mjs`.
+- `C:/GitHub/WendKeep/schema/migration-receipt-v1.schema.json`.
+- `C:/GitHub/WendKeep/tests/migration-harness.test.mjs`.
+- `C:/GitHub/WendKeep/tests/migration-sequential-upgrade.test.mjs`.
+- `C:/GitHub/WendKeep/tests/migration-crash-repair.test.mjs`.
+- `C:/GitHub/WendKeep/tests/fixtures/migrations/n-2/` e `n-1/` sanitizados.
+- Guias PT-BR/EN de upgrade, rollback e repair.
+
+### Modificar
+
+- `C:/GitHub/WendKeep/hooks/active-context-store.mjs` — adapter de migration.
+- `C:/GitHub/WendKeep/src/observer-sql-migrate.mjs` — registry comum.
+- `C:/GitHub/WendKeep/src/portable.mjs` — upgrade antes de rejeitar schema suportado.
+- Stores de memória/ledger — registrations sem I/O duplicado.
+- CLI, doctor, package exports, READMEs e docs bilíngues.
+
+## Passos
+
+1. Definir contrato e receipt de migration.
+2. Implementar plan dry-run e validação de preconditions.
+3. Implementar journal atômico e runner idempotente.
+4. Adaptar active context, Observer e portable state.
+5. Adaptar Vault/ledger sem alterar autoridade histórica.
+6. Criar fixtures N-2/N-1 e upgrades sequenciais.
+7. Injetar crash antes/depois de cada passo e provar resume/repair.
+8. Documentar rollback quando possível e repair quando rollback não for seguro.
+
+## Testes focados
+
+- Três novos arquivos de harness.
+- Suites existentes de active context, Observer migrate, portable e memory migration.
+- Mutantes: passo repetido, journal truncado, checksum divergente, versão futura, crash pós-write.
+
+## Critérios de sucesso
+
+- N-2 e N-1 chegam ao schema atual sem perda de autoridade.
+- Crash em qualquer passo não produz estado silenciosamente parcial.
+- Resume e repair são idempotentes.
+- Versão futura falha fechada e preserva os dados.
+- Receipt identifica origem, destino, passos, hashes e resultado.
+
+## Riscos e mitigação
+
+- **Fixture irreal:** snapshots sanitizados derivados de formatos publicados reais.
+- **Rollback destrutivo:** backup verificado e repair preferido quando não reversível.
+- **Concorrência:** lock por recurso e comparação de generation/revision.

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/phase-05-migration-harness.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/phase-05-migration-harness.md
@@ -2,9 +2,9 @@
 
 ## Visão geral
 
-**Branch:** `wk/migration-harness-0x`  
-**Dependência:** packages da fase 04  
-**Estado:** bloqueada
+- **Branch:** `wk/migration-harness-0x`
+- **Dependência:** packages da fase 04
+- **Estado:** bloqueada
 
 Unificar migrations de Vault, ledger, contexts, Observer e portable state com recuperação explícita.
 

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/phase-06-ci-supply-chain.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/phase-06-ci-supply-chain.md
@@ -1,0 +1,78 @@
+# Fase 06 — #84-C/D: CI, supply chain e suporte
+
+## Visão geral
+
+**Branch:** `wk/ci-supply-chain-0x`  
+**Dependências:** packages e migration harness  
+**Estado:** bloqueada
+
+Fechar os gates de plataforma, qualidade, dependências, artefatos e proteção remota sem antecipar 1.0.
+
+## Requisitos
+
+- Linux, Windows, macOS e Node 20 na matriz relevante.
+- Coverage threshold por package e mutation em kernels críticos.
+- Actions fixadas por SHA; permissões mínimas por job.
+- CodeQL, dependency review, SBOM e provenance do tarball.
+- Tarball testado em consumidor isolado.
+- Compatibility/support/deprecation policy PT-BR/EN.
+- Required checks na proteção da `main` somente após nomes estabilizados.
+
+## Arquivos
+
+### Criar
+
+- `C:/GitHub/WendKeep/.github/workflows/codeql.yml`.
+- `C:/GitHub/WendKeep/.github/workflows/dependency-review.yml`.
+- `C:/GitHub/WendKeep/scripts/coverage-gate.mjs`.
+- `C:/GitHub/WendKeep/scripts/mutation-kernels.mjs`.
+- `C:/GitHub/WendKeep/scripts/generate-sbom.mjs`.
+- `C:/GitHub/WendKeep/tests/ci-policy.test.mjs`.
+- `C:/GitHub/WendKeep/tests/sbom.test.mjs`.
+- `C:/GitHub/WendKeep/docs/pt-BR/compatibility.md`.
+- `C:/GitHub/WendKeep/docs/en/compatibility.md`.
+- `C:/GitHub/WendKeep/docs/pt-BR/support-policy.md`.
+- `C:/GitHub/WendKeep/docs/en/support-policy.md`.
+
+### Modificar
+
+- `C:/GitHub/WendKeep/.github/workflows/test.yml` — matriz e permissões.
+- `C:/GitHub/WendKeep/.github/workflows/auto-tag.yml` — SHAs, jobs e artifacts.
+- `C:/GitHub/WendKeep/package.json` — scripts e toolchain.
+- `C:/GitHub/WendKeep/tests/tarball-smoke.test.mjs` — packages/adapters/migrations.
+- READMEs e arquitetura PT-BR/EN.
+- Configuração remota de branch protection após autorização operacional.
+
+## Passos
+
+1. Inventariar Actions e fixar versões por commit SHA com comentário da versão humana.
+2. Separar permissões por job; `id-token: write` apenas no publish.
+3. Adicionar Node 20/macOS sem duplicar matrizes irrelevantes.
+4. Definir thresholds iniciais a partir do baseline e impedir regressão.
+5. Mutar somente policy/authz, contracts/authority, migrations e provenance.
+6. Adicionar CodeQL e dependency review.
+7. Gerar SBOM do tarball e anexar ao receipt/release.
+8. Expandir consumer tarball e publicar matrizes/políticas bilíngues.
+9. Ler nomes reais dos checks e configurar branch protection.
+
+## Testes focados
+
+- `ci-policy`, `sbom`, `tarball-smoke`, release/provenance e docs bilíngues.
+- Validação YAML e dry-runs locais onde disponíveis.
+- Jobs remotos do PR são a prova de macOS/CodeQL/dependency review.
+- Suíte longa local apenas no candidato final.
+
+## Critérios de sucesso
+
+- Nenhuma Action usa tag mutável.
+- Jobs têm permissões mínimas.
+- SBOM e provenance correspondem ao tarball publicado.
+- Required checks impedem merge sem gates definidos.
+- Matriz de suporte explica claramente plataformas e janela das fachadas.
+
+## Riscos e mitigação
+
+- **CI excessivo:** matriz por superfície, não produto cartesiano completo.
+- **Mutation lenta:** somente kernels críticos e execução final/agendada.
+- **SHA incorreto:** Dependabot/renovação controlada e teste de policy.
+- **Lockout da main:** configurar checks somente depois de execução verde e com bypass do owner preservado.

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/phase-06-ci-supply-chain.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/phase-06-ci-supply-chain.md
@@ -2,9 +2,9 @@
 
 ## Visão geral
 
-**Branch:** `wk/ci-supply-chain-0x`  
-**Dependências:** packages e migration harness  
-**Estado:** bloqueada
+- **Branch:** `wk/ci-supply-chain-0x`
+- **Dependências:** packages e migration harness
+- **Estado:** bloqueada
 
 Fechar os gates de plataforma, qualidade, dependências, artefatos e proteção remota sem antecipar 1.0.
 

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/phase-07-program-e2e-and-closure.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/phase-07-program-e2e-and-closure.md
@@ -1,0 +1,67 @@
+# Fase 07 — #84/#69: E2E e fechamento do programa
+
+## Visão geral
+
+**Branch:** `wk/control-plane-program-e2e`  
+**Dependências:** fases 01–06 entregues  
+**Estado:** bloqueada
+
+Revalidar o programa completo em clone limpo, atualizar checklists por prova e fechar #84/#69.
+
+## Cenário E2E
+
+1. Instalar o tarball atual em consumidor isolado.
+2. Inicializar projeto com perfil `OFF` e Keep Core ativo.
+3. Criar duas worktrees concorrentes e provar isolamento causal.
+4. Produzir task/handoff/evidence e retomar em novo agente por contrato.
+5. Exercitar authored/private, sync e degradação de host.
+6. Executar MCP com capability permitida e negar capability ausente.
+7. Publicar no Observer sob policy; testar token, redaction, encryption, retention e purge receipt.
+8. Importar Spec Kit read-only e despachar Superpowers sem ownership duplicado.
+9. Gerar commit pela #40 e validar mensagem/receipt.
+10. Simular upgrade N-2/N-1 e crash/repair.
+11. Fazer cleanup pós-merge e provar ausência de perda de estado.
+12. Validar tarball, SBOM, provenance e cadeia changelog/tag/npm/Release da última versão `0.x`.
+
+## Arquivos
+
+### Criar
+
+- `C:/GitHub/WendKeep/tests/control-plane-program-e2e.test.mjs`.
+- `C:/GitHub/WendKeep/tests/fixtures/control-plane-consumer/` — fixture sanitizada.
+- `C:/GitHub/WendKeep/docs/pt-BR/control-plane-program.md`.
+- `C:/GitHub/WendKeep/docs/en/control-plane-program.md`.
+
+### Modificar
+
+- `C:/GitHub/WendKeep/README.md` e `README.en.md` — estado 0.x comprovado.
+- `C:/GitHub/WendKeep/CHANGELOG.md` — somente na janela de integração.
+- Bodies/checklists das issues #40, #81, #83, #84 e #69 — operação GitHub após autorização.
+
+## Passos
+
+1. Construir fixture sem Vault/runtime/dados reais.
+2. Implementar E2E por checkpoints independentes e diagnóstico curto.
+3. Executar testes focados do cenário.
+4. Auditar os 11 itens do DoD da #69 contra evidência fresca.
+5. Revisar diff e privacidade de package/docs.
+6. Executar uma suíte longa final no commit candidato.
+7. Abrir PR, aguardar todos os checks e integrar após autorização.
+8. Ler npm, tag, Release, SBOM, provenance e receipt de volta.
+9. Marcar checklists somente onde a prova passou; fechar #84 e então #69.
+
+## Critérios de sucesso
+
+- Os 11 itens do DoD possuem evidência fresca e reproduzível.
+- Issues filhas estão fechadas antes da epic.
+- Nenhum dado privado entra no fixture, tarball, PR ou Release.
+- `main`, npm, tag e GitHub Release estão alinhados na versão `0.x` final.
+- O perfil persistente permanece `OFF`.
+- Nenhuma comunicação chama a entrega de `1.0.0`.
+
+## Riscos e mitigação
+
+- **E2E monolítico/flaky:** checkpoints isolados, clocks/ports/temp dirs controlados.
+- **Prova stale:** executar somente depois de todas as fases em `main`.
+- **Fechamento administrativo incorreto:** child-first e readback de cada issue.
+- **Custo de máquina:** suíte longa uma vez no candidato; falhas são depuradas com testes focados.

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/phase-07-program-e2e-and-closure.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/phase-07-program-e2e-and-closure.md
@@ -2,9 +2,9 @@
 
 ## Visão geral
 
-**Branch:** `wk/control-plane-program-e2e`  
-**Dependências:** fases 01–06 entregues  
-**Estado:** bloqueada
+- **Branch:** `wk/control-plane-program-e2e`
+- **Dependências:** fases 01–06 entregues
+- **Estado:** bloqueada
 
 Revalidar o programa completo em clone limpo, atualizar checklists por prova e fechar #84/#69.
 

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/plan.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/plan.md
@@ -1,0 +1,67 @@
+# Plano — finalização incremental do WendKeep Control Plane
+
+**Status:** pronto para revisão  
+**Design:** [design aprovado](../../docs/superpowers/specs/2026-08-29-wendkeep-control-plane-finalization-design.md)  
+**Perfil:** `OFF`; Keep Core ativo  
+**Base auditada:** `main`/`origin/main` em `77fc0b8307ca8ee4c6d57f1c6158d2f0c87f9fae`
+
+## Objetivo
+
+Entregar #40, #81, #83 e #84 em versões intermediárias `0.x`, comprovar o DoD program-level e
+fechar #69 sem antecipar `1.0.0`.
+
+## Dependências
+
+```text
+#40 ─┐
+#81 ─┼─→ #84-A → #84-B → #84-C → #84-D → E2E → #69
+#83 ─┘
+```
+
+#40, #81 e #83 podem ser construídas em paralelo. Integração, bump, release e fechamento são
+seriais: cada branch reconcilia a `main` e consulta o npm antes de definir a próxima versão.
+
+## Fases
+
+| Fase | Escopo | Estado |
+|---|---|---|
+| [01](phase-01-universal-commit.md) | #40 — commit universal | Pendente |
+| [02](phase-02-observer-security.md) | #81 — segurança do Observer | Pendente |
+| [03](phase-03-ecosystem-bridges.md) | #83 — Spec Kit/Superpowers | Pendente |
+| [04](phase-04-package-extraction.md) | #84-A — packages e fachadas | Bloqueada por 01–03 |
+| [05](phase-05-migration-harness.md) | #84-B — migrations e repair | Bloqueada por 04 |
+| [06](phase-06-ci-supply-chain.md) | #84-C/D — CI, supply chain e suporte | Bloqueada por 04–05 |
+| [07](phase-07-program-e2e-and-closure.md) | #84/#69 — E2E e fechamento | Bloqueada por 01–06 |
+
+## Política de testes
+
+- Red/Green: somente testes focados do comportamento alterado.
+- Check intermediário: sintaxe, fronteira, privacidade, docs ou package apenas quando aplicável.
+- Candidato final: testes focados + revisão independente + checks aplicáveis + uma suíte longa.
+- Alteração após suíte longa invalida o candidato.
+- Após merge, confiar na matriz automática; não repetir manualmente.
+
+## Gate de integração por PR
+
+1. Branch limpa e reconciliada com `origin/main`.
+2. Testes focados verdes.
+3. Diff e fronteiras revisados independentemente.
+4. `npm view wendkeep version` consultado.
+5. Bump minor `0.x` e `CHANGELOG.md` adicionados somente nessa janela.
+6. Suíte longa executada no commit final.
+7. PR e check remoto verdes.
+8. Merge, tag, npm e GitHub Release lidos de volta antes de atualizar a issue.
+
+## Restrições
+
+- Não usar Wend Runtime além de confirmar o perfil `OFF`.
+- Não publicar Vault/runtime/dados reais.
+- Não fazer mega-PR.
+- Não declarar `1.0.0`.
+- Commit, push, merge e alterações de proteção remota exigem autorização no momento operacional.
+
+## Pontos operacionais a resolver durante a execução
+
+- Próxima versão exata: derivada do npm no momento de cada integração.
+- Nomes finais dos required checks: derivados dos workflows após a fase 06.
+- Janela de remoção das fachadas legadas: publicada na matriz de suporte da fase 06.

--- a/plans/20260829-1330-wendkeep-control-plane-finalization/plan.md
+++ b/plans/20260829-1330-wendkeep-control-plane-finalization/plan.md
@@ -1,9 +1,9 @@
 # Plano — finalização incremental do WendKeep Control Plane
 
-**Status:** pronto para revisão  
-**Design:** [design aprovado](../../docs/superpowers/specs/2026-08-29-wendkeep-control-plane-finalization-design.md)  
-**Perfil:** `OFF`; Keep Core ativo  
-**Base auditada:** `main`/`origin/main` em `77fc0b8307ca8ee4c6d57f1c6158d2f0c87f9fae`
+- **Status:** pronto para execução
+- **Design:** [design aprovado](../../docs/superpowers/specs/2026-08-29-wendkeep-control-plane-finalization-design.md)
+- **Perfil:** `OFF`; Keep Core ativo
+- **Base auditada:** `main`/`origin/main` em `77fc0b8307ca8ee4c6d57f1c6158d2f0c87f9fae`
 
 ## Objetivo
 


### PR DESCRIPTION
## Resumo

- registra o design aprovado para concluir #40, #81, #83, #84 e #69;
- preserva o perfil OFF e versões intermediárias 0.x;
- define TDD focado e suíte longa apenas no candidato final pré-merge;
- divide a execução em sete fases revisáveis.

## Validação

- autorrevisão de placeholders e ambiguidades;
- links internos válidos;
- \git diff --check\ verde;
- alteração exclusivamente documental, sem suíte longa redundante.