### PR TITLE
fix: publish release candidate from explicit local path

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -193,7 +193,7 @@ jobs:
           if npm view "$PKG@$VERSION" version --prefer-online >/dev/null 2>&1; then
             echo "$PKG@$VERSION já está no registry — publish idempotente"
           else
-            npm publish artifacts/release-candidate.tgz --provenance
+            npm publish ./artifacts/release-candidate.tgz --provenance
           fi
       - name: Create verified tag
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to **wendkeep** are documented here. Format based on
 
 ### Fixed
 
+- **Publicação do candidato local.** O workflow passa o tarball preservado ao npm com path relativo
+  explícito (`./artifacts/...`), impedindo que o package spec seja interpretado como shorthand Git.
 - **Ingestão gzip sob pressão.** O publisher repete uma única vez o mesmo lote idempotente quando
   um socket keep-alive é encerrado transitoriamente, preservando o timeout total e a outbox diante
   de outras falhas.

--- a/tests/ci-policy.test.mjs
+++ b/tests/ci-policy.test.mjs
@@ -74,7 +74,7 @@ test('[req:CI-SC-5] release preserves the tested tarball, SBOM and #40 commit bi
   assert.ok(upload > prepare && consume > upload && publish > consume,
     'the durable candidate must pass isolated consumers before publish');
   assert.match(release, /npm run release:candidate:test/);
-  assert.match(release, /npm publish artifacts\/release-candidate\.tgz --provenance/);
+  assert.match(release, /npm publish \.\/artifacts\/release-candidate\.tgz --provenance/);
   assert.doesNotMatch(release.slice(prepare, publish), /npm pack/,
     'no second tarball may replace the candidate between preparation and publish');
   const provenanceAttempts = release

--- a/tests/release-changelog.test.mjs
+++ b/tests/release-changelog.test.mjs
@@ -281,7 +281,7 @@ test('[sensor:release-tests] [req:REL-CI-2] workflow confiável publica antes de
   assert.ok(tagAt > -1, 'workflow precisa criar a tag comprovada');
   assert.ok(publishAt < tagAt, 'publish precisa ocorrer antes da tag');
   assert.match(RELEASE_PUBLISH_STEP, /npm view[\s\S]*--prefer-online/);
-  assert.match(RELEASE_PUBLISH_STEP, /npm publish artifacts\/release-candidate\.tgz --provenance/);
+  assert.match(RELEASE_PUBLISH_STEP, /npm publish \.\/artifacts\/release-candidate\.tgz --provenance/);
   assert.match(RELEASE_WORKFLOW, /git tag -a "\$TAG" "\$GITHUB_SHA"/);
 });
 


### PR DESCRIPTION
## Resumo
- publica o tarball preservado com path local explícito (`./artifacts/release-candidate.tgz`)
- impede o npm de interpretar o package spec como shorthand Git
- registra a correção na release intermediária 0.90.0

## Evidência
- RED: os dois contratos de CI falharam ao exigir o prefixo local explícito
- GREEN: 62/62 testes focados
- `npm run check`: PASS
- `validate-commit-range`: 1 commit válido
- revisão independente no SHA `77df380df405fa03683d75c11fe1e4581ab7feab`: PASS

## Limites
- hotfix exclusivamente do transporte do tarball; sem novo bump
- fechamento depende do CI completo e da convergência npm/tag/GitHub Release/receipt

Refs #84